### PR TITLE
Fix/go to page : Permettre le rechargement de n'importe quelle page du questionnaire

### DIFF
--- a/src/stories/component-set/data1.json
+++ b/src/stories/component-set/data1.json
@@ -1,18 +1,25 @@
 {
 	"COLLECTED": {
+		"COUNT_PERSONS": {
+			"EDITED": null,
+			"FORCED": null,
+			"INPUTED": null,
+			"PREVIOUS": null,
+			"COLLECTED": 5
+		},
 		"PRENOMS": {
 			"EDITED": [null],
 			"FORCED": [null],
 			"INPUTED": [null],
 			"PREVIOUS": [null],
-			"COLLECTED": ["Fanny", "Renaud"]
+			"COLLECTED": ["Fanny", "Renaud", "Julia", "Matt", "Tien"]
 		},
-		"AGE": {
+		"AGES": {
 			"EDITED": [null],
 			"FORCED": [null],
 			"INPUTED": [null],
 			"PREVIOUS": [null],
-			"COLLECTED": [15, 4]
+			"COLLECTED": [11, 49, 37, 26, 25]
 		}
 	}
 }

--- a/src/stories/component-set/source1.json
+++ b/src/stories/component-set/source1.json
@@ -5,46 +5,30 @@
 			"id": "seq",
 			"componentType": "Sequence",
 			"label": {
-				"value": "\"Description des individus de votre logement\"",
+				"value": "\"Combien de personne vivent chez vous ?\"",
 				"type": "VTL|MD"
 			},
 			"conditionFilter": { "value": "true", "type": "VTL" },
 			"page": "1"
 		},
+
 		{
-			"id": "loop-prenom",
-			"componentType": "Loop",
-			"label": { "value": "\"Ajouter un individu\"", "type": "VTL|MD" },
-			"conditionFilter": { "value": "true", "type": "VTL" },
-			"bindingDependencies": ["PRENOM"],
-			"lines": {
-				"min": { "value": 1, "type": "VTL" },
-				"max": { "value": 10, "type": "VTL" }
-			},
+			"componentType": "InputNumber",
 			"page": "1",
-			"components": [
-				{
-					"componentType": "Input",
-					"label": { "value": "\"Prénom\"", "type": "VTL|MD" },
-					"conditionFilter": { "value": "true", "type": "VTL" },
-					"maxLength": 30,
-					"bindingDependencies": ["PRENOM"],
-					"id": "prenom",
-					"response": {
-						"name": "PRENOM"
-					}
-				}
-			]
+			"label": { "value": "\"Nombre de personne(s)\"", "type": "VTL|MD" },
+			"conditionFilter": { "value": "true", "type": "VTL" },
+			"maxLength": 30,
+			"id": "prenom",
+			"response": {
+				"name": "COUNT_PERSONS"
+			}
 		},
 		{
 			"id": "loop",
 			"componentType": "Loop",
-
-			"loopDependencies": ["PRENOM"],
-			"iterations": { "value": "count(PRENOM)", "type": "VTL" },
+			"loopDependencies": ["COUNT_PERSONS"],
+			"iterations": { "value": "COUNT_PERSONS", "type": "VTL" },
 			"page": "2",
-			"maxPage": "1",
-			"depth": 1,
 			"paginatedLoop": true,
 			"conditionFilter": {
 				"value": "true",
@@ -52,162 +36,122 @@
 			},
 			"components": [
 				{
-					"id": "age1",
-					"label": {
-						"value": "PRENOM || \", quel est vôtre âge ?\"",
-						"type": "VTL"
-					},
-					"conditionFilter": {
-						"value": "true",
-						"type": "VTL"
-					},
+					"id": "component-set",
+					"componentType": "ComponentSet",
 					"page": "2.1",
-					"componentType": "InputNumber",
-					"min": 0,
-					"max": 120,
-					"decimals": 0,
-					"response": { "name": "AGE1" }
-				}, 
-        {
-          "id": "component-set",
-          "componentType": "ComponentSet",
-          "page": "2.1",
-          "depth": 1,
-          "conditionFilter": { "value": "true", "type": "VTL" },
-          "label": {
-            "value": "\"## Who are you?\"", 
-            "type":"VTL|MD"
-          },
-          "description": { "value": "\"This is your opportunity to tell me about yourself!\"", "type": "VTL|MD" },
-          "components": [
-            {
-              "id": "prenom",
-              "componentType": "Input",
-              "mandatory": false,
-              "maxLength": 20,
-              "label": {
-                "value": "\"Prénom\"))",
-                "type": "VTL|MD"
-              },
-              "conditionFilter": {
-                "value": "true",
-                "type": "VTL"
-              },
-              "response": { "name": "PRENOMS" }
-            },
-            {
-              "id": "age",
-              "componentType": "InputNumber",
-              "maxLength": 3,
-              "label": {
-                "value": "\"Age\"))",
-                "type": "VTL|MD"
-              },
-              "conditionFilter": {
-                "value": "true",
-                "type": "VTL"
-              },
-              "response": { "name": "AGE" }, 
-              "controls": [
-                {
-                  "criticality": "WARN",
-                  "errorMessage": {
-                    "type": "VTL",
-                    "value": "\"booleen pas coché et on affiche un message un peu long histoire de tester le truc \""
-                  },
-                  "typeOfControl": "CONSISTENCY",
-                  "control": {
-                    "type": "VTL",
-                    "value": "false"
-                  },
-                  "id": "kfxmjupm-CI-0"
-                }
-              ]
-            },
-            {
-              "id": "j4nw5cqz",
-              "componentType": "Dropdown",
-              "mandatory": false,
-              "label": { "value": "\"In which state do The Simpsons reside?\"", "type": "VTL|MD" },
-              "description": "\"This is a test description\"",
-              "response": {
-                  "name": "STATE"
-              },
-              "controls": [
-                  {
-                      "id": "j4nw5cqz",
-                      "typeOfControl": "CONSISTENCY",
-                      "criticality": "WARN",
-                      "control": {
-                          "value": "not(nvl(STATE,\"\") = \"13\")",
-                          "type": "VTL"
-                      },
-                      "errorMessage": {
-                          "value": "\"Please choose a state!\"",
-                          "type": "VTL|MD"
-                      },
-                      "bindingDependencies": ["STATE"]
-                  },
-                  {
-                      "id": "j4nw5cqz",
-                      "typeOfControl": "CONSISTENCY",
-                      "criticality": "INFO",
-                      "control": {
-                          "value": "not(nvl(STATE,\"\") = \"4\")",
-                          "type": "VTL"
-                      },
-                      "errorMessage": {
-                          "value": "\"Idk if this is right, I'm just testing error messages!!\"",
-                          "type": "VTL|MD"
-                      },
-                      "bindingDependencies": ["STATE"]
-                  }
-              ],
-              "options": [
-                  {
-                      "value": "1",
-                      "label": { "value": "\"Washington\"", "type": "VTL" }
-                  },
-                  {
-                      "value": "2",
-                      "label": { "value": "\"Kentucky\"", "type": "VTL" }
-                  },
-                  { "value": "3", "label": { "value": "\"Ohio\"", "type": "VTL" } },
-                  { "value": "4", "label": { "value": "\"Maine\"", "type": "VTL" } },
-                  {
-                      "value": "5",
-                      "label": { "value": "\"North Dakota\"", "type": "VTL" }
-                  },
-                  { "value": "6", "label": { "value": "\"Florida\"", "type": "VTL" } },
-                  {
-                      "value": "7",
-                      "label": { "value": "\"North Takoma\"", "type": "VTL" }
-                  },
-                  {
-                      "value": "8",
-                      "label": { "value": "\"California\"", "type": "VTL" }
-                  },
-                  { "value": "9", "label": { "value": "\"Texas\"", "type": "VTL" } },
-                  {
-                      "value": "10",
-                      "label": { "value": "\"Massachusetts\"", "type": "VTL" }
-                  },
-                  { "value": "11", "label": { "value": "\"Nevada\"", "type": "VTL" } },
-                  {
-                      "value": "12",
-                      "label": { "value": "\"Illinois\"", "type": "VTL" }
-                  },
-                  {
-                      "value": "13",
-                      "label": {
-                          "value": "\"Not in any state, you fool!\"",
-                          "type": "VTL"
-                      }
-                  }
-              ]
-            }
-          ]
-        }
+					"depth": 1,
+					"conditionFilter": { "value": "true", "type": "VTL" },
+					"label": {
+						"value": "\"## Who are you?\"",
+						"type": "VTL|MD"
+					},
+					"description": {
+						"value": "\"This is your opportunity to tell me about yourself!\"",
+						"type": "VTL|MD"
+					},
+					"components": [
+						{
+							"id": "prenom",
+							"componentType": "Input",
+							"mandatory": false,
+							"maxLength": 20,
+							"label": {
+								"value": "\"Prénom\"))",
+								"type": "VTL|MD"
+							},
+							"conditionFilter": {
+								"value": "true",
+								"type": "VTL"
+							},
+							"response": { "name": "PRENOMS" }
+						},
+						{
+							"id": "age",
+							"componentType": "InputNumber",
+							"maxLength": 3,
+							"label": {
+								"value": "\"Age\"))",
+								"type": "VTL|MD"
+							},
+							"conditionFilter": {
+								"value": "true",
+								"type": "VTL"
+							},
+							"response": { "name": "AGES" }
+						},
+						{
+							"id": "j4nw5cqz",
+							"componentType": "Dropdown",
+							"mandatory": false,
+							"label": {
+								"value": "\"In which state do The Simpsons reside?\"",
+								"type": "VTL|MD"
+							},
+							"description": "\"This is a test description\"",
+							"response": {
+								"name": "STATES"
+							},
+							"controls": [],
+							"options": [
+								{
+									"value": "1",
+									"label": { "value": "\"Washington\"", "type": "VTL" }
+								},
+								{
+									"value": "2",
+									"label": { "value": "\"Kentucky\"", "type": "VTL" }
+								},
+								{
+									"value": "3",
+									"label": { "value": "\"Ohio\"", "type": "VTL" }
+								},
+								{
+									"value": "4",
+									"label": { "value": "\"Maine\"", "type": "VTL" }
+								},
+								{
+									"value": "5",
+									"label": { "value": "\"North Dakota\"", "type": "VTL" }
+								},
+								{
+									"value": "6",
+									"label": { "value": "\"Florida\"", "type": "VTL" }
+								},
+								{
+									"value": "7",
+									"label": { "value": "\"North Takoma\"", "type": "VTL" }
+								},
+								{
+									"value": "8",
+									"label": { "value": "\"California\"", "type": "VTL" }
+								},
+								{
+									"value": "9",
+									"label": { "value": "\"Texas\"", "type": "VTL" }
+								},
+								{
+									"value": "10",
+									"label": { "value": "\"Massachusetts\"", "type": "VTL" }
+								},
+								{
+									"value": "11",
+									"label": { "value": "\"Nevada\"", "type": "VTL" }
+								},
+								{
+									"value": "12",
+									"label": { "value": "\"Illinois\"", "type": "VTL" }
+								},
+								{
+									"value": "13",
+									"label": {
+										"value": "\"Not in any state, you fool!\"",
+										"type": "VTL"
+									}
+								}
+							]
+						}
+					]
+				}
 			]
 		},
 		{
@@ -230,7 +174,7 @@
 	"variables": [
 		{
 			"variableType": "COLLECTED",
-			"name": "PRENOM",
+			"name": "COUNT_PERSONS",
 			"values": {
 				"PREVIOUS": [null],
 				"COLLECTED": [null],
@@ -241,7 +185,7 @@
 		},
 		{
 			"variableType": "COLLECTED",
-			"name": "AGE1",
+			"name": "AGES",
 			"values": {
 				"PREVIOUS": [null],
 				"COLLECTED": [null],
@@ -250,7 +194,7 @@
 				"INPUTED": [null]
 			}
 		},
-    {
+		{
 			"variableType": "COLLECTED",
 			"name": "PRENOMS",
 			"values": {
@@ -261,20 +205,10 @@
 				"INPUTED": [null]
 			}
 		},
-    {
+
+		{
 			"variableType": "COLLECTED",
-			"name": "AGE",
-			"values": {
-				"PREVIOUS": [null],
-				"COLLECTED": [null],
-				"FORCED": [null],
-				"EDITED": [null],
-				"INPUTED": [null]
-			}
-		},
-    {
-			"variableType": "COLLECTED",
-			"name": "STATE",
+			"name": "STATES",
 			"values": {
 				"PREVIOUS": [null],
 				"COLLECTED": [null],

--- a/src/stories/utils/orchestrator.jsx
+++ b/src/stories/utils/orchestrator.jsx
@@ -1,20 +1,36 @@
 import './custom-lunatic.scss';
 import './orchestrator.scss';
-
 import * as lunatic from '../..';
-
 import React, { memo, useCallback, useState } from 'react';
-
 import { Overview } from './overview';
 import Waiting from './waiting';
 import { Logger } from '../../utils/logger';
+
+export function getPagerFromPageTag(pageTag = '1') {
+	const pattern =
+		/(?<page>\d+)\.?(?<subPagePlusUn>\d+)?#?(?<iterationPlusUn>\d+)?/g;
+	const match = [...pageTag?.matchAll(pattern)];
+	if (match.length === 0) {
+		return null;
+	}
+	const [
+		{
+			groups: { page, subPagePlusUn, iterationPlusUn },
+		},
+	] = match;
+	return {
+		page,
+		subPage: parseInt(subPagePlusUn, 10) - 1,
+		iteration: parseInt(iterationPlusUn, 10) - 1,
+	};
+}
 
 function getStoreInfoRequired() {
 	return {};
 }
 
 function DevOptions({ goToPage, getData }) {
-	const [toPage, setToPage] = useState(1);
+	const [toPage, setToPage] = useState('2.1#2');
 
 	function handleChange(_, value) {
 		setToPage(value);
@@ -27,14 +43,15 @@ function DevOptions({ goToPage, getData }) {
 				<lunatic.Button onClick={() => Logger.log(getData(true))}>
 					Get State
 				</lunatic.Button>
-				<lunatic.Button onClick={() => goToPage({ page: `${toPage}` })}>
+				<lunatic.Button
+					onClick={() => goToPage({ ...getPagerFromPageTag(`${toPage}`) })}
+				>
 					{`Go to page ${toPage}`}
 				</lunatic.Button>
-				<lunatic.InputNumber
+				<lunatic.Input
 					id="page-to-jump"
 					value={toPage}
 					handleChange={handleChange}
-					min={1}
 					label={'Page'}
 					description={'the page wher you want to jump'}
 				/>

--- a/src/stories/utils/orchestrator.jsx
+++ b/src/stories/utils/orchestrator.jsx
@@ -6,31 +6,12 @@ import { Overview } from './overview';
 import Waiting from './waiting';
 import { Logger } from '../../utils/logger';
 
-export function getPagerFromPageTag(pageTag = '1') {
-	const pattern =
-		/(?<page>\d+)\.?(?<subPagePlusUn>\d+)?#?(?<iterationPlusUn>\d+)?/g;
-	const match = [...pageTag?.matchAll(pattern)];
-	if (match.length === 0) {
-		return null;
-	}
-	const [
-		{
-			groups: { page, subPagePlusUn, iterationPlusUn },
-		},
-	] = match;
-	return {
-		page,
-		subPage: parseInt(subPagePlusUn, 10) - 1,
-		iteration: parseInt(iterationPlusUn, 10) - 1,
-	};
-}
-
 function getStoreInfoRequired() {
 	return {};
 }
 
 function DevOptions({ goToPage, getData }) {
-	const [toPage, setToPage] = useState('2.1#2');
+	const [toPage, setToPage] = useState('2.1#2|5');
 
 	function handleChange(_, value) {
 		setToPage(value);
@@ -43,9 +24,7 @@ function DevOptions({ goToPage, getData }) {
 				<lunatic.Button onClick={() => Logger.log(getData(true))}>
 					Get State
 				</lunatic.Button>
-				<lunatic.Button
-					onClick={() => goToPage({ ...getPagerFromPageTag(`${toPage}`) })}
-				>
+				<lunatic.Button onClick={() => goToPage({ pageTag: toPage })}>
 					{`Go to page ${toPage}`}
 				</lunatic.Button>
 				<lunatic.Input

--- a/src/use-lunatic/commons/page-tag.ts
+++ b/src/use-lunatic/commons/page-tag.ts
@@ -4,9 +4,9 @@ import { LunaticState } from '../type';
  * Generate page name from the pager
  */
 export function getPageTag(pager: LunaticState['pager']): string {
-	const { page, subPage, iteration } = pager;
+	const { page, subPage, iteration, nbIterations } = pager;
 	if (subPage !== undefined && iteration !== undefined) {
-		return `${page}.${subPage + 1}#${iteration + 1}`; //|${nbIterations}
+		return `${page}.${subPage + 1}#${iteration + 1}|${nbIterations}`;
 	}
 
 	return `${page}`;
@@ -14,7 +14,7 @@ export function getPageTag(pager: LunaticState['pager']): string {
 
 export function getPagerFromPageTag(pageTag: string = '1') {
 	const pattern =
-		/(?<page>\d+)\.?(?<subPagePlusUn>\d+)?#?(?<iterationPlusUn>\d+)?/g;
+		/(?<page>\d+)\.?(?<subPagePlusUn>\d+)?#?(?<iterationPlusUn>\d+)?\|?(?<nbIterations>\d+)/g;
 	const match = [...(pageTag?.matchAll(pattern) as any)] as
 		| [
 				{
@@ -22,6 +22,7 @@ export function getPagerFromPageTag(pageTag: string = '1') {
 						page: string;
 						subPagePlusUn: string;
 						iterationPlusUn: string;
+						nbIterations: string;
 					};
 				}
 		  ]
@@ -31,13 +32,14 @@ export function getPagerFromPageTag(pageTag: string = '1') {
 	}
 	const [
 		{
-			groups: { page, subPagePlusUn, iterationPlusUn },
+			groups: { page, subPagePlusUn, iterationPlusUn, nbIterations },
 		},
 	] = match;
 	return {
 		page,
 		subPage: parseInt(subPagePlusUn, 10) - 1,
 		iteration: parseInt(iterationPlusUn, 10) - 1,
+		nbIterations: parseInt(nbIterations),
 	};
 }
 

--- a/src/use-lunatic/commons/page-tag.ts
+++ b/src/use-lunatic/commons/page-tag.ts
@@ -6,7 +6,7 @@ import { LunaticState } from '../type';
 export function getPageTag(pager: LunaticState['pager']): string {
 	const { page, subPage, iteration } = pager;
 	if (subPage !== undefined && iteration !== undefined) {
-		return `${page}.${subPage + 1}#${iteration + 1}`;
+		return `${page}.${subPage + 1}#${iteration + 1}`; //|${nbIterations}
 	}
 
 	return `${page}`;

--- a/src/use-lunatic/reducer/reduce-go-next-page.ts
+++ b/src/use-lunatic/reducer/reduce-go-next-page.ts
@@ -149,7 +149,6 @@ function reduceGoNextPage(state: LunaticState): LunaticState {
 		nbIterations: 0,
 		...pager,
 	};
-
 	/* next iteration of loop/roundabout */
 	if (isInLoop && subPage !== undefined && subPage < nbSubPages - 1) {
 		return validateChange(reduceNextSubPage(state));

--- a/src/use-lunatic/reducer/reduce-go-to-page.ts
+++ b/src/use-lunatic/reducer/reduce-go-to-page.ts
@@ -2,6 +2,7 @@ import { ActionGoToPage, ActionKind } from '../actions';
 import { LunaticState } from '../type';
 import { isOnEmptyPage } from './commons';
 import reduceGoNextPage from './reduce-go-next-page';
+import { getPagerFromPageTag } from '../commons/page-tag';
 
 function validateChange(state: LunaticState) {
 	const updatedState = { ...state } satisfies LunaticState;
@@ -26,15 +27,16 @@ function resolveSubPage(
 		subPage = 0,
 		roundabout,
 	} = action.payload;
-	const { subPages } = pages[page] || { subPages: [] };
+	const parsed = getPagerFromPageTag(page);
+	const rootPage = parsed ? parsed.page : '1';
+	const { subPages } = pages[rootPage] || { subPages: [] };
 	const nbSubPages = subPages?.length;
-
 	return {
 		...state,
 		isInLoop: true,
 		pager: {
 			...pager,
-			page,
+			page: rootPage,
 			iteration,
 			nbIterations,
 			nbSubPages,

--- a/src/use-lunatic/reducer/reduce-go-to-page.ts
+++ b/src/use-lunatic/reducer/reduce-go-to-page.ts
@@ -20,28 +20,26 @@ function resolveSubPage(
 	action: ActionGoToPage
 ): LunaticState {
 	const { pager, pages } = state;
-	const {
-		page,
-		iteration,
-		nbIterations,
-		subPage = 0,
-		roundabout,
-	} = action.payload;
-	const parsed = getPagerFromPageTag(page);
-	const rootPage = parsed ? parsed.page : '1';
-	const { subPages } = pages[rootPage] || { subPages: [] };
+	const { pageTag } = action.payload;
+	const parsed = getPagerFromPageTag(pageTag);
+	if (!parsed) {
+		return state;
+	}
+	const { page, subPage, iteration, nbIterations } = parsed;
+	const { subPages } = pages[page] || { subPages: [] };
 	const nbSubPages = subPages?.length;
+
 	return {
 		...state,
 		isInLoop: true,
 		pager: {
 			...pager,
-			page: rootPage,
+			page,
 			iteration,
 			nbIterations,
 			nbSubPages,
 			subPage,
-			roundabout,
+			// roundabout: {page},
 		},
 	};
 }
@@ -51,8 +49,13 @@ function reduceGoToPage(
 	action: ActionGoToPage
 ): LunaticState {
 	const { isInLoop, pager } = state;
-	const { page: newPage, iteration } = action.payload;
+	const { pageTag } = action.payload;
+	const content = getPagerFromPageTag(pageTag);
+	if (!content) {
+		return state;
+	}
 
+	const { iteration, page: newPage } = content;
 	if (iteration !== undefined) {
 		return resolveSubPage(state, action);
 	}

--- a/src/use-lunatic/type.ts
+++ b/src/use-lunatic/type.ts
@@ -165,13 +165,7 @@ export type LunaticState = {
 	shortcut?: boolean;
 	// TODO : Explain this
 	management?: boolean;
-	goToPage: (page: {
-		page: string;
-		iteration?: number;
-		nbIterations?: number;
-		subPage?: number;
-		roundabout?: { page: string };
-	}) => void;
+	goToPage: (page: { pageTag: string }) => void;
 	getSuggesterStatus: (name: string) => {
 		status: SuggesterStatus;
 		timestamp: number;


### PR DESCRIPTION
La fonction goToPage ne permet pas aujourd'hui un rechargement correct à l'intérieur d'une boucle et d'un roundabout.
Pour cela, on propose d'étendre le pageTag pour lui faire porter toute l'information nécessaire et modifier Lunatic, pour le recharger correctement.
- Le pageTag prend aujourd'hui la forme 2.1#1. On lui ajoute le nombre d'itération et le contexte spécifique, propre au rond point quand les pages visées sont au milieu d'un rond point : 4.1#2|2r4, par exemple (2|2 signifie itération 2 sur 2 iterations possible et r4 on est dans le rond point de la page 4)
- Tout le fonctionnement est résolu avec les 2 fonctions d'interprétation du pageTag.
-La fonction goToPage a été réécrite pour recharger directement le pageTag, plutôt que le pager (c'est plutôt son cas d'usage, - puisqu'elle est à destination des utilisateurs externes de lunatic)
- le input des options developpeurs est passé de inputNumber à input pour permettre de recharger des pageTag complet

PS : les pagTags sont en fait rédigés et interprétés par lunatic himself, cela ne devrait pas contraindre particulièrement les utilisateur et les dévéloppeurs intégrant ces changements.
