### PR TITLE
Add loopVariables property to expose variables used for the currentLoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=InseeFr_Lunatic&metric=alert_status)](https://sonarcloud.io/dashboard?id=InseeFr_Lunatic)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
-Lunatic est un librairie front-end sous forme de hook react et de librairies de composants pour générer un questionnaire à partir du format de données [Lunatic-Model](https://github.com/InseeFr/Lunatic-Model).
+Lunatic est une librairie front-end sous forme de hook react et de librairies de composants pour générer un questionnaire à partir du format de données [Lunatic-Model](https://github.com/InseeFr/Lunatic-Model).
 
 - [Storybook v2](https://inseefr.github.io/Lunatic/storybook-v2)
 - [Storybook v1](https://inseefr.github.io/Lunatic/storybook-v1)
@@ -18,15 +18,17 @@ Lunatic est un librairie front-end sous forme de hook react et de librairies de 
 
 ## Sommaire
 
-- [Utilisation](#utilisation)
-  - [Le hook useLunatic](#le-hook-uselunatic)
-  - [Les composants](#les-composants)
-- [Personnalisation](#personnalisation)
-- [Fonctionnement interne](#fonctionnement-interne)
-  - [Fonctionnement général](#fonctionnement-g-n-ral)
-  - [pages et pager](#pages-et-pager)
-  - [Exécution du VTL](#ex-cution-du-vtl)
-- [Convention et bonnes pratiques](#convention-et-bonnes-pratiques)
+- [Lunatic](#lunatic)
+	- [Sommaire](#sommaire)
+	- [Utilisation](#utilisation)
+		- [Le hook useLunatic](#le-hook-uselunatic)
+		- [Les composants](#les-composants)
+	- [Personnalisation](#personnalisation)
+	- [Fonctionnement interne](#fonctionnement-interne)
+		- [Fonctionnement général](#fonctionnement-général)
+		- [pages et pager](#pages-et-pager)
+		- [Exécution du VTL](#exécution-du-vtl)
+	- [Convention et bonnes pratiques](#convention-et-bonnes-pratiques)
 
 ## Utilisation
 
@@ -38,7 +40,7 @@ yarn add @inseefr/lunatic@2.0.7-v2
 
 ### Le hook useLunatic
 
-Ensuite, à l'endroit où vous souhaiter afficher le formulaire il faudra utiliser le hook `useLunatic`.
+Ensuite, à l'endroit où vous souhaitez afficher le formulaire il faudra utiliser le hook `useLunatic`. 
 
 ```js
 import { useLunatic } from '@inseefr/lunatic';
@@ -76,6 +78,7 @@ Et retourne un objet permettant de piloter le questionnaire :
 - `pager`, un objet contenant les informations liées à la page
 - `waiting`, indique une attente d'information de la part d'un suggester
 - `getData()`, renvoie les données collectées dans le questionnaire
+- `loopVariables`, est un tableau contenant la liste des variables utilisées pour la boucle courante
 
 Pour plus d'informations sur les types de ce retour vous pouvez vous référer aux types disponibles dans le [code source](https://github.com/InseeFr/Lunatic/blob/v2-typescript/src/use-lunatic/type.ts#L64-L200). Vous pouvez aussi trouver un exemple d'utilisation du hook dans la partie [Storybook](https://github.com/InseeFr/Lunatic/blob/v2-develop/src/stories/utils/orchestrator.js#L69-L93).
 
@@ -113,32 +116,18 @@ L'ensemble des composants offerts par Lunatic sont disponibles dans le dossier [
 
 ## Personnalisation
 
-Par défaut les composants offerts par Lunatic sont plutôt simples avec un style minimal. Il est possible de personnaliser les champs avec votre propre CSS, mais pour des cas plus complexes vous pouvez aussi remplacer les composants de bases à l'aide de la propriété `custom` que vous pouvez passer au composant.
+Par défaut les composants offerts par Lunatic sont plutôt simples avec un style minimal. Il est possible de personnaliser les champs avec votre propre CSS, mais pour des cas plus complexes vous pouvez aussi remplacer les composants de bases à l'aide de la propriété `custom` que vous pouvez passer lors de l'appel à useLunatic.
 
 ```jsx
 const custom = {
-	Input: MyCustomInput,
-	InputNumber: MyCustomInputNumber,
-};
+  Input: MyCustomInput,
+  InputNumber: MyCustomInputNumber
+}
 
-function App({ source, data }) {
-	// ...
-
-	return (
-		<div className="container">
-			{components.map(function (component) {
-				const Component = lunatic[component.componentType];
-				return (
-					<Component
-						key={component.id}
-						{...component}
-						custom={custom}
-						errors={currentErrors}
-					/>
-				);
-			})}
-		</div>
-	);
+function App ({source, data}) {
+  const {} = useLunatic(source, data, {custom})
+  
+  // ...
 }
 ```
 
@@ -152,7 +141,7 @@ Le hook se base sur un [état interne](https://github.com/InseeFr/Lunatic/blob/v
 
 - Une action `'use-lunatic/on-init'` permet l'initialisation de l'état à partir des données reçu en paramètre du hook.
 - Les actions `'use-lunatic/go-previous'`, `'use-lunatic/go-next'` et `'use-lunatic/go-to-page'` sont appelées lors de la navigation à l'aide des méthodes renvoyées par le hook
-- L'action `use-lunatic/handle-change` est l'action la plus importante qui est appelé dès lors qu'une donnée est changée dans le questionnaire.
+- L'action `use-lunatic/handle-change` est l'action la plus importante qui est appelée dès lors qu'une donnée est changée dans le questionnaire.
 
 L'ensemble des [reducers correspondants à ces actions sont disponibles ici](https://github.com/InseeFr/Lunatic/blob/v2-develop/src/use-lunatic/reducer/reducer.js). En général, ils sont décomposés en plusieurs méthodes en fonction de la partie de l'état qu'ils modifient.
 

--- a/src/use-lunatic/hooks/use-loop-variables.ts
+++ b/src/use-lunatic/hooks/use-loop-variables.ts
@@ -1,0 +1,23 @@
+import { LunaticComponentDefinition, LunaticState } from '../type';
+import { useMemo } from 'react';
+
+/**
+ * Extract the list of variables used for the current loop
+ */
+export function useLoopVariables(
+	pager: LunaticState['pager'],
+	pages: LunaticState['pages']
+): string[] {
+	const { iteration, page } = pager;
+	const inIteration = iteration !== undefined;
+	return useMemo(() => {
+		if (!inIteration) {
+			return [];
+		}
+		// Find the loop to extract the dependencies
+		const loop = pages[page]?.components.find(
+			(c) => c.componentType === 'Loop'
+		) as LunaticComponentDefinition<'Loop'> | undefined;
+		return loop?.loopDependencies ?? [];
+	}, [page, inIteration]);
+}

--- a/src/use-lunatic/use-lunatic.ts
+++ b/src/use-lunatic/use-lunatic.ts
@@ -20,6 +20,7 @@ import { getQuestionnaireData } from './commons/get-data';
 import { loadSuggesters } from '../utils/store-tools/auto-load';
 import { overviewWithChildren } from './commons/getOverview';
 import reducer from './reducer';
+import { useLoopVariables } from './hooks/use-loop-variables';
 
 const empty = {}; // Keep the same empty object (to avoid problem with useEffect dependencies)
 const DEFAULT_DATA = empty as LunaticData;
@@ -261,6 +262,7 @@ function useLunatic(
 		getData,
 		Provider,
 		overview: buildedOverview,
+		loopVariables: useLoopVariables(pager, state.pages),
 	};
 }
 


### PR DESCRIPTION
## Why 

The user wants to navigate inside a loop so we need to expose the variable used for the current loop. This feature replaces the loopBindings that was removed in a previous commit.