### PR TITLE
Avoid rerender when state changed

### DIFF
--- a/src/hooks/use-why-render.ts
+++ b/src/hooks/use-why-render.ts
@@ -1,0 +1,14 @@
+import { useRef } from 'react';
+
+/**
+ * Debugging hook that log what changed between 2 renders
+ */
+export function useWhyRender(props: Record<string, any>, prefix: string = '') {
+	const propsRef = useRef(props);
+	for (const key in props) {
+		if (propsRef.current[key] !== props[key]) {
+			console.log(`${prefix}: ${key} changed`);
+		}
+	}
+	propsRef.current = props;
+}

--- a/src/use-lunatic/commons/use-components-from-state.ts
+++ b/src/use-lunatic/commons/use-components-from-state.ts
@@ -1,28 +1,20 @@
-import { useEffect, useState } from 'react';
+import { useMemo } from 'react';
 import getComponentsFromState from './get-components-from-state';
 import fillComponents from './fill-components';
 import { LunaticState } from '../type';
-import { LunaticComponentProps } from './fill-components/fill-components';
 
 function useComponentsFromState(state: LunaticState) {
-	const [componentsFilled, setComponentsFilled] = useState(
-		[] as LunaticComponentProps[]
-	);
-
-	useEffect(
+	return useMemo(
 		function () {
 			const { pager, pages, isInLoop } = state;
 			const components = getComponentsFromState({ pager, pages, isInLoop });
 			const filled = fillComponents(components, state);
-			const filtered = filled.filter(({ conditionFilter }) => {
+			return filled.filter(({ conditionFilter }) => {
 				return conditionFilter !== undefined ? conditionFilter : true;
 			});
-			setComponentsFilled(filtered);
 		},
 		[state]
 	);
-
-	return componentsFilled;
 }
 
 export default useComponentsFromState;


### PR DESCRIPTION
## Problème

Dans la version courante de lunatic, si on tape au milieu d'un champs, le curseur est placé à la fin.
De la même manière dans le cas du Datepicker quand on tape certains champs la valeur est réinitialisée.

## Cause

Lorsque handleChange est appelé dans un composant il y avait 2 rendus

1. Un premier avec la valeur passée au composant inchangée
2. Un second avec la valeur passée au composant changée

Ce double rendu provoquait des problème lors de la saisi au clavier dans différents champs

## Solution

En investiguant un bout de code déclenche un double rendu (un `setState` dans un `useEffect`). Ce code est remplacé par un `useMemo`


Fix #559
Fix #563 
Helps #571