### PR TITLE
fix: missing with invalid value

### DIFF
--- a/src/use-lunatic/commons/fill-components/fill-missing-response.ts
+++ b/src/use-lunatic/commons/fill-components/fill-missing-response.ts
@@ -27,7 +27,7 @@ function fillMissingResponse(
 		const missingValue =
 			pager.iteration === undefined
 				? value
-				: (value as unknown[])[pager.iteration];
+				: ((value as unknown[]) ?? [])[pager.iteration];
 		return {
 			...component,
 			missingResponse: { ...missingResponse, value: missingValue },


### PR DESCRIPTION
Fix le cas où missing value n'a pas le bon format (force un tableau)

A voir la cible de la fusion (si on branche sur main ou si on commence à utiliser les branches en fonction du numéro)


Fix #704 