### PR TITLE
Add LUNATIC_INDEX global variable

### DIFF
--- a/src/stories/loop/source-paginated.json
+++ b/src/stories/loop/source-paginated.json
@@ -40,7 +40,7 @@
 					"page": "2.1",
 					"maxLength": 20,
 					"label": {
-						"value": "\"Questions 1, Itération : \" || LUNATIC_INDEX",
+						"value": "\"Questions 1, Itération : \" || GLOBAL_ITERATION_INDEX",
 						"type": "VTL"
 					},
 					"conditionFilter": {
@@ -56,7 +56,7 @@
 					"page": "2.2",
 					"maxLength": 20,
 					"label": {
-						"value": "\"Vous avez mis en question 1, itération  \" || LUNATIC_INDEX || \" : \" || LIBELLE",
+						"value": "\"Vous avez mis en question 1, itération  \" || GLOBAL_ITERATION_INDEX || \" : \" || LIBELLE",
 						"type": "VTL"
 					},
 					"conditionFilter": {

--- a/src/stories/loop/source-paginated.json
+++ b/src/stories/loop/source-paginated.json
@@ -40,7 +40,7 @@
 					"page": "2.1",
 					"maxLength": 20,
 					"label": {
-						"value": "\"Page 1\"",
+						"value": "\"Questions 1, Itération : \" || LUNATIC_INDEX",
 						"type": "VTL"
 					},
 					"conditionFilter": {
@@ -56,7 +56,7 @@
 					"page": "2.2",
 					"maxLength": 20,
 					"label": {
-						"value": "\"Vous avez mis en page 1 \" || LIBELLE",
+						"value": "\"Vous avez mis en question 1, itération  \" || LUNATIC_INDEX || \" : \" || LIBELLE",
 						"type": "VTL"
 					},
 					"conditionFilter": {

--- a/src/use-lunatic/commons/execute-expression/create-execute-expression.ts
+++ b/src/use-lunatic/commons/execute-expression/create-execute-expression.ts
@@ -248,7 +248,9 @@ function createExecuteExpression(
 			{ rootExpression: expression, iteration, linksIterations }
 		);
 		// Add index has a specific variable
-		vtlBindings['LUNATIC_INDEX'] = ((args?.iteration ?? 0) + 1).toString();
+		vtlBindings['GLOBAL_ITERATION_INDEX'] = (
+			(args?.iteration ?? 0) + 1
+		).toString();
 		const memoized = getMemoizedValue(expression, vtlBindings);
 		if (memoized === undefined) {
 			const result = executeExpression(

--- a/src/use-lunatic/commons/execute-expression/create-execute-expression.ts
+++ b/src/use-lunatic/commons/execute-expression/create-execute-expression.ts
@@ -247,6 +247,8 @@ function createExecuteExpression(
 			}),
 			{ rootExpression: expression, iteration, linksIterations }
 		);
+		// Add index has a specific variable
+		vtlBindings['LUNATIC_INDEX'] = ((args?.iteration ?? 0) + 1).toString();
 		const memoized = getMemoizedValue(expression, vtlBindings);
 		if (memoized === undefined) {
 			const result = executeExpression(


### PR DESCRIPTION
Add a global variable to display the current iteration in VTL expression.

For instance 

```js
"label": {
    "value": "\"Questions 1, Itération : \" || LUNATIC_INDEX",
    "type": "VTL"
},
```