### PR TITLE
Handle mandatory property

### DIFF
--- a/src/components/textarea/html/textarea.tsx
+++ b/src/components/textarea/html/textarea.tsx
@@ -15,6 +15,7 @@ type Props = {
 	description?: string;
 	errors?: LunaticBaseProps['errors'];
 	readOnly?: boolean;
+	required?: boolean;
 };
 
 function Textarea({
@@ -29,6 +30,7 @@ function Textarea({
 	description,
 	errors,
 	readOnly,
+	required,
 }: Props) {
 	const labelId = `label-${id}`;
 	const handleChange = useCallback<ChangeEventHandler<HTMLTextAreaElement>>(
@@ -44,6 +46,7 @@ function Textarea({
 				{label}
 			</Label>
 			<textarea
+				required={required}
 				id={id}
 				rows={rows}
 				maxLength={maxLength}

--- a/src/components/textarea/lunatic-textarea.tsx
+++ b/src/components/textarea/lunatic-textarea.tsx
@@ -23,6 +23,7 @@ const LunaticTextarea = (props: LunaticComponentProps<'Textarea'>) => {
 		missingResponse,
 		management,
 		readOnly,
+		required,
 	} = props;
 
 	const onChange = useOnHandleChange({ handleChange, response, value });
@@ -50,6 +51,7 @@ const LunaticTextarea = (props: LunaticComponentProps<'Textarea'>) => {
 				label={label}
 				errors={errors}
 				readOnly={readOnly}
+				required={required}
 			/>
 		</LunaticComponent>
 	);

--- a/src/use-lunatic/commons/fill-components/fill-component-required.ts
+++ b/src/use-lunatic/commons/fill-components/fill-component-required.ts
@@ -1,0 +1,14 @@
+import type { LunaticComponentDefinition } from '../../type';
+
+/**
+ * Add required attribute on component that are mandatory
+ */
+export function fillComponentRequired(component: LunaticComponentDefinition) {
+	if (component.mandatory) {
+		return {
+			...component,
+			required: true,
+		};
+	}
+	return component;
+}

--- a/src/use-lunatic/commons/fill-components/fill-components.ts
+++ b/src/use-lunatic/commons/fill-components/fill-components.ts
@@ -18,6 +18,7 @@ import fillPagination, {
 	type FilledProps as FilledPaginationProps,
 } from './fill-pagination';
 import fillSpecificExpressions from './fill-specific-expression';
+import { fillComponentRequired } from './fill-component-required';
 
 export type FilledLunaticComponentProps<
 	T = LunaticComponentDefinition['componentType']
@@ -56,6 +57,7 @@ const fillComponent = compose(
 	fillPagination,
 	fillComponentValue,
 	fillMissingResponse,
+	fillComponentRequired,
 	fillManagement,
 	fillSpecificExpressions
 ) as (


### PR DESCRIPTION
When mandatory is set to true for a component a "required" attribute is sent to the component props.