### PR TITLE
fix fill errors and remove get current errors function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules/
 # Built directories
 *.css
 /dist/
+**/dist/
 /lib/
 /coverage/
 /test-report.xml

--- a/src/components/checkbox/checkbox-boolean/lunatic-checkbox-boolean.js
+++ b/src/components/checkbox/checkbox-boolean/lunatic-checkbox-boolean.js
@@ -20,6 +20,7 @@ function LunaticCheckboxBoolean({
 	description,
 }) {
 	const onChange = useOnHandleChange({ handleChange, response, value });
+
 	return (
 		<LunaticComponent
 			id={id}

--- a/src/components/checkbox/checkbox-one/lunatic-checkbox-one.js
+++ b/src/components/checkbox/checkbox-one/lunatic-checkbox-one.js
@@ -20,6 +20,7 @@ function LunaticCheckboxOne({
 	shortcut,
 }) {
 	const onSelect = useOnHandleChange({ handleChange, response, value });
+
 	return (
 		<LunaticComponent
 			id={id}

--- a/src/components/input-number/lunatic-input-number.js
+++ b/src/components/input-number/lunatic-input-number.js
@@ -26,8 +26,6 @@ function LunaticInputNumber(props) {
 		readOnly,
 	} = props;
 
-	console.log('Decimals', decimals);
-
 	const onChange = useOnHandleChange({ handleChange, response, value });
 
 	return (

--- a/src/stories/utils/orchestrator.js
+++ b/src/stories/utils/orchestrator.js
@@ -142,7 +142,7 @@ function OrchestratorForStories({
 
 	const components = getComponents();
 	const modalErrors = getModalErrors();
-	const currentErrors = getCurrentErrors();
+	// const currentErrors = getCurrentErrors();
 
 	return (
 		<Provider>
@@ -173,7 +173,6 @@ function OrchestratorForStories({
 									{...component}
 									{...storeInfo}
 									filterDescription={filterDescription}
-									errors={currentErrors}
 								/>
 							</div>
 						);

--- a/src/use-lunatic/commons/fill-components/fill-errors.ts
+++ b/src/use-lunatic/commons/fill-components/fill-errors.ts
@@ -13,16 +13,10 @@ function fillErrors(
 	component: LunaticComponentDefinition,
 	state: LunaticState
 ): LunaticComponentDefinition & FilledProps {
-	const { id } = component;
 	const page = getPageTag(state.pager);
-	const errors = state.errors?.[page] ?? {};
-	if (errors) {
-		// TODO only keep criticality info
-		if (id in errors && errors) {
-			return { ...component, error: errors[id] };
-		}
-	}
-	return component;
+	const errors = state.errors?.[page];
+
+	return { ...component, errors };
 }
 
 export default fillErrors;

--- a/src/use-lunatic/type-source.ts
+++ b/src/use-lunatic/type-source.ts
@@ -1,3 +1,5 @@
+import { LunaticError } from './type';
+
 /**
  * Types used for source data (lunatic models and data.json)
  *
@@ -93,6 +95,7 @@ export type ComponentTypeBase = {
 	missingResponse: ResponseType;
 	mandatory?: boolean;
 	page: string;
+	errors?: Record<string, Array<LunaticError>>;
 };
 export type ComponentType =
 	| (ComponentTypeBase & ComponentSequenceType)

--- a/src/use-lunatic/type.ts
+++ b/src/use-lunatic/type.ts
@@ -137,7 +137,7 @@ export type LunaticState = {
 	// TODO : Explain this
 	waiting: boolean;
 	// Errors for the form
-	errors?: { [page: string]: { [id: string]: LunaticError[] } };
+	errors?: Record<string, Record<string, Array<LunaticError>>>;
 	// Contains the errors for the current page / iteration
 	currentErrors?: { [id: string]: LunaticError[] };
 	// Errors

--- a/src/use-lunatic/use-lunatic.ts
+++ b/src/use-lunatic/use-lunatic.ts
@@ -156,13 +156,6 @@ function useLunatic(
 		[modalErrors]
 	);
 
-	const getCurrentErrors = useCallback(
-		function () {
-			return currentErrors;
-		},
-		[currentErrors]
-	);
-
 	const goPreviousPage = useCallback(
 		function () {
 			dispatch(actions.goPreviousPage());
@@ -254,7 +247,6 @@ function useLunatic(
 		goToPage,
 		getErrors,
 		getModalErrors,
-		getCurrentErrors,
 		pageTag,
 		isFirstPage,
 		isLastPage,


### PR DESCRIPTION
J'ai corrigé fillErrors pour éviter d'avoir à utiliser getCurrentErrors pour ré-injecter les erreurs dans les composants depuis un orchestrateur.
J'ai du adapté le type de errors dans LunaticState
Ce dernier conserve un attribut error (sans s) dont je n'ai pas audité l'utilité.