### PR TITLE
Fix incorrect types for getComponents

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@inseefr/lunatic",
-	"version": "2.5.1",
+	"version": "2.5.0",
 	"workersVersion": "0.2.5-experimental",
 	"description": "Library of questionnaire components",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@inseefr/lunatic",
-	"version": "2.5.0",
+	"version": "2.5.1",
 	"workersVersion": "0.2.5-experimental",
 	"description": "Library of questionnaire components",
 	"repository": {

--- a/src/use-lunatic/use-lunatic.ts
+++ b/src/use-lunatic/use-lunatic.ts
@@ -145,7 +145,10 @@ function useLunatic(
 		function ({
 			only,
 			except,
-		}: { only?: LunaticComponentType[]; except?: LunaticComponentType } = {}) {
+		}: {
+			only?: LunaticComponentType[];
+			except?: LunaticComponentType[];
+		} = {}) {
 			if (only && except) {
 				throw new Error(
 					'"only" and "except" cannot be used together in getComponents()'


### PR DESCRIPTION
L'argument `except` n'était pas déclaré comme un tableau. 