### PR TITLE
Refactor Modal to simplify the logic

### DIFF
--- a/src/components/button/lunatic-button.tsx
+++ b/src/components/button/lunatic-button.tsx
@@ -7,31 +7,36 @@ import classnames from 'classnames';
 import { isElement } from '../../utils/is-element';
 import { createCustomizableLunaticField } from '../commons';
 import './button.scss';
+import { prevent } from '../../utils/dom';
 
 type Props = PropsWithChildren<{
-	onClick: MouseEventHandler<HTMLButtonElement | HTMLInputElement>;
+	onClick?: MouseEventHandler<HTMLButtonElement | HTMLInputElement>;
 	className?: string;
 	disabled?: boolean;
 	label?: string;
+	value?: string;
+	type?: 'button' | 'submit' | 'reset' | undefined;
 }>;
 
-function Button({ children, onClick, disabled, label, className }: Props) {
-	const handleClick: Props['onClick'] = useCallback(
-		function (e) {
-			e.stopPropagation();
-			e.preventDefault();
-			onClick?.(e);
-		},
-		[onClick]
-	);
+function Button({
+	children,
+	onClick,
+	disabled,
+	label,
+	className,
+	value,
+	type = 'button',
+}: Props) {
+	const handleClick = prevent(onClick);
 
-	if (isElement(children))
+	if (isElement(children) || value)
 		return (
 			<button
 				disabled={disabled}
-				type="button"
+				type={type}
 				className={classnames('button-lunatic', className, { disabled })}
 				onClick={handleClick}
+				value={value}
 			>
 				{children}
 			</button>
@@ -43,7 +48,7 @@ function Button({ children, onClick, disabled, label, className }: Props) {
 				disabled={disabled}
 				type="button"
 				className={classnames('button-lunatic', className, { disabled })}
-				value={label || children?.toString()}
+				value={label ?? children?.toString()}
 				onClick={handleClick}
 			/>
 		</>

--- a/src/components/modal/html/modal.scss
+++ b/src/components/modal/html/modal.scss
@@ -8,15 +8,10 @@
   border-radius: 8px;
   overflow-wrap: break-word;
   position: relative;
-  padding: 0;
-}
-.lunatic-modal_body {
   width: 50vw;
   padding: 0.5rem;
-  position: relative;
 }
 .lunatic-modal_buttons {
-  justify-self: flex-end;
   display: flex;
   gap: .5rem;
 }

--- a/src/components/modal/html/modal.scss
+++ b/src/components/modal/html/modal.scss
@@ -1,43 +1,28 @@
+.lunatic-modal::backdrop {
+  background-color: rgba(50, 50, 50, 0.5);
+}
 .lunatic-modal {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(50, 50, 50, 0.5);
-    z-index: 101;
-  
-    .modal-content {
-      background-color: snow;
-      height: fit-content;
-      width: 50%;
-      margin: auto;
-      padding: 0.5rem;
-      margin-top: 38vh;
-      display: flex;
-      flex-direction: column;
-      border-radius: 8px;
-      overflow-wrap: break-word;
-      .lunatic-modal-container {
-        .close-button {
-          color: blue;
-          display: flex;
-          justify-content: right;
-        }
-      }
-      .body {
-        color: black;
-        font-size: 16px;
-        font-family: 'Roboto', 'Helvetica', 'Arial', sans-serif;
-      }
-  
-      .modal-buttons {
-        align-self: end;
-        margin: 0 0.2em 0.2em 0;
-        :first-child {
-          margin-right: 0.5em;
-        }
-      }
-    }
-  }
-  
+  background-color: snow;
+  height: fit-content;
+  flex-direction: column;
+  border-radius: 8px;
+  overflow-wrap: break-word;
+  position: relative;
+  padding: 0;
+}
+.lunatic-modal_body {
+  width: 50vw;
+  padding: 0.5rem;
+  position: relative;
+}
+.lunatic-modal_buttons {
+  justify-self: flex-end;
+  display: flex;
+  gap: .5rem;
+}
+.lunatic-modal_close {
+  position: absolute;
+  top: .5rem;
+  right: .5rem;
+  align-self: flex-end;
+}

--- a/src/components/modal/html/modal.scss
+++ b/src/components/modal/html/modal.scss
@@ -8,11 +8,14 @@
   border-radius: 8px;
   overflow-wrap: break-word;
   position: relative;
-  width: 50vw;
+  width: max-content;
+  min-width: 400px;
+  max-width: calc(100vw - 2rem);
   padding: 0.5rem;
 }
 .lunatic-modal_buttons {
   display: flex;
+  flex-direction: row-reverse;
   gap: .5rem;
 }
 .lunatic-modal_close {

--- a/src/components/modal/html/modal.tsx
+++ b/src/components/modal/html/modal.tsx
@@ -61,11 +61,9 @@ function ModalPure({
 			id={id}
 			onClick={handleDialogClick}
 		>
-			<form method="dialog" className="lunatic-modal_body">
-				<div className="modal-message">
-					<div>{label}</div>
-					<div>{description}</div>
-				</div>
+			<form method="dialog">
+				<div className="lunatic-modal_title">{label}</div>
+				<div className="lunatic-modal_description">{description}</div>
 				<div className="lunatic-modal_buttons">
 					<Button type="submit" value="default">
 						Je confirme

--- a/src/components/modal/html/modal.tsx
+++ b/src/components/modal/html/modal.tsx
@@ -1,65 +1,37 @@
-import { useEffect, useRef } from 'react';
-import type { MouseEventHandler } from 'react';
+import type { MouseEventHandler, ReactEventHandler, RefObject } from 'react';
 import type { LunaticComponentProps } from '../../type';
 import { createCustomizableLunaticField } from '../../commons';
 import { createPortal } from 'react-dom';
 import './modal.scss';
 import Button from '../../button';
-import { isEventInRect } from '../../../utils/dom';
 
 type Props = Pick<
 	LunaticComponentProps<'Modal'>,
-	| 'id'
-	| 'label'
-	| 'description'
-	| 'goToPage'
-	| 'page'
-	| 'goNextPage'
-	| 'goPreviousPage'
->;
+	'id' | 'label' | 'description'
+> & {
+	onClose: ReactEventHandler<HTMLDialogElement>;
+	onCancel: ReactEventHandler<HTMLDialogElement>;
+	onClick: MouseEventHandler<HTMLDialogElement>;
+	dialogRef: RefObject<HTMLDialogElement>;
+};
 
 function ModalPure({
 	id,
 	label,
 	description,
-	goNextPage,
-	goPreviousPage,
+	onClose,
+	onCancel,
+	onClick,
+	dialogRef,
 }: Props) {
-	const dialogRef = useRef<HTMLDialogElement>(null);
-
-	useEffect(() => {
-		// Browser behaviour is different for dialog displayed with this API, it creates de dialog with backdrop
-		dialogRef.current?.showModal();
-	}, []);
-
-	const handleClose = () => {
-		// A cancel button was pressed
-		if (dialogRef.current?.returnValue === 'cancel') {
-			handleCancel();
-			return;
-		}
-		goNextPage();
-	};
-
-	const handleCancel = () => {
-		goPreviousPage();
-	};
-
-	const handleDialogClick: MouseEventHandler<HTMLDialogElement> = (e) => {
-		// Cancel the modal on backdrop blick
-		if (!isEventInRect(e, dialogRef.current!.getBoundingClientRect())) {
-			handleCancel();
-		}
-	};
-
 	return createPortal(
 		<dialog
-			onClose={handleClose}
-			onCancel={handleCancel}
+			onClose={onClose}
+			onCancel={onCancel}
 			className="lunatic-modal"
 			ref={dialogRef}
 			id={id}
-			onClick={handleDialogClick}
+			onClick={onClick}
 		>
 			<form method="dialog">
 				<div className="lunatic-modal_title">{label}</div>

--- a/src/components/modal/lunatic-modal.tsx
+++ b/src/components/modal/lunatic-modal.tsx
@@ -1,12 +1,40 @@
 import { Modal } from './html/modal';
 import LunaticComponent from '../commons/components/lunatic-component-without-label';
 import { LunaticComponentProps } from '../type';
+import { MouseEventHandler, useEffect, useRef } from 'react';
+import { isEventInRect } from '../../utils/dom';
 
 function empty() {}
 
 function LunaticModal(props: LunaticComponentProps<'Modal'>) {
-	const { id, label, description, goToPage, page, goNextPage, goPreviousPage } =
-		props;
+	const { id, label, description, goNextPage, goPreviousPage } = props;
+
+	const dialogRef = useRef<HTMLDialogElement>(null);
+
+	useEffect(() => {
+		// Browser behaviour is different for dialog displayed with this API, it creates de dialog with backdrop
+		dialogRef.current?.showModal();
+	}, []);
+
+	const handleClose = () => {
+		// A cancel button was pressed
+		if (dialogRef.current?.returnValue === 'cancel') {
+			handleCancel();
+			return;
+		}
+		goNextPage();
+	};
+
+	const handleCancel = () => {
+		goPreviousPage();
+	};
+
+	const handleDialogClick: MouseEventHandler<HTMLDialogElement> = (e) => {
+		// Cancel the modal on backdrop blick
+		if (!isEventInRect(e, dialogRef.current!.getBoundingClientRect())) {
+			handleCancel();
+		}
+	};
 
 	return (
 		<LunaticComponent
@@ -17,13 +45,13 @@ function LunaticModal(props: LunaticComponentProps<'Modal'>) {
 			description={description}
 		>
 			<Modal
+				dialogRef={dialogRef}
+				onClose={handleClose}
+				onCancel={handleCancel}
+				onClick={handleDialogClick}
 				id={id}
 				label={label}
-				page={page}
 				description={description}
-				goToPage={goToPage}
-				goNextPage={goNextPage}
-				goPreviousPage={goPreviousPage}
 			/>
 		</LunaticComponent>
 	);

--- a/src/components/modal/lunatic-modal.tsx
+++ b/src/components/modal/lunatic-modal.tsx
@@ -1,4 +1,4 @@
-import Modal from './html/modal';
+import { Modal } from './html/modal';
 import LunaticComponent from '../commons/components/lunatic-component-without-label';
 import { LunaticComponentProps } from '../type';
 

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -1,0 +1,33 @@
+/**
+ * Wrap a callback calling preventDefault and stopPropagation on the event before passing it
+ */
+export function prevent<
+	T extends {
+		preventDefault: () => void;
+		stopPropagation: () => void;
+	}
+>(cb?: (e: T) => void): undefined | ((e: T) => void) {
+	if (!cb) {
+		return undefined;
+	}
+	return (e) => {
+		e.preventDefault();
+		e.stopPropagation();
+		cb(e);
+	};
+}
+
+/**
+ * Check if an event is within a rectangle
+ */
+export function isEventInRect(
+	event: { clientX: number; clientY: number },
+	rect: DOMRect
+): boolean {
+	return (
+		rect.top <= event.clientY &&
+		event.clientY <= rect.top + rect.height &&
+		rect.left <= event.clientX &&
+		event.clientX <= rect.left + rect.width
+	);
+}


### PR DESCRIPTION
Simplify modal structure 

## Modal edits

- Improves accessibility using showModal() to open the dialog
- Reduce CSS nesting
- Simplify HTML Markup
- Use native form instead of event handler on button
- Change element order to have a more natural focus order (confirm button first, close button last)
- Move all event up (in LunaticModal) to simplify consumer
