### PR TITLE
Fix typings when published on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@inseefr/lunatic",
-	"version": "2.4.9",
+	"version": "2.4.10",
 	"workersVersion": "0.2.5-experimental",
 	"description": "Library of questionnaire components",
 	"repository": {
@@ -24,6 +24,7 @@
 	],
 	"license": "MIT",
 	"main": "lib/index.js",
+	"types": "lib/src/index.d.ts",
 	"files": [
 		"lib"
 	],


### PR DESCRIPTION
## Problème

Le typage a été cassé lorsqu'on a retiré la clef "module" du package.json car TypeScript ne trouve plus le fichier de déclaration associé au fichier index.js.

![image](https://github.com/InseeFr/Lunatic/assets/395137/14c9a003-d2ee-4190-8717-3dfc245709fc)

## Solution

On ne peut pas remettre la clef "module" au risque de casser à nouveau les outils de builds qui inclue Lunatic. Ajouter une clef `types`  spécifique au TypeScript permet de spécifier le type manuellement.