### PR TITLE
Fix : Filter being ignored when entering a loop

### DIFF
--- a/src/use-lunatic/commons/page.ts
+++ b/src/use-lunatic/commons/page.ts
@@ -43,15 +43,5 @@ export function isPageEmpty(state: LunaticState): boolean {
 		return true;
 	}
 
-	// We have a roundabout with only one iteration
-	const firstComponent = visibleComponents[0];
-	if (
-		visibleComponents.length === 1 &&
-		firstComponent?.componentType === 'Roundabout' &&
-		executeExpression<number>(firstComponent.iterations) === 1
-	) {
-		return true;
-	}
-
 	return false;
 }

--- a/src/use-lunatic/reducer/reduce-go-next-page.ts
+++ b/src/use-lunatic/reducer/reduce-go-next-page.ts
@@ -17,13 +17,15 @@ function reduceGoNextPage(state: LunaticState): LunaticState {
 		throw new Error(`Cannot reach next page ${pageId}`);
 	}
 
-	// If we reached a loop, go inside
-	const newState = autoExploreLoop({ ...state, pager: nextPager }, 'forward');
+	let newState = { ...state, pager: nextPager };
 
 	// We reached an empty page, move forward
 	if (isPageEmpty(newState)) {
 		return reduceGoNextPage(newState);
 	}
+
+	// If we reached a loop, go inside
+	newState = autoExploreLoop(newState, 'forward');
 
 	return {
 		...newState,

--- a/src/use-lunatic/reducer/reduce-go-previous-page.ts
+++ b/src/use-lunatic/reducer/reduce-go-previous-page.ts
@@ -2,6 +2,7 @@ import { LunaticState } from '../type';
 import { getPrevPager } from '../commons/page-navigation';
 import { autoExploreLoop } from './commons/auto-explore-loop';
 import { getPageId, isPageEmpty } from '../commons/page';
+import { getComponentsFromState } from '../commons';
 
 function reduceGoPreviousPage(state: LunaticState): LunaticState {
 	const { pages, pager } = state;
@@ -14,11 +15,23 @@ function reduceGoPreviousPage(state: LunaticState): LunaticState {
 		throw new Error(`Cannot reach previous page ${pageId}`);
 	}
 
-	// If we reached a loop, go to the last iteration / sequence
-	const newState = autoExploreLoop({ ...state, pager: prevPager }, 'backward');
+	let newState = { ...state, pager: prevPager };
 
 	// We reached an empty page, keep going backward
 	if (isPageEmpty(newState)) {
+		return reduceGoPreviousPage(newState);
+	}
+
+	// If we reached a loop, go to the last iteration / sequence
+	newState = autoExploreLoop(newState, 'backward');
+
+	// We have a roundabout with only one iteration skip it
+	const components = getComponentsFromState(newState);
+	if (
+		components.length === 1 &&
+		components[0]?.componentType === 'Roundabout' &&
+		newState.executeExpression<number>(components[0].iterations) === 1
+	) {
 		return reduceGoPreviousPage(newState);
 	}
 

--- a/src/use-lunatic/reducer/reduce-go-to-page.ts
+++ b/src/use-lunatic/reducer/reduce-go-to-page.ts
@@ -59,18 +59,19 @@ function reduceGoToPage(
 	}
 
 	// Move forward if the page is empty
-	if (isPageEmpty(state)) {
-		return reduceGoNextPage(state, {
+	const newState = {
+		...state,
+		isInLoop: newPager.nbIterations !== undefined,
+		pager: newPager,
+	};
+	if (isPageEmpty(newState)) {
+		return reduceGoNextPage(newState, {
 			type: ActionKind.GO_NEXT_PAGE,
 			payload: {},
 		});
 	}
 
-	return {
-		...state,
-		isInLoop: newPager.nbIterations !== undefined,
-		pager: newPager,
-	};
+	return newState;
 }
 
 export default reduceGoToPage;


### PR DESCRIPTION
## Problème

Dans une précédente PR, pour gérer la logique des roundabout le système d'exploration de boucle a été placé avant le système qui vérifie si la page est vide (via les conditionFilter). Du coup, lors de l'arrivée sur une boucle, on était redirigé vers la première itération avant même la vérification de l'accessibilité de la page.

## Solution

- On vérifie en premier si la page est vide
- On déplace le cas spécial du roundabout de taille 1 dans le reduce-go-previous vu que ce n'est qu'ici que le cas arrive.