### PR TITLE
Keep value when resizing

### DIFF
--- a/src/use-lunatic/reducer/reduce-handle-change/reduce-resizing.ts
+++ b/src/use-lunatic/reducer/reduce-handle-change/reduce-resizing.ts
@@ -4,9 +4,6 @@ import { LunaticState } from '../../type';
 import { ActionHandleChange } from '../../actions';
 
 function refillValue(size: number, precSize: number, value: unknown) {
-	if (precSize > size) {
-		return new Array(size).fill(null);
-	}
 	return resizeArrayVariable(value, size, null);
 }
 


### PR DESCRIPTION
Retrait de la fonctionnalité qui supprime les valeurs lors du resizing. 
Si le comportement est trop disruptif on pourra introduire une variable pour configurer l'activation / désactivation de ce comportement.