### PR TITLE
Remove meta env

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@inseefr/lunatic",
-	"version": "2.7.0",
+	"version": "2.7.0-rc.1",
 	"workersVersion": "0.2.5-experimental",
 	"description": "Library of questionnaire components",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@inseefr/lunatic",
-	"version": "2.6.3-rc.1",
+	"version": "2.7.0",
 	"workersVersion": "0.2.5-experimental",
 	"description": "Library of questionnaire components",
 	"repository": {

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,4 +1,4 @@
 export function isTestEnv(): boolean {
-	const meta = import.meta as any;
-	return meta && meta?.env ? (import.meta as any).env.MODE === 'test' : false;
+	// @ts-ignore
+	return import.meta.env.MODE === 'test';
 }


### PR DESCRIPTION
Queen v2 uses webpack and having a variable based on `meta.env` creates an issue with building

```
WARNING in ./node_modules/@inseefr/lunatic/lib/utils/env.js 8:13-24
Critical dependency: Accessing import.meta directly is unsupported (only property access or destructuring is supported)
```

Originally I created the intermediary variable to make it work with TypeScript. This MR removes this intermediary variable to avoid issue with webpack.