### PR TITLE
feat: make overview optional

### DIFF
--- a/src/stories/utils/orchestrator.js
+++ b/src/stories/utils/orchestrator.js
@@ -81,7 +81,6 @@ function OrchestratorForStories({
 		isLastPage,
 		waiting,
 		overview,
-		getErrors,
 		getModalErrors,
 		getCurrentErrors,
 		getData,
@@ -96,10 +95,10 @@ function OrchestratorForStories({
 		suggesterFetcher,
 		management,
 		activeControls,
+		withOverview: showOverview,
 	});
 
 	const components = getComponents();
-	const errors = getErrors();
 	const modalErrors = getModalErrors();
 	const currentErrors = getCurrentErrors();
 

--- a/src/use-lunatic/actions.js
+++ b/src/use-lunatic/actions.js
@@ -24,6 +24,7 @@ export const onInit = ({
 	management,
 	handleChange,
 	activeControls,
+	withOverview,
 }) => ({
 	type: ON_INIT,
 	payload: {
@@ -36,6 +37,7 @@ export const onInit = ({
 		management,
 		handleChange,
 		activeControls,
+		withOverview,
 	},
 });
 

--- a/src/use-lunatic/reducer/overview/overview-on-change.js
+++ b/src/use-lunatic/reducer/overview/overview-on-change.js
@@ -1,6 +1,11 @@
 import { isPageReached } from '../../commons/page-tag';
 
 export const overviewOnChange = (state) => {
+	// The breadcrumb was not initialized, do nothing
+	if (state.overview.length === 0) {
+		return state;
+	}
+
 	const {
 		overview,
 		pager: { page, lastReachedPage },
@@ -21,9 +26,11 @@ export const overviewOnChange = (state) => {
 		return {
 			...overviewEntry,
 			reached: isPageReached(overviewEntry.page, lastReachedPage),
-			visible: executeExpression(overviewEntry.conditionFilter, {
-				bindingDependencies: overviewEntry.conditionFilter.bindingDependencies,
-			}),
+			visible:
+				executeExpression(overviewEntry.conditionFilter, {
+					bindingDependencies:
+						overviewEntry.conditionFilter.bindingDependencies,
+				}) ?? false,
 			evaluatedLabel: executeExpression(overviewEntry.label),
 		};
 	});

--- a/src/use-lunatic/reducer/overview/overview-on-init.js
+++ b/src/use-lunatic/reducer/overview/overview-on-init.js
@@ -14,7 +14,7 @@ const isSubsequenceSamePage = (sourceComponent, page) =>
 function getOverview(state) {
 	const { pages, executeExpression, pager } = state;
 
-	//prevent misordered pages by extracting forbidden pages
+	// prevent misordered pages by extracting forbidden pages
 	const subPages = Object.values(pages).reduce((acc, curr) => {
 		if (curr.subPages !== undefined) return [...acc, ...curr.subPages];
 		return acc;
@@ -38,7 +38,7 @@ function getOverview(state) {
 				type: 'subSequence',
 				parent: hierarchy.sequence.page,
 				conditionFilter,
-				visible: executeExpression(conditionFilter),
+				visible: executeExpression(conditionFilter) ?? false,
 				reached: isPageReached(
 					hierarchy.subSequence.page,
 					pager.lastReachedPage
@@ -51,7 +51,7 @@ function getOverview(state) {
 				type: 'sequence',
 				conditionFilter,
 				reached: isPageReached(hierarchy.sequence.page, pager.lastReachedPage),
-				visible: executeExpression(conditionFilter),
+				visible: executeExpression(conditionFilter) ?? false,
 				evaluatedLabel: executeExpression(hierarchy.sequence.label),
 			});
 		}
@@ -61,7 +61,7 @@ function getOverview(state) {
 	return [...sequences, ...subSequences];
 }
 
-export function reduceOverviewOnInit(state) {
-	const overview = getOverview(state);
+export function reduceOverviewOnInit(state, action) {
+	const overview = action.payload.withOverview ? getOverview(state) : [];
 	return { ...state, overview };
 }

--- a/src/use-lunatic/use-lunatic.js
+++ b/src/use-lunatic/use-lunatic.js
@@ -29,6 +29,8 @@ function useLunatic(
 		suggesters: suggestersConfiguration,
 		suggesterFetcher,
 		activeControls = false,
+		// Calculate an overview of every sequence (will be exposed as "overview")
+		withOverview = false,
 	}
 ) {
 	const [state, dispatch] = useReducer(reducer, INITIAL_STATE);
@@ -151,6 +153,7 @@ function useLunatic(
 					management,
 					handleChange,
 					activeControls,
+					withOverview,
 				})
 			);
 		},
@@ -163,6 +166,7 @@ function useLunatic(
 			savingType,
 			management,
 			handleChange,
+			withOverview,
 			activeControls,
 		]
 	);

--- a/src/use-lunatic/use-lunatic.spec.js
+++ b/src/use-lunatic/use-lunatic.spec.js
@@ -3,7 +3,7 @@ import useLunatic from './use-lunatic';
 import { renderHook, act } from '@testing-library/react-hooks';
 import sourceWithoutHierarchy from '../stories/overview/source.json';
 
-const lunaticConfiguration = {
+const lunaticConfigurationWithoutOverview = {
 	management: false,
 	activeControls: false,
 	initialPage: '1',
@@ -15,17 +15,28 @@ const lunaticConfiguration = {
 	filterDescription: true,
 };
 
+const lunaticConfiguration = {
+	...lunaticConfigurationWithoutOverview,
+	withOverview: true,
+};
+
 const advancedQestionnaireData = {
 	COLLECTED: { CADR: { COLLECTED: '1' } },
 };
 
 describe('overview', function () {
-	it('only first sequence visible', function () {
+	it('should not calculate overview by default', function () {
 		const data = [];
 		const { result } = renderHook(() =>
-			useLunatic(source, data, {
-				...lunaticConfiguration,
-			})
+			useLunatic(source, data, lunaticConfigurationWithoutOverview)
+		);
+		const overview = result.current.overview;
+		expect(overview).toHaveLength(0);
+	});
+	it('should make the first sequence visible', function () {
+		const data = [];
+		const { result } = renderHook(() =>
+			useLunatic(source, data, lunaticConfiguration)
 		);
 		const overview = result.current.overview;
 		expect(overview).toHaveLength(11);
@@ -34,31 +45,45 @@ describe('overview', function () {
 		expect(overview[1].reached).toEqual(false);
 		expect(overview[1].visible).toEqual(true);
 	});
-	it('Empty overview when no hierarchy', function () {
+	it('should update the breadcrumb on page change', function () {
 		const data = [];
 		const { result } = renderHook(() =>
-			useLunatic(sourceWithoutHierarchy, data, {
-				...lunaticConfiguration,
-			})
+			useLunatic(source, data, lunaticConfiguration)
+		);
+		// '8' page should not be visible
+		expect(result.current.overview[0].children[0].visible).toBe(false);
+		// Simulate a change of value in the form
+		act(() => {
+			const c = result.current.getComponents();
+			c[0].handleChange({ name: 'CADR' }, '3');
+			result.current.goNextPage();
+		});
+		// Page '8' should now be visible
+		expect(result.current.overview[0].children[0].visible).toBe(true);
+	});
+	it('should be empty when no hierarchy', function () {
+		const data = [];
+		const { result } = renderHook(() =>
+			useLunatic(sourceWithoutHierarchy, data, lunaticConfiguration)
 		);
 		expect(result.current.overview).toHaveLength(0);
 	});
-});
 
-describe('overview with initial data', function () {
-	it('Second Sequence visible', function () {
-		const { result } = renderHook(() =>
-			useLunatic(source, advancedQestionnaireData, {
-				...lunaticConfiguration,
-				// hack on initialPage : useLunatic SHOULD find lastReachedPage from COLLECTED data
-				initialPage: 16,
-			})
-		);
-		const overview = result.current.overview;
-		expect(overview).toHaveLength(11);
-		expect(overview[0].reached).toEqual(true);
-		expect(overview[0].visible).toEqual(true);
-		expect(overview[1].reached).toEqual(true);
-		expect(overview[1].visible).toEqual(true);
+	describe('with initial data', function () {
+		it('should make second sequence visible', function () {
+			const { result } = renderHook(() =>
+				useLunatic(source, advancedQestionnaireData, {
+					...lunaticConfiguration,
+					// hack on initialPage : useLunatic SHOULD find lastReachedPage from COLLECTED data
+					initialPage: 16,
+				})
+			);
+			const overview = result.current.overview;
+			expect(overview).toHaveLength(11);
+			expect(overview[0].reached).toEqual(true);
+			expect(overview[0].visible).toEqual(true);
+			expect(overview[1].reached).toEqual(true);
+			expect(overview[1].visible).toEqual(true);
+		});
 	});
 });


### PR DESCRIPTION
- Ajout d'une option withOverview dans le hook "useLunatic" pour activer / désactiver la gestion de l'overview (`false`  par défaut)
- Ajout d'un test pour vérifier que le changement de réponse recalcul bien le breadcrumb
- Ajout d'une petite condition pour s'assurer que visible soit bien un booléen (ajout de ` ?? false `)