### PR TITLE
Revert "use npm instead of yarn for publish"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,13 +80,13 @@ jobs:
             false
           fi
           if [ ${{github.ref}} = 'refs/heads/master' ]; then
-            npm publish --access public
+            yarn publish --access public
           fi
           if [ ${{github.ref}} = 'refs/heads/v2-master' ]; then
-            npm publish --tag v2 --access public
+            yarn publish --tag v2 --access public
           fi
           if [ ${{github.ref}} = 'refs/heads/prisme' ]; then
-            npm publish --tag prisme --access public
+            yarn publish --tag prisme --access public
           fi
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
This reverts commit 9c5d322bdc9b5da183d06584fbf386183d1530ca.