### PR TITLE
Fix editor readme typo

### DIFF
--- a/example/lunatic-editor/README.md
+++ b/example/lunatic-editor/README.md
@@ -1,4 +1,3 @@
 # Lunatic Editor
 
-A simple editor, allowing to edit Lunatic Model specification looking dynamically to the questionnaire produced by Lunatic, is deployed [online](https://inseefr.github.io/Lunatic/Editor).
-
+A simple editor, allowing to edit Lunatic Model specification looking dynamically to the questionnaire produced by Lunatic, is deployed [online](https://inseefr.github.io/Lunatic/editor).


### PR DESCRIPTION
Fix #10 : link should be lowercase (the link on the base README is ok)