### PR TITLE
Fix : Filter being ignored when entering a loop 

### DIFF
--- a/src/use-lunatic/commons/page-navigation.ts
+++ b/src/use-lunatic/commons/page-navigation.ts
@@ -30,7 +30,8 @@ export function getNextPager(
 	// We reached the end of the sequence
 	const isEndSequence =
 		subPage && pager.nbSubPages ? subPage >= pager.nbSubPages : false;
-	const moveUpOnEnd = parent === 'Roundabout';
+	const moveUpOnEnd =
+		parent === 'Roundabout' && pager.nbIterations && pager.nbIterations > 1;
 	// Move up at the end of a sequence (instead of going to the next Iteration)
 	if (isEndSequence && moveUpOnEnd) {
 		return {
@@ -78,7 +79,8 @@ export function getPrevPager(
 			? [parseInt(pager.page, 10), pager.subPage - 1]
 			: [parseInt(pager.page, 10) - 1, undefined];
 	let iteration = pager.iteration;
-	const moveUpOnStart = parent === 'Roundabout';
+	const moveUpOnStart =
+		parent === 'Roundabout' && pager.nbIterations && pager.nbIterations > 1;
 
 	// We reached the start of the questionnaire
 	if (page <= 0) {

--- a/src/use-lunatic/reducer/commons/auto-explore-loop.ts
+++ b/src/use-lunatic/reducer/commons/auto-explore-loop.ts
@@ -24,7 +24,7 @@ export function autoExploreLoop(
 		newPager.page = firstSubPage[0].toString();
 		newPager.subPage = firstSubPage[1] - 1; // Subpage starts at 0
 		newPager.nbSubPages = maxSubPage;
-		newPager.nbIterations = state.executeExpression<number>(page.iterations);
+		newPager.nbIterations = nbIteration;
 		newPager.iteration = isForward ? 0 : newPager.nbIterations - 1;
 		hasExploredLoop = true;
 	};
@@ -41,8 +41,7 @@ export function autoExploreLoop(
 	if (
 		page.components[0].componentType === 'Roundabout' &&
 		page.subPages &&
-		page.subPages.length > 0 &&
-		isForward
+		page.subPages.length > 0
 	) {
 		const nbIterations = state.executeExpression<number>(page.iterations);
 		if (nbIterations === 1) {

--- a/src/use-lunatic/reducer/commons/auto-explore-loop.ts
+++ b/src/use-lunatic/reducer/commons/auto-explore-loop.ts
@@ -13,6 +13,7 @@ export function autoExploreLoop(
 	};
 	const pageId = getPageId(newPager);
 	let page = state.pages[pageId];
+	let hasExploredLoop = false;
 	const isForward = direction === 'forward';
 
 	const goInsideSubpage = (subPages: string[], nbIteration: number) => {
@@ -25,6 +26,7 @@ export function autoExploreLoop(
 		newPager.nbSubPages = maxSubPage;
 		newPager.nbIterations = state.executeExpression<number>(page.iterations);
 		newPager.iteration = isForward ? 0 : newPager.nbIterations - 1;
+		hasExploredLoop = true;
 	};
 
 	// The page is a loop
@@ -36,7 +38,6 @@ export function autoExploreLoop(
 	}
 
 	// The page contains a roundabout, go to the first iteration if it only has one iteration
-	const firstComponent = page.components[0];
 	if (
 		page.components[0].componentType === 'Roundabout' &&
 		page.subPages &&
@@ -47,6 +48,11 @@ export function autoExploreLoop(
 		if (nbIterations === 1) {
 			goInsideSubpage(page.subPages, 1);
 		}
+	}
+
+	// No loop were explored, don't mutate the state
+	if (!hasExploredLoop) {
+		return state;
 	}
 
 	return {

--- a/src/use-lunatic/reducer/reduce-go-next-page.ts
+++ b/src/use-lunatic/reducer/reduce-go-next-page.ts
@@ -27,6 +27,11 @@ function reduceGoNextPage(state: LunaticState): LunaticState {
 	// If we reached a loop, go inside
 	newState = autoExploreLoop(newState, 'forward');
 
+	// We explored a loop, check if we reached an empty page, move forward
+	if (newState.pager !== nextPager && isPageEmpty(newState)) {
+		return reduceGoNextPage(newState);
+	}
+
 	return {
 		...newState,
 		pager: {

--- a/src/use-lunatic/reducer/reduce-go-next-page.ts
+++ b/src/use-lunatic/reducer/reduce-go-next-page.ts
@@ -34,6 +34,7 @@ function reduceGoNextPage(state: LunaticState): LunaticState {
 
 	return {
 		...newState,
+		isInLoop: newState.pager.iteration !== undefined,
 		pager: {
 			...newState.pager,
 			lastReachedPage: getNewReachedPage(newState.pager),

--- a/src/use-lunatic/reducer/reduce-go-previous-page.ts
+++ b/src/use-lunatic/reducer/reduce-go-previous-page.ts
@@ -25,6 +25,11 @@ function reduceGoPreviousPage(state: LunaticState): LunaticState {
 	// If we reached a loop, go to the last iteration / sequence
 	newState = autoExploreLoop(newState, 'backward');
 
+	// We explored a loop, check if we reached an empty page, move forward
+	if (newState.pager !== prevPager && isPageEmpty(newState)) {
+		return reduceGoPreviousPage(newState);
+	}
+
 	// We have a roundabout with only one iteration skip it
 	const components = getComponentsFromState(newState);
 	if (

--- a/src/use-lunatic/reducer/reduce-go-previous-page.ts
+++ b/src/use-lunatic/reducer/reduce-go-previous-page.ts
@@ -40,7 +40,10 @@ function reduceGoPreviousPage(state: LunaticState): LunaticState {
 		return reduceGoPreviousPage(newState);
 	}
 
-	return newState;
+	return {
+		...newState,
+		isInLoop: newState.pager.iteration !== undefined,
+	};
 }
 
 export default reduceGoPreviousPage;

--- a/src/use-lunatic/reducer/reduce-go-previous-page.ts
+++ b/src/use-lunatic/reducer/reduce-go-previous-page.ts
@@ -30,16 +30,6 @@ function reduceGoPreviousPage(state: LunaticState): LunaticState {
 		return reduceGoPreviousPage(newState);
 	}
 
-	// We have a roundabout with only one iteration skip it
-	const components = getComponentsFromState(newState);
-	if (
-		components.length === 1 &&
-		components[0]?.componentType === 'Roundabout' &&
-		newState.executeExpression<number>(components[0].iterations) === 1
-	) {
-		return reduceGoPreviousPage(newState);
-	}
-
 	return {
 		...newState,
 		isInLoop: newState.pager.iteration !== undefined,


### PR DESCRIPTION
Quand on entre dans une boucle il faut immédiatement vérifier si la page est vide pour continuer la navigation.