### PR TITLE
Track changes

### DIFF
--- a/src/hooks/use-track-changes.ts
+++ b/src/hooks/use-track-changes.ts
@@ -1,0 +1,59 @@
+import { useCallback, useRef } from 'react';
+import { useRefSync } from './use-ref-sync';
+import { getQuestionnaireData } from '../use-lunatic/commons/get-data';
+
+type getDataType = (
+	withRefreshedCalculated: boolean,
+	variableNames?: string[]
+) => ReturnType<typeof getQuestionnaireData>;
+
+/**
+ * Allow tracking changed while interacting with Lunatic forms
+ */
+export function useTrackChanges(enabled: boolean, getData: getDataType) {
+	// Saves the list of changed variable
+	const changedVariables = useRef(new Set<string>());
+	// Use ref to avoid dependencies in useCallback
+	const enabledRef = useRefSync(enabled);
+	const getDataRef = useRefSync(getData);
+
+	// Add a new variable in the changeList
+	const addChange = useCallback(
+		(name: string) => {
+			if (enabledRef.current) {
+				changedVariables.current.add(name);
+			}
+		},
+		[enabledRef, changedVariables]
+	);
+
+	const getChangedData = useCallback(
+		(reset: boolean = false) => {
+			if (!enabledRef.current) {
+				throw new Error(
+					'getChangedData() cannot be used without enabling tracking mode, add "trackChanges: true" to useLunatic options'
+				);
+			}
+			const data = getDataRef.current(
+				false,
+				Array.from(changedVariables.current)
+			);
+			if (reset) {
+				resetChangedData();
+			}
+			return data;
+		},
+		[enabledRef, getDataRef]
+	);
+
+	// Reset list of changed variables
+	const resetChangedData = useCallback(() => {
+		changedVariables.current.clear();
+	}, [changedVariables]);
+
+	return {
+		addChange,
+		getChangedData,
+		resetChangedData,
+	};
+}

--- a/src/hooks/use-track-changes.ts
+++ b/src/hooks/use-track-changes.ts
@@ -27,6 +27,11 @@ export function useTrackChanges(enabled: boolean, getData: getDataType) {
 		[enabledRef, changedVariables]
 	);
 
+	// Reset list of changed variables
+	const resetChangedData = useCallback(() => {
+		changedVariables.current.clear();
+	}, [changedVariables]);
+
 	const getChangedData = useCallback(
 		(reset: boolean = false) => {
 			if (!enabledRef.current) {
@@ -43,13 +48,8 @@ export function useTrackChanges(enabled: boolean, getData: getDataType) {
 			}
 			return data;
 		},
-		[enabledRef, getDataRef]
+		[enabledRef, getDataRef, resetChangedData]
 	);
-
-	// Reset list of changed variables
-	const resetChangedData = useCallback(() => {
-		changedVariables.current.clear();
-	}, [changedVariables]);
 
 	return {
 		addChange,

--- a/src/use-lunatic/commons/variables/get-questionnaire-data.ts
+++ b/src/use-lunatic/commons/variables/get-questionnaire-data.ts
@@ -1,11 +1,13 @@
 import type { LunaticVariablesStore } from './lunatic-variables-store';
 import type { LunaticSource } from '../../type-source';
+import type { LunaticData } from '../../type';
 
 export function getQuestionnaireData(
 	store: LunaticVariablesStore,
 	variables: LunaticSource['variables'],
-	withCalculated: boolean = false
-) {
+	withCalculated: boolean = false,
+	variableNames?: string[]
+): LunaticData {
 	const result = {
 		EXTERNAL: {} as Record<string, unknown>,
 		CALCULATED: {} as Record<string, unknown>,
@@ -22,7 +24,26 @@ export function getQuestionnaireData(
 	};
 
 	if (!variables) {
-		return {};
+		return result;
+	}
+
+	// Only return requested variables
+	if (variableNames) {
+		return {
+			...result,
+			COLLECTED: Object.fromEntries(
+				variableNames.map((name) => [
+					name,
+					{
+						EDITED: null,
+						FORCED: null,
+						INPUTED: null,
+						PREVIOUS: null,
+						COLLECTED: store.get(name),
+					},
+				])
+			),
+		};
 	}
 
 	for (const variable of variables) {

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.ts
@@ -13,7 +13,7 @@ import { isNumber } from '../../../utils/number';
 let interpretCount = 0;
 
 type IterationLevel = number[];
-type Events = {
+type EventArgs = {
 	change: {
 		// Name of the changed variable
 		name: string;
@@ -22,6 +22,9 @@ type Events = {
 		// Iteration changed (for array)
 		iteration?: IterationLevel | undefined;
 	};
+};
+export type LunaticVariablesStoreEvent<T extends keyof EventArgs> = {
+	detail: EventArgs[T];
 };
 
 export class LunaticVariablesStore {
@@ -84,7 +87,7 @@ export class LunaticVariablesStore {
 	public set(
 		name: string,
 		value: unknown,
-		args: Pick<Events['change'], 'iteration'> = {}
+		args: Pick<EventArgs['change'], 'iteration'> = {}
 	): LunaticVariable {
 		if (!this.dictionary.has(name)) {
 			this.dictionary.set(
@@ -102,7 +105,7 @@ export class LunaticVariablesStore {
 						...args,
 						name: name,
 						value: value,
-					} satisfies Events['change'],
+					} satisfies EventArgs['change'],
 				})
 			);
 		}
@@ -149,9 +152,9 @@ export class LunaticVariablesStore {
 	/**
 	 * Bind event listeners
 	 */
-	public on<T extends keyof Events>(
+	public on<T extends keyof EventArgs>(
 		eventName: T,
-		cb: (e: CustomEvent<Events[T]>) => void
+		cb: (e: CustomEvent<EventArgs[T]>) => void
 	): void {
 		this.eventTarget.addEventListener(eventName, cb as EventListener);
 	}
@@ -159,9 +162,9 @@ export class LunaticVariablesStore {
 	/**
 	 * Detach a listener
 	 */
-	public off<T extends keyof Events>(
+	public off<T extends keyof EventArgs>(
 		eventName: T,
-		cb: (e: CustomEvent<Events[T]>) => void
+		cb: (e: CustomEvent<EventArgs[T]>) => void
 	): void {
 		this.eventTarget.removeEventListener(eventName, cb as EventListener);
 	}

--- a/src/use-lunatic/type.ts
+++ b/src/use-lunatic/type.ts
@@ -15,11 +15,12 @@ export type LunaticControl = ControlType;
 
 export type VTLBindings = { [variableName: string]: unknown };
 
-export type LunaticData = Partial<
-	Record<Exclude<VariableType, 'COLLECTED'>, Record<string, unknown>> & {
-		COLLECTED: Record<string, LunaticCollectedValue>;
-	}
->;
+export type LunaticData = Record<
+	Exclude<VariableType, 'COLLECTED'>,
+	Record<string, unknown>
+> & {
+	COLLECTED: Record<string, LunaticCollectedValue>;
+};
 
 export type LunaticValues = {
 	[variableName: string]: unknown;

--- a/src/use-lunatic/use-lunatic.test.ts
+++ b/src/use-lunatic/use-lunatic.test.ts
@@ -292,11 +292,11 @@ describe('use-lunatic()', () => {
 			hookRef.current.resetChangedData();
 			expect(hookRef.current.getChangedData().COLLECTED).toEqual({});
 			act(() => {
-				hookRef.current.onChange({ name: 'READY' }, true);
+				hookRef.current.onChange({ name: 'READY' }, false);
 			});
 			expect(hookRef.current.getChangedData().COLLECTED).toMatchObject({
 				READY: {
-					COLLECTED: true,
+					COLLECTED: false,
 				},
 			});
 		});

--- a/src/use-lunatic/use-lunatic.test.ts
+++ b/src/use-lunatic/use-lunatic.test.ts
@@ -4,7 +4,7 @@ import useLunatic from './use-lunatic';
 
 import sourceWithoutHierarchy from '../stories/overview/source.json';
 import sourceLogement from '../stories/questionnaires/logement/source.json';
-import sourceSimpsons from '../stories/questionnaires/simpsons/source.json';
+import sourceSimpsons from '../stories/questionnaires2023/simpsons/source.json';
 import sourceComponentSet from '../stories/component-set/source.json';
 import type { LunaticData } from './type';
 import { type FilledLunaticComponentProps } from './commons/fill-components/fill-components';
@@ -40,7 +40,7 @@ describe('use-lunatic()', () => {
 		const { result } = renderHook(() => useLunatic(...defaultParams));
 		expect(result.current.pager.page).toBe('1');
 		expect(result.current.pager.lastReachedPage).toBe('1');
-		expect(result.current.pager.maxPage).toBe('39');
+		expect(result.current.pager.maxPage).toBe('41');
 	});
 	it('should go to the next page correcly', () => {
 		const { result } = renderHook(() => useLunatic(...defaultParams));
@@ -217,13 +217,13 @@ describe('use-lunatic()', () => {
 					},
 				},
 			});
-			expect(Object.keys(data.COLLECTED)).toHaveLength(164);
+			expect(Object.keys(data.COLLECTED)).toHaveLength(109);
 			expect(Object.keys(data.CALCULATED)).toHaveLength(0);
 		});
 		it('should return calculated values', () => {
 			const data = hookRef.current.getData(true);
-			expect(Object.keys(data.COLLECTED)).toHaveLength(164);
-			expect(Object.keys(data.CALCULATED)).toHaveLength(165);
+			expect(Object.keys(data.COLLECTED)).toHaveLength(109);
+			expect(Object.keys(data.CALCULATED)).toHaveLength(33);
 		});
 		it('should only return requested variables', () => {
 			const data = hookRef.current.getData(false, ['COMMENT']);


### PR DESCRIPTION
Allow tracking changes done inside lunatic.

## Changelog

- Add a new option for `trackChanges` for `useLunatic()` options
- Add a new method `getChangedData(reset: boolean)` that work like `getData()` but will only return changed values (if reset is set to true, the change list will be reset)
- Add a new method `resetChangedData()` that clear the change list 

## Example

You can look at the [test suite](https://github.com/InseeFr/Lunatic/blob/19e07133b2d9abd9f8160450d1db2b0375ff369a/src/use-lunatic/use-lunatic.test.ts#L241-L302) to see how it work

Fix #705