### PR TITLE
Export du type LunaticSource

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,3 +16,4 @@ export type {
 } from './use-lunatic/type';
 
 export type { LunaticComponentProps } from './components/type';
+export type { LunaticSource } from './use-lunatic/type-source';

--- a/src/use-lunatic/type-source.ts
+++ b/src/use-lunatic/type-source.ts
@@ -1,7 +1,5 @@
 /**
  * Types used for source data (lunatic models and data.json)
- *
- * These types should not be used outside of use-lunatic
  */
 export type LabelType = { value: string; type: 'VTL' | 'VTL|MD' };
 


### PR DESCRIPTION
## Problèmes

@ddecrulle a besoin du type LunaticSource pour représenter les types de retours des APIs dans le cadre de la synchronisation dans dramaQueen

## Solution

On exporte LunaticSource qui est le type du premier paramètre attendu par `useLunatic()` 