### PR TITLE
fix: LunaticData : Calculated, External, Collected could be optional

### DIFF
--- a/src/use-lunatic/reducer/reduce-on-init.ts
+++ b/src/use-lunatic/reducer/reduce-on-init.ts
@@ -21,17 +21,17 @@ import { reduceOverviewOnInit } from './overview/overview-on-init';
  */
 function getInitalValueFromCollected(
 	variable: LunaticVariable,
-	data = {} as LunaticData['COLLECTED']
-): unknown {
+	data: LunaticData['COLLECTED']
+) {
 	const { name } = variable;
 	let fromData;
-	if (name in data) {
+	if (data && name in data) {
 		const { COLLECTED, FORCED } = data[name];
 		fromData = COLLECTED || FORCED;
 	}
 	if ('values' in variable && variable.values) {
 		const { COLLECTED, FORCED } = variable.values;
-		return fromData || FORCED || COLLECTED;
+		return fromData ?? (FORCED || COLLECTED);
 	}
 	return undefined;
 }
@@ -44,10 +44,7 @@ function getInitialValueFromExternal(
 	data = {} as LunaticData['EXTERNAL']
 ) {
 	const { name } = variable;
-	if (name in data) {
-		return data[name];
-	}
-	return undefined;
+	return data?.[name];
 }
 
 /**

--- a/src/use-lunatic/type.ts
+++ b/src/use-lunatic/type.ts
@@ -15,11 +15,11 @@ export type LunaticControl = ControlType;
 
 export type VTLBindings = { [variableName: string]: unknown };
 
-export type LunaticData = {
-	CALCULATED: Record<string, unknown>;
-	EXTERNAL: Record<string, unknown>;
-	COLLECTED: Record<string, LunaticCollectedValue>;
-};
+export type LunaticData = Partial<
+	Record<Exclude<VariableType, 'COLLECTED'>, Record<string, unknown>> & {
+		COLLECTED: Record<string, LunaticCollectedValue>;
+	}
+>;
 
 export type LunaticValues = {
 	[variableName: string]: unknown;


### PR DESCRIPTION
This pull request allows for handling cases where the data passed at the start of a questionnaire can be empty or partial object.

Additionally, it's essential to highlight that the collected data should be capable of functioning even when not all modes (INPUTED, COLLECTED, FORCED, EDITED, PREVIOUS) are explicitly specified. The changes made in this pull request **doest not** achieve this necessary flexibility.
