### PR TITLE
build workers

### DIFF
--- a/webpack-append-worker.config.js
+++ b/webpack-append-worker.config.js
@@ -5,6 +5,7 @@ var version = PACKAGE.workersVersion;
 module.exports = {
 	mode: 'production',
 	entry: './src/utils/suggester-workers/append-to-index/append.worker.js',
+	target: 'webworker',
 	output: {
 		path: path.resolve(`./workers-release/${version}`),
 		filename: `lunatic-append-worker-${version}.js`,

--- a/webpack-label-worker.config.js
+++ b/webpack-label-worker.config.js
@@ -6,6 +6,7 @@ module.exports = {
 	mode: 'production',
 	entry:
 		'./src/utils/suggester-workers/find-best-label/find-best-label.worker.js',
+	target: 'webworker',
 	output: {
 		path: path.resolve(`./workers-release/${version}`),
 		filename: `lunatic-label-worker-${version}.js`,

--- a/webpack-searching-worker.config.js
+++ b/webpack-searching-worker.config.js
@@ -5,6 +5,7 @@ var version = PACKAGE.workersVersion;
 module.exports = {
 	mode: 'production',
 	entry: './src/utils/suggester-workers/searching/searching.worker.js',
+	target: 'webworker',
 	output: {
 		path: path.resolve(`./workers-release/${version}`),
 		filename: `lunatic-searching-worker-${version}.js`,


### PR DESCRIPTION
il faut ajouter target: 'webworker" dans les scripts de construction de workers pour éviter d'avoir window qui traine dans le script.