### PR TITLE
Fix/errors in table

### DIFF
--- a/src/components/table/cell.tsx
+++ b/src/components/table/cell.tsx
@@ -67,7 +67,7 @@ type Props = {
 	row?: string | number;
 	index?: string | number;
 	handleChange: LunaticBaseProps['handleChange'];
-	errors: LunaticBaseProps['errors'];
+	errors?: LunaticBaseProps['errors'];
 };
 function Cell({
 	content,

--- a/src/components/table/lunatic-table.tsx
+++ b/src/components/table/lunatic-table.tsx
@@ -44,7 +44,6 @@ function LunaticTable(props: LunaticComponentProps<'Table'>) {
 						handleChange={handleChange}
 						iteration={iteration}
 						value={value}
-						errors={errors}
 					/>
 				</Tbody>
 			</Table>

--- a/src/components/table/row.tsx
+++ b/src/components/table/row.tsx
@@ -17,7 +17,7 @@ type Props = {
 	valueMap: Record<string, unknown>;
 	rowIndex?: string | number;
 	handleChange: LunaticBaseProps['handleChange'];
-	errors: LunaticBaseProps['errors'];
+	errors?: LunaticBaseProps['errors'];
 };
 function Row({
 	id,

--- a/src/components/table/table-orchestrator.tsx
+++ b/src/components/table/table-orchestrator.tsx
@@ -4,13 +4,7 @@ import { LunaticComponentProps } from '../type';
 
 type Props = {} & Pick<
 	LunaticComponentProps<'Table'>,
-	| 'body'
-	| 'id'
-	| 'executeExpression'
-	| 'value'
-	| 'handleChange'
-	| 'iteration'
-	| 'errors'
+	'body' | 'id' | 'executeExpression' | 'value' | 'handleChange' | 'iteration'
 >;
 function TableOrchestrator({
 	body,
@@ -19,7 +13,6 @@ function TableOrchestrator({
 	value: valueMap,
 	handleChange,
 	iteration,
-	errors,
 }: Props) {
 	if (!Array.isArray(body)) {
 		return null;
@@ -37,7 +30,6 @@ function TableOrchestrator({
 						handleChange={handleChange}
 						iteration={iteration}
 						executeExpression={executeExpression}
-						errors={errors}
 					/>
 				);
 			})}


### PR DESCRIPTION
## Problème

Les erreurs s'affiche dans chaque cellules du tableau de manière dupliquées

## Cause

Lors de la migration en TS j'ai propagé la props errors dans le tableau (alors que ce n'était pas le cas avant).

## Solution

On ne passe plus l'erreur au TableOrchestrator pour qu'elle ne descende plus vers les cellules.

Fix #537