### PR TITLE
Move worker path resolution

### DIFF
--- a/src/utils/store-tools/auto-load.ts
+++ b/src/utils/store-tools/auto-load.ts
@@ -4,17 +4,13 @@ import cleanStorage from './clear-store-data';
 import cleanInfoStorage from './clear-store-info';
 // @ts-ignore
 import { createWorker } from '../suggester-workers/create-worker';
+import { getWorkerPath } from './worker-path';
 
 type Task = {
 	name: string;
 	fields: string[];
 	stopWords: string[];
 };
-
-const workerPath =
-	process.env.LUNATIC_LOADER_WORKER_PATH ||
-	process.env.REACT_APP_LUNATIC_LOADER_WORKER_PATH ||
-	'workers/lunatic-loader-worker-0.1.0.js';
 
 export const loadSuggesters =
 	(suggesterFetcher: typeof fetch) =>
@@ -53,7 +49,7 @@ function task(
 	version: number,
 	log: (v: any) => void = () => null
 ) {
-	const worker = createWorker(workerPath);
+	const worker = createWorker(getWorkerPath());
 	let start = false;
 	let stop = false;
 

--- a/src/utils/store-tools/worker-path.ts
+++ b/src/utils/store-tools/worker-path.ts
@@ -1,0 +1,10 @@
+export function getWorkerPath(): string {
+	if ('LUNATIC_WORKER_PATH' in window) {
+		return window.LUNATIC_WORKER_PATH as string;
+	}
+	return (
+		process.env.LUNATIC_LOADER_WORKER_PATH ??
+		process.env.REACT_APP_LUNATIC_LOADER_WORKER_PATH ??
+		'workers/lunatic-loader-worker-0.1.0.js'
+	);
+}

--- a/src/utils/suggester-workers/append-to-index/create-append-task.ts
+++ b/src/utils/suggester-workers/append-to-index/create-append-task.ts
@@ -1,6 +1,7 @@
 import { SuggesterType } from '../../../use-lunatic/type-source';
 import { createWorker } from '../create-worker-ts';
 import { getWorkerPath } from '../../store-tools/worker-path';
+import { Logger } from '../../logger';
 
 function consoleLogging(...args: Array<any>) {
 	args.forEach(function (any) {

--- a/src/utils/suggester-workers/append-to-index/create-append-task.ts
+++ b/src/utils/suggester-workers/append-to-index/create-append-task.ts
@@ -1,11 +1,6 @@
 import { SuggesterType } from '../../../use-lunatic/type-source';
 import { createWorker } from '../create-worker-ts';
-import { Logger } from '../../logger';
-
-const workerPath =
-	process.env.LUNATIC_LOADER_WORKER_PATH ||
-	process.env.REACT_APP_LUNATIC_LOADER_WORKER_PATH ||
-	'workers/lunatic-loader-worker-0.1.0.js';
+import { getWorkerPath } from '../../store-tools/worker-path';
 
 function consoleLogging(...args: Array<any>) {
 	args.forEach(function (any) {
@@ -22,7 +17,7 @@ export function createAppendTask<T>(
 	log = consoleLogging
 ): [(args: Array<any>) => Promise<boolean>, () => void] {
 	const { name, fields, stopWords, meloto } = info;
-	const worker = createWorker(workerPath);
+	const worker = createWorker(getWorkerPath());
 	let start = false;
 	let stop = false;
 


### PR DESCRIPTION
Déplacement de la résolution du WorkerPath dans une fonction pour éviter les erreurs à la compilation. Ajout d'une variable globale `LUNATIC_WORKER_PATH` qui permet de définir le worker path plus tard.