### PR TITLE
:bug: ',' impossible pour les décimales + '0' ineffacables + clavier numérique

### DIFF
--- a/src/components/declarations/wrappers/input-declarations-wrapper.js
+++ b/src/components/declarations/wrappers/input-declarations-wrapper.js
@@ -37,6 +37,7 @@ const InputDeclarationsWrapper = ({
 	numberAsTextfield,
 	logFunction,
 	componentType,
+	inputMode,
 }) => {
 	const inputRef = useRef();
 	const createEventFocus = (focusIn = true) =>
@@ -170,6 +171,7 @@ const InputDeclarationsWrapper = ({
 							maxLength={maxLength || 524288}
 							required={mandatory}
 							aria-required={mandatory}
+							inputMode={numberAsTextfield ? inputMode : 'text'}
 							onChange={(e) => {
 								const v = e.target.value;
 								const valueToFire = v === '' ? null : v;
@@ -202,7 +204,7 @@ const InputDeclarationsWrapper = ({
 										Number.parseFloat(`${Math.pow(10, -decimals)}`).toFixed(
 											decimals
 										) &&
-										!Number.parseInt(v, 10) &&
+										isNaN(Number.parseInt(v, 10)) &&
 										isInputNumber)
 								) {
 									setValue(valueToFireForArrows);
@@ -285,6 +287,7 @@ InputDeclarationsWrapper.defaultProps = {
 	style: {},
 	validators: [],
 	isInputNumber: false,
+	inputMode: 'text',
 };
 
 InputDeclarationsWrapper.propTypes = {
@@ -319,6 +322,7 @@ InputDeclarationsWrapper.propTypes = {
 	]),
 	validators: PropTypes.arrayOf(PropTypes.func),
 	isInputNumber: PropTypes.bool,
+	inputMode: PropTypes.oneOf(['none', 'text', 'decimal', 'numeric']),
 };
 
 export default InputDeclarationsWrapper;

--- a/src/components/input/input-number.js
+++ b/src/components/input/input-number.js
@@ -15,6 +15,7 @@ const InputNumber = ({ numberAsTextfield, decimals, ...props }) => (
 		isInputNumber
 		numberAsTextfield
 		validators={[getTypeControls]}
+		inputMode={decimals ? 'decimals' : 'numeric'}
 	/>
 );
 

--- a/src/utils/lib/env.js
+++ b/src/utils/lib/env.js
@@ -1,2 +1,2 @@
-export const isDev =
-	!process.env.NODE_ENV || process.env.NODE_ENV === 'development';
+export const isDev = false;
+// !process.env.NODE_ENV || process.env.NODE_ENV === 'development';

--- a/src/utils/lib/input-number.js
+++ b/src/utils/lib/input-number.js
@@ -1,6 +1,6 @@
 export const isNumberValid = (num, decimals = 0) => {
 	// \\ because of escaping, basic regex has only one \
 	if (num.includes('.') && !decimals) return false;
-	const regex = new RegExp(`^(-)?(0|[1-9]\\d*)(\\.(\\d){0,${decimals}})?$`);
+	const regex = new RegExp(`^(-)?(0|[1-9]\\d*)((\\.|,)(\\d){0,${decimals}})?$`);
 	return regex.test(num);
 };


### PR DESCRIPTION
- Ajout de "inputmode" qui permet d'indiquer pour les appareils tactiles quel clavier utiliser
- Test à NaN plutôt à toutes valeurs fausses la conversion en int -> Cela causait l'apparition de plein de 0 non effaçables dans les décimales quand on commençait à écrire "0." ou "0,"
- La virgule peut être entrée à la place du point quand "numberAsTextField" est true
- La log de développement est désactivé