### PR TITLE
Allow custom ComboBoxContent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ playwright-report
 test-report.xml
 /playwright-report/
 /playwright/.cache/
+*.tgz

--- a/src/components/commons/components/combo-box/combo-box-container.spec.tsx
+++ b/src/components/commons/components/combo-box/combo-box-container.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { ComboBoxContainer } from './combo-box-container';
+import ComboBoxContainer from './combo-box-container';
 import { expect, it, describe } from 'vitest';
 
 describe('ComboBoxContainer', () => {

--- a/src/components/commons/components/combo-box/combo-box-container.tsx
+++ b/src/components/commons/components/combo-box/combo-box-container.tsx
@@ -1,17 +1,22 @@
 import type { PropsWithChildren } from 'react';
 import classnames from 'classnames';
+import { LunaticBaseProps } from '../../../type';
+import createCustomizableLunaticField from '../../create-customizable-field';
+import Errors from '../errors';
 
 type Props = PropsWithChildren<{
 	className?: string;
 	id?: string;
 	classStyle?: string;
+	errors?: LunaticBaseProps['errors'];
 }>;
 
-export function ComboBoxContainer({
+function ComboBoxContainer({
 	children,
 	className,
 	id,
 	classStyle = 'default-style',
+	errors,
 }: Props) {
 	return (
 		<div
@@ -24,6 +29,13 @@ export function ComboBoxContainer({
 			)}
 		>
 			{children}
+			{/* Errors are called here so that they can be customised */}
+			{errors && <Errors errors={errors} activeId={id} />}
 		</div>
 	);
 }
+
+export default createCustomizableLunaticField(
+	ComboBoxContainer,
+	'ComboboxContainer'
+);

--- a/src/components/commons/components/combo-box/combo-box-container.tsx
+++ b/src/components/commons/components/combo-box/combo-box-container.tsx
@@ -15,10 +15,11 @@ export function ComboBoxContainer({
 }: Props) {
 	return (
 		<div
-			id={`lunatic-combo-box-container-${id}`}
+			id={`${className ?? 'lunatic'}-combo-box-container-${id}`}
 			className={classnames(
-				'lunatic-combo-box-container',
-				className,
+				`${className ?? 'lunatic'}-combo-box-container`,
+				`${className ?? 'lunatic'}-suggester-${classStyle}`,
+				`lunatic-suggester-default-style`,
 				classStyle
 			)}
 		>

--- a/src/components/commons/components/combo-box/combo-box-container.tsx
+++ b/src/components/commons/components/combo-box/combo-box-container.tsx
@@ -5,7 +5,7 @@ import createCustomizableLunaticField from '../../create-customizable-field';
 import Errors from '../errors';
 
 type Props = PropsWithChildren<{
-	className?: string;
+	classNamePrefix?: string;
 	id?: string;
 	classStyle?: string;
 	errors?: LunaticBaseProps['errors'];
@@ -13,17 +13,17 @@ type Props = PropsWithChildren<{
 
 function ComboBoxContainer({
 	children,
-	className,
+	classNamePrefix,
 	id,
 	classStyle = 'default-style',
 	errors,
 }: Props) {
 	return (
 		<div
-			id={`${className ?? 'lunatic'}-combo-box-container-${id}`}
+			id={`${classNamePrefix ?? 'lunatic'}-combo-box-container-${id}`}
 			className={classnames(
-				`${className ?? 'lunatic'}-combo-box-container`,
-				`${className ?? 'lunatic'}-suggester-${classStyle}`,
+				`${classNamePrefix ?? 'lunatic'}-combo-box-container`,
+				`${classNamePrefix ?? 'lunatic'}-suggester-${classStyle}`,
 				`lunatic-suggester-default-style`,
 				classStyle
 			)}

--- a/src/components/commons/components/combo-box/combo-box-container.tsx
+++ b/src/components/commons/components/combo-box/combo-box-container.tsx
@@ -6,6 +6,7 @@ import Errors from '../errors';
 
 type Props = PropsWithChildren<{
 	classNamePrefix?: string;
+	className?: string;
 	id?: string;
 	classStyle?: string;
 	errors?: LunaticBaseProps['errors'];
@@ -13,6 +14,7 @@ type Props = PropsWithChildren<{
 
 function ComboBoxContainer({
 	children,
+	className,
 	classNamePrefix,
 	id,
 	classStyle = 'default-style',
@@ -22,6 +24,7 @@ function ComboBoxContainer({
 		<div
 			id={`${classNamePrefix ?? 'lunatic'}-combo-box-container-${id}`}
 			className={classnames(
+				className,
 				`${classNamePrefix ?? 'lunatic'}-combo-box-container`,
 				`${classNamePrefix ?? 'lunatic'}-suggester-${classStyle}`,
 				`lunatic-suggester-default-style`,

--- a/src/components/commons/components/combo-box/combo-box-content-box.tsx
+++ b/src/components/commons/components/combo-box/combo-box-content-box.tsx
@@ -4,17 +4,17 @@ import { createCustomizableLunaticField } from '../../index';
 
 type Props = PropsWithChildren<{
 	focused?: boolean;
-	className?: string;
+	classNamePrefix?: string;
 }>;
 
 export function ComboBoxContentBox({
 	children,
-	className,
+	classNamePrefix,
 	focused,
 }: Props) {
 	return (
 		<div
-			className={classnames(`${className ?? 'lunatic'}-combo-box`, {
+			className={classnames(`${classNamePrefix ?? 'lunatic'}-combo-box`, {
 				focused,
 			})}
 		>

--- a/src/components/commons/components/combo-box/combo-box-content-box.tsx
+++ b/src/components/commons/components/combo-box/combo-box-content-box.tsx
@@ -8,7 +8,6 @@ type Props = PropsWithChildren<{
 	onFocus: () => void;
 	onKeyDown: (e: KeyboardEvent<Element>) => void;
 	className?: string;
-	ref: React.RefObject<HTMLDivElement>;
 }>;
 
 export function ComboBoxContentBox({
@@ -17,7 +16,6 @@ export function ComboBoxContentBox({
 	onFocus,
 	onKeyDown,
 	focused,
-	ref,
 }: Props) {
 	return (
 		<div
@@ -27,8 +25,6 @@ export function ComboBoxContentBox({
 			onFocus={onFocus}
 			onClick={onFocus}
 			onKeyDown={onKeyDown}
-			ref={ref}
-			tabIndex={0}
 		>
 			{children}
 		</div>

--- a/src/components/commons/components/combo-box/combo-box-content-box.tsx
+++ b/src/components/commons/components/combo-box/combo-box-content-box.tsx
@@ -6,7 +6,7 @@ import { createCustomizableLunaticField } from '../../index';
 type Props = PropsWithChildren<{
 	focused?: boolean;
 	onFocus: () => void;
-	handleKeyDown: (e: KeyboardEvent<Element>) => void;
+	onKeyDown: (e: KeyboardEvent<Element>) => void;
 	className?: string;
 	ref: React.RefObject<HTMLDivElement>;
 }>;
@@ -15,11 +15,10 @@ export function ComboBoxContentBox({
 	children,
 	className,
 	onFocus,
-	handleKeyDown,
+	onKeyDown,
 	focused,
-	ref
+	ref,
 }: Props) {
-
 	return (
 		<div
 			className={classnames(`${className ?? 'lunatic'}-combo-box`, {
@@ -27,7 +26,7 @@ export function ComboBoxContentBox({
 			})}
 			onFocus={onFocus}
 			onClick={onFocus}
-			onKeyDown={handleKeyDown}
+			onKeyDown={onKeyDown}
 			ref={ref}
 			tabIndex={0}
 		>
@@ -36,4 +35,7 @@ export function ComboBoxContentBox({
 	);
 }
 
-export default createCustomizableLunaticField(ComboBoxContentBox, 'ComboboxContentBox');
+export default createCustomizableLunaticField(
+	ComboBoxContentBox,
+	'ComboboxContentBox'
+);

--- a/src/components/commons/components/combo-box/combo-box-content-box.tsx
+++ b/src/components/commons/components/combo-box/combo-box-content-box.tsx
@@ -1,19 +1,15 @@
-import type { KeyboardEvent } from 'react';
 import React, { PropsWithChildren } from 'react';
 import classnames from 'classnames';
 import { createCustomizableLunaticField } from '../../index';
 
 type Props = PropsWithChildren<{
 	focused?: boolean;
-	onFocus: () => void;
-	onKeyDown: (e: KeyboardEvent<Element>) => void;
 	className?: string;
 }>;
 
 export function ComboBoxContentBox({
 	children,
 	className,
-	onFocus,
 	focused,
 }: Props) {
 	return (
@@ -21,8 +17,6 @@ export function ComboBoxContentBox({
 			className={classnames(`${className ?? 'lunatic'}-combo-box`, {
 				focused,
 			})}
-			onFocus={onFocus}
-			onClick={onFocus}
 		>
 			{children}
 		</div>

--- a/src/components/commons/components/combo-box/combo-box-content-box.tsx
+++ b/src/components/commons/components/combo-box/combo-box-content-box.tsx
@@ -14,7 +14,6 @@ export function ComboBoxContentBox({
 	children,
 	className,
 	onFocus,
-	onKeyDown,
 	focused,
 }: Props) {
 	return (
@@ -24,7 +23,6 @@ export function ComboBoxContentBox({
 			})}
 			onFocus={onFocus}
 			onClick={onFocus}
-			onKeyDown={onKeyDown}
 		>
 			{children}
 		</div>

--- a/src/components/commons/components/combo-box/combo-box-content-box.tsx
+++ b/src/components/commons/components/combo-box/combo-box-content-box.tsx
@@ -1,0 +1,39 @@
+import type { KeyboardEvent } from 'react';
+import React, { PropsWithChildren } from 'react';
+import classnames from 'classnames';
+import { createCustomizableLunaticField } from '../../index';
+
+type Props = PropsWithChildren<{
+	focused?: boolean;
+	onFocus: () => void;
+	handleKeyDown: (e: KeyboardEvent<Element>) => void;
+	className?: string;
+	ref: React.RefObject<HTMLDivElement>;
+}>;
+
+export function ComboBoxContentBox({
+	children,
+	className,
+	onFocus,
+	handleKeyDown,
+	focused,
+	ref
+}: Props) {
+
+	return (
+		<div
+			className={classnames(`${className ?? 'lunatic'}-combo-box`, {
+				focused,
+			})}
+			onFocus={onFocus}
+			onClick={onFocus}
+			onKeyDown={handleKeyDown}
+			ref={ref}
+			tabIndex={0}
+		>
+			{children}
+		</div>
+	);
+}
+
+export default createCustomizableLunaticField(ComboBoxContentBox, 'ComboboxContentBox');

--- a/src/components/commons/components/combo-box/combo-box-content.tsx
+++ b/src/components/commons/components/combo-box/combo-box-content.tsx
@@ -64,6 +64,7 @@ export function ComboBoxContent({
 				})}
 				ref={ref}
 				tabIndex={0}
+				onKeyDown={handleKeyDown}
 			>
 				{children}
 			</div>

--- a/src/components/commons/components/combo-box/combo-box-content.tsx
+++ b/src/components/commons/components/combo-box/combo-box-content.tsx
@@ -9,6 +9,7 @@ type Props = PropsWithChildren<{
 	onBlur: () => void;
 	onFocus: () => void;
 	onKeyDown: (key: string) => void;
+	className?: string;
 }>;
 
 export function ComboBoxContent({
@@ -17,6 +18,7 @@ export function ComboBoxContent({
 	onFocus,
 	onBlur,
 	onKeyDown,
+	className,
 }: Props) {
 	const ref = useRef<HTMLDivElement>(null);
 
@@ -51,7 +53,7 @@ export function ComboBoxContent({
 
 	return (
 		<div
-			className={classnames('lunatic-combo-box', {
+			className={classnames(`${className ?? 'lunatic'}-combo-box`, {
 				focused,
 			})}
 			onFocus={onFocus}
@@ -60,7 +62,11 @@ export function ComboBoxContent({
 			ref={ref}
 			tabIndex={0}
 		>
-			<div className={classnames('lunatic-combo-box-content', { focused })}>
+			<div
+				className={classnames(`${className ?? 'lunatic'}-combo-box-content`, {
+					focused,
+				})}
+			>
 				{children}
 			</div>
 		</div>

--- a/src/components/commons/components/combo-box/combo-box-content.tsx
+++ b/src/components/commons/components/combo-box/combo-box-content.tsx
@@ -3,6 +3,7 @@ import React, { PropsWithChildren, useCallback, useRef } from 'react';
 import classnames from 'classnames';
 import { KEYBOARD_KEY_CODES } from './state-management/reduce-on-keydown/keyboard-key-codes';
 import { useDocumentAddEventListener } from '../../index';
+import ComboBoxContentBox from './combo-box-content-box';
 
 type Props = PropsWithChildren<{
 	focused?: boolean;
@@ -52,15 +53,11 @@ export function ComboBoxContent({
 	);
 
 	return (
-		<div
-			className={classnames(`${className ?? 'lunatic'}-combo-box`, {
-				focused,
-			})}
+		<ComboBoxContentBox
+			className={className}
 			onFocus={onFocus}
-			onClick={onFocus}
-			onKeyDown={handleKeyDown}
+			handleKeyDown={handleKeyDown}
 			ref={ref}
-			tabIndex={0}
 		>
 			<div
 				className={classnames(`${className ?? 'lunatic'}-combo-box-content`, {
@@ -69,7 +66,7 @@ export function ComboBoxContent({
 			>
 				{children}
 			</div>
-		</div>
+		</ ComboBoxContentBox>
 	);
 }
 

--- a/src/components/commons/components/combo-box/combo-box-content.tsx
+++ b/src/components/commons/components/combo-box/combo-box-content.tsx
@@ -57,12 +57,13 @@ export function ComboBoxContent({
 			className={className}
 			onFocus={onFocus}
 			onKeyDown={handleKeyDown}
-			ref={ref}
 		>
 			<div
 				className={classnames(`${className ?? 'lunatic'}-combo-box-content`, {
 					focused,
 				})}
+				ref={ref}
+				tabIndex={0}
 			>
 				{children}
 			</div>

--- a/src/components/commons/components/combo-box/combo-box-content.tsx
+++ b/src/components/commons/components/combo-box/combo-box-content.tsx
@@ -55,8 +55,6 @@ export function ComboBoxContent({
 	return (
 		<ComboBoxContentBox
 			className={className}
-			onFocus={onFocus}
-			onKeyDown={handleKeyDown}
 		>
 			<div
 				className={classnames(`${className ?? 'lunatic'}-combo-box-content`, {
@@ -64,6 +62,8 @@ export function ComboBoxContent({
 				})}
 				ref={ref}
 				tabIndex={0}
+				onFocus={onFocus}
+				onClick={onFocus}
 				onKeyDown={handleKeyDown}
 			>
 				{children}

--- a/src/components/commons/components/combo-box/combo-box-content.tsx
+++ b/src/components/commons/components/combo-box/combo-box-content.tsx
@@ -56,7 +56,7 @@ export function ComboBoxContent({
 		<ComboBoxContentBox
 			className={className}
 			onFocus={onFocus}
-			handleKeyDown={handleKeyDown}
+			onKeyDown={handleKeyDown}
 			ref={ref}
 		>
 			<div
@@ -66,7 +66,7 @@ export function ComboBoxContent({
 			>
 				{children}
 			</div>
-		</ ComboBoxContentBox>
+		</ComboBoxContentBox>
 	);
 }
 

--- a/src/components/commons/components/combo-box/combo-box-content.tsx
+++ b/src/components/commons/components/combo-box/combo-box-content.tsx
@@ -10,7 +10,7 @@ type Props = PropsWithChildren<{
 	onBlur: () => void;
 	onFocus: () => void;
 	onKeyDown: (key: string) => void;
-	className?: string;
+	classNamePrefix?: string;
 }>;
 
 export function ComboBoxContent({
@@ -19,7 +19,7 @@ export function ComboBoxContent({
 	onFocus,
 	onBlur,
 	onKeyDown,
-	className,
+	classNamePrefix,
 }: Props) {
 	const ref = useRef<HTMLDivElement>(null);
 
@@ -54,10 +54,10 @@ export function ComboBoxContent({
 
 	return (
 		<ComboBoxContentBox
-			className={className}
+			classNamePrefix={classNamePrefix}
 		>
 			<div
-				className={classnames(`${className ?? 'lunatic'}-combo-box-content`, {
+				className={classnames(`${classNamePrefix ?? 'lunatic'}-combo-box-content`, {
 					focused,
 				})}
 				ref={ref}

--- a/src/components/commons/components/combo-box/combo-box.tsx
+++ b/src/components/commons/components/combo-box/combo-box.tsx
@@ -17,6 +17,7 @@ const EMPTY_SEARCH = '';
 type Props = SelectionProps &
 	PanelProps & {
 		className?: string;
+		classNamePrefix?: string;
 		classStyle?: string;
 		value: string | null;
 		messageError?: string;
@@ -31,6 +32,7 @@ type Props = SelectionProps &
 
 function ComboBox({
 	className,
+	classNamePrefix,
 	classStyle = 'default-style',
 	placeholder = 'Please, do something...',
 	editable = false,
@@ -125,7 +127,7 @@ function ComboBox({
 		<ComboBoxContainer
 			id={id}
 			classStyle={classStyle}
-			className={className}
+			classNamePrefix={classNamePrefix}
 			errors={errors}
 		>
 			<Label htmlFor={id} id={labelId} description={description}>
@@ -136,7 +138,7 @@ function ComboBox({
 				onFocus={onFocus}
 				onBlur={onBlur}
 				onKeyDown={onKeyDown}
-				className={className}
+				classNamePrefix={classNamePrefix}
 			>
 				<Selection
 					labelRenderer={labelRenderer}
@@ -151,7 +153,7 @@ function ComboBox({
 					selectedIndex={selectedIndex}
 					options={options}
 					onChange={handleChange}
-					className={className}
+					classNamePrefix={classNamePrefix}
 				/>
 				<Panel
 					optionRenderer={optionRenderer}

--- a/src/components/commons/components/combo-box/combo-box.tsx
+++ b/src/components/commons/components/combo-box/combo-box.tsx
@@ -63,6 +63,12 @@ function ComboBox({
 		[options, value, getOptionValue]
 	);
 
+	useEffect(
+		function() {
+
+		}, [options, selectedIndex, onSelect]
+	)
+
 	const onFocus = useCallback(function () {
 		dispatch(actions.onFocus());
 	}, []);

--- a/src/components/commons/components/combo-box/combo-box.tsx
+++ b/src/components/commons/components/combo-box/combo-box.tsx
@@ -65,8 +65,11 @@ function ComboBox({
 
 	useEffect(
 		function() {
-
-		}, [options, selectedIndex, onSelect]
+			if (selectedIndex) {
+				const option = options[selectedIndex]
+				onSelect(getOptionValue(option))
+			}
+		}, [selectedIndex, options, getOptionValue, onSelect]
 	)
 
 	const onFocus = useCallback(function () {

--- a/src/components/commons/components/combo-box/combo-box.tsx
+++ b/src/components/commons/components/combo-box/combo-box.tsx
@@ -122,6 +122,7 @@ function ComboBox({
 				onFocus={onFocus}
 				onBlur={onBlur}
 				onKeyDown={onKeyDown}
+				className={className}
 			>
 				<Selection
 					labelRenderer={labelRenderer}
@@ -136,6 +137,7 @@ function ComboBox({
 					selectedIndex={selectedIndex}
 					options={options}
 					onChange={handleChange}
+					className={className}
 				/>
 				<Panel
 					optionRenderer={optionRenderer}

--- a/src/components/commons/components/combo-box/combo-box.tsx
+++ b/src/components/commons/components/combo-box/combo-box.tsx
@@ -63,6 +63,7 @@ function ComboBox({
 		[options, value, getOptionValue]
 	);
 
+	// This useEffect ensures that onSelect is called when selectedIndex changes
 	useEffect(
 		function() {
 			if (selectedIndex) {

--- a/src/components/commons/components/combo-box/combo-box.tsx
+++ b/src/components/commons/components/combo-box/combo-box.tsx
@@ -6,11 +6,10 @@ import './combo-box.scss';
 import { ComboBoxOptionType } from './combo-box.type';
 import { SelectionProps, Selection } from './selection/selection';
 import { Panel, PanelProps } from './panel/panel';
-import { ComboBoxContainer } from './combo-box-container';
+import ComboBoxContainer from './combo-box-container';
 import ComboBoxContent from './combo-box-content';
 import { LunaticBaseProps } from '../../../type';
 import Label from '../label';
-import Errors from '../errors';
 import { createCustomizableLunaticField } from '../../index';
 
 const EMPTY_SEARCH = '';
@@ -113,7 +112,12 @@ function ComboBox({
 	}
 
 	return (
-		<ComboBoxContainer id={id} classStyle={classStyle} className={className}>
+		<ComboBoxContainer
+			id={id}
+			classStyle={classStyle}
+			className={className}
+			errors={errors}
+		>
 			<Label htmlFor={id} id={labelId} description={description}>
 				{label}
 			</Label>
@@ -156,7 +160,6 @@ function ComboBox({
 				onClick={onDelete}
 				editable={editable}
 			/>
-			{errors && <Errors errors={errors} activeId={id} />}
 		</ComboBoxContainer>
 	);
 }

--- a/src/components/commons/components/combo-box/panel/panel-container.spec.tsx
+++ b/src/components/commons/components/combo-box/panel/panel-container.spec.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
-import { PanelContainer } from './panel-container';
+import PanelContainer from './panel-container';
 
 describe('PanelContainer', () => {
 	it('should render children', () => {

--- a/src/components/commons/components/combo-box/panel/panel-container.tsx
+++ b/src/components/commons/components/combo-box/panel/panel-container.tsx
@@ -1,5 +1,6 @@
 import classnames from 'classnames';
 import { PropsWithChildren } from 'react';
+import createCustomizableLunaticField from '../../../create-customizable-field';
 
 type Props = PropsWithChildren<{
 	focused?: boolean;
@@ -7,7 +8,7 @@ type Props = PropsWithChildren<{
 	id?: string;
 }>;
 
-export function PanelContainer({ children, focused, expanded, id }: Props) {
+function PanelContainer({ children, focused, expanded, id }: Props) {
 	return (
 		<ul
 			id={`lunatic-combo-box-panel-${id}`}
@@ -22,3 +23,8 @@ export function PanelContainer({ children, focused, expanded, id }: Props) {
 		</ul>
 	);
 }
+
+export default createCustomizableLunaticField(
+	PanelContainer,
+	'ComboboxPanelContainer'
+);

--- a/src/components/commons/components/combo-box/panel/panel.tsx
+++ b/src/components/commons/components/combo-box/panel/panel.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { PanelContainer } from './panel-container';
+import PanelContainer from './panel-container';
 import { OptionContainer } from './option-container';
 import { ComboBoxOptionType } from '../combo-box.type';
 import ComboBoxOption from './combo-box-option';

--- a/src/components/commons/components/combo-box/selection/selection-container.tsx
+++ b/src/components/commons/components/combo-box/selection/selection-container.tsx
@@ -7,6 +7,7 @@ type Props = PropsWithChildren<{
 	disabled?: boolean;
 	labelId?: string;
 	id?: string;
+	className?: string;
 }>;
 
 function SelectionContainer({
@@ -16,12 +17,13 @@ function SelectionContainer({
 	focused,
 	disabled,
 	labelId,
+	className,
 }: Props) {
 	const comboBoxId = `${id}`;
 	return (
 		<div
 			id={comboBoxId}
-			className={classnames('lunatic-combo-box-selection', {
+			className={classnames(`${className ?? 'lunatic'}-combo-box-selection`, {
 				focused,
 				disabled,
 			})}

--- a/src/components/commons/components/combo-box/selection/selection-container.tsx
+++ b/src/components/commons/components/combo-box/selection/selection-container.tsx
@@ -7,7 +7,7 @@ type Props = PropsWithChildren<{
 	disabled?: boolean;
 	labelId?: string;
 	id?: string;
-	className?: string;
+	classNamePrefix?: string;
 }>;
 
 function SelectionContainer({
@@ -17,13 +17,13 @@ function SelectionContainer({
 	focused,
 	disabled,
 	labelId,
-	className,
+	classNamePrefix,
 }: Props) {
 	const comboBoxId = `${id}`;
 	return (
 		<div
 			id={comboBoxId}
-			className={classnames(`${className ?? 'lunatic'}-combo-box-selection`, {
+			className={classnames(`${classNamePrefix ?? 'lunatic'}-combo-box-selection`, {
 				focused,
 				disabled,
 			})}

--- a/src/components/commons/components/combo-box/selection/selection.tsx
+++ b/src/components/commons/components/combo-box/selection/selection.tsx
@@ -10,6 +10,7 @@ export type SelectionProps = {
 	editable?: boolean;
 	labelId?: string;
 	id?: string;
+	className?: string;
 } & LabelSelectionProps;
 
 export function Selection({
@@ -25,6 +26,7 @@ export function Selection({
 	editable,
 	labelId,
 	id,
+	className,
 }: SelectionProps) {
 	const onChangeEx = useCallback<ChangeEventHandler<HTMLInputElement>>(
 		(e) => {
@@ -39,6 +41,7 @@ export function Selection({
 			labelId={labelId}
 			expanded={expanded}
 			aria-owns={`${id}-list`}
+			className={className}
 		>
 			<LabelOrInput
 				labelRenderer={labelRenderer}

--- a/src/components/commons/components/combo-box/selection/selection.tsx
+++ b/src/components/commons/components/combo-box/selection/selection.tsx
@@ -10,7 +10,7 @@ export type SelectionProps = {
 	editable?: boolean;
 	labelId?: string;
 	id?: string;
-	className?: string;
+	classNamePrefix?: string;
 } & LabelSelectionProps;
 
 export function Selection({
@@ -26,7 +26,7 @@ export function Selection({
 	editable,
 	labelId,
 	id,
-	className,
+	classNamePrefix,
 }: SelectionProps) {
 	const onChangeEx = useCallback<ChangeEventHandler<HTMLInputElement>>(
 		(e) => {
@@ -41,7 +41,7 @@ export function Selection({
 			labelId={labelId}
 			expanded={expanded}
 			aria-owns={`${id}-list`}
-			className={className}
+			classNamePrefix={classNamePrefix}
 		>
 			<LabelOrInput
 				labelRenderer={labelRenderer}

--- a/src/components/suggester/html/suggester.tsx
+++ b/src/components/suggester/html/suggester.tsx
@@ -9,6 +9,7 @@ import D from '../../../i18n';
 
 type Props = {
 	className?: string;
+	classNamePrefix?: string;
 	placeholder?: string;
 	onSelect?: (s: string | null) => void;
 	value: string | null;
@@ -23,7 +24,8 @@ type Props = {
 };
 
 function Suggester({
-	className = 'lunatic',
+	className,
+	classNamePrefix = 'lunatic',
 	placeholder = D.PLACEHOLDER,
 	onSelect = voidFunction,
 	labelRenderer,
@@ -69,6 +71,7 @@ function Suggester({
 		<ComboBox
 			id={id}
 			className={className}
+			classNamePrefix={classNamePrefix}
 			onChange={handleChange}
 			disabled={disabled}
 			options={options}

--- a/src/components/suggester/html/suggester.tsx
+++ b/src/components/suggester/html/suggester.tsx
@@ -23,7 +23,7 @@ type Props = {
 };
 
 function Suggester({
-	className = 'lunatic-suggester-default-style',
+	className = 'lunatic',
 	placeholder = D.PLACEHOLDER,
 	onSelect = voidFunction,
 	labelRenderer,

--- a/src/components/suggester/html/suggester.tsx
+++ b/src/components/suggester/html/suggester.tsx
@@ -52,6 +52,8 @@ function Suggester({
 				const { results } = await searching(search);
 				setOptions(results);
 				setSearch(search);
+				// if a user does not select an option in the list, their search term is saved
+				onSelect(search)
 			} else {
 				setOptions([]);
 				onSelect(null);

--- a/src/components/suggester/lunatic-suggester.tsx
+++ b/src/components/suggester/lunatic-suggester.tsx
@@ -22,10 +22,10 @@ function LunaticSuggester({
 	missingResponse,
 	management,
 	response,
+	className,
 	getSuggesterStatus,
 }: LunaticComponentProps<'Suggester'>) {
 	const onChange = useOnHandleChange({ handleChange, response, value });
-
 	return (
 		<LunaticComponent
 			id={id}
@@ -50,6 +50,7 @@ function LunaticSuggester({
 				errors={errors}
 				label={label}
 				getSuggesterStatus={getSuggesterStatus}
+				className={className}
 			/>
 		</LunaticComponent>
 	);

--- a/src/stories/suggester/simple.json
+++ b/src/stories/suggester/simple.json
@@ -46,6 +46,21 @@
 				"value": "true",
 				"type": "VTL"
 			},
+			"controls": [
+				{
+					"id": "age-controls",
+					"criticality": "ERROR",
+					"typeOfControl": "FORMAT",
+					"control": {
+						"value": "not(isnull(HELLO))",
+						"type": "VTL"
+					},
+					"errorMessage": {
+						"value": "\"Veuillez selectionner quelquechose\"",
+						"type": "VTL"
+					}
+				}
+			],
 			"response": {
 				"name": "HELLO"
 			},


### PR DESCRIPTION
# Initial Problem
Thanks to the recent changes to make the subcomponents of the `Suggester` component customisable, we are now able to customise these elements in Lunatic-DSFR. 
Unfortunately, there is higher-level CSS in subcomponents of the `Suggester` that are not customisable, and which we can't access from Lunatic-DSFR. 
I wanted to avoid changing the CSS defined in Lunatic, as it may have implications on other components. 

(image: Above, suggester with proposed solution, Below, suggester prior to changes to Lunatic)

![image](https://github.com/InseeFr/Lunatic/assets/87824367/3974f4c6-acdf-4e09-b574-bcad99089f1a)

In addition, the errors in LunaticSuggester are not passed to any of the customisable components.  This means that we are unable to display any errors in the manner that fits the DSFR. 
I modified two components to make them customisable: `PanelContainer` and `ComboBoxContainer`.  This means we are able to customise the style as required in the Lunatic-DSFR components. 
I also moved the `Errors` component inside the `ComboBoxContainer` so that the errors can also be customised.  

# Solution
I discovered that we can get the target style simply by changing the class of one html element (`lunatic-combo-box`).  This element is rendered in the `ComboBoxContent` subcomponent, which holds a fair amount of logic and is not customisable. 
I isolated the html element that we want to customise into a new customisable subcomponent: `ComboBoxContentBox` which simply renders the html element in question.  
In Lunatic-DSFR we can therefore create a component that with a different className therefore disabling the unwanted CSS.  

<details>
<summary>Previous solution</summary>
# Solution
As there was already a primarily unused parametre `className` in some parts of the component, I figured that I could make use of this to render the classes of the higher components dynamic and customisable in the source.json.  
If no `className` is defined, it defaults to `"lunatic"`, which is then prepended to html classes within the component: eg `${className}-combo-box-content`. 
This allows us to define `className="lunatic-dsfr"` in the source.json, which customises the classes of the html elements meaning that the native css in Lunatic is no longer active. 

# Note
Ideally, it would be preferable to define the default className directly in the Lunatic-DSFR component. This introduces the requirement to manually add a `className` in the json whenever we use a Suggester in Stromae-v3/Lunatic-DSFR.
</details>