### PR TITLE
Fix: GLOBAL_ITERATION_INDEX

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@inseefr/lunatic",
-	"version": "2.7.0-rc.1",
+	"version": "2.7.1",
 	"workersVersion": "0.2.5-experimental",
 	"description": "Library of questionnaire components",
 	"repository": {

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
@@ -134,6 +134,15 @@ describe('lunatic-variables-store', () => {
 				variables.run('FIRSTNAME || " " || LASTNAME', { iteration: [1] })
 			).toEqual('Jane Doe');
 		});
+		it('should handle global iteration variable', () => {
+			variables.set('FIRSTNAME', ['John', 'Jane']);
+			variables.setCalculated(
+				'FULLNAME',
+				'FIRSTNAME || " " || cast(GLOBAL_ITERATION_INDEX, string)'
+			);
+			expect(variables.get('FULLNAME', [0])).toEqual('John 0');
+			expect(variables.get('FULLNAME', [1])).toEqual('Jane 1');
+		});
 	});
 
 	describe('resizing', () => {

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.ts
@@ -11,6 +11,8 @@ import { isNumber } from '../../../utils/number';
 
 // Interpret counter, used for testing purpose
 let interpretCount = 0;
+// Special variable that will take the current iteration value
+const iterationVariableName = 'GLOBAL_ITERATION_INDEX';
 
 type IterationLevel = number[];
 type EventArgs = {
@@ -295,6 +297,9 @@ class LunaticVariable {
 		try {
 			return Object.fromEntries(
 				this.getDependencies().map((dep) => {
+					if (dep === iterationVariableName && iteration) {
+						return [dep, iteration[0]];
+					}
 					const dependencyIteration =
 						isNumber(this.iterationDepth) && Array.isArray(iteration)
 							? [iteration[this.iterationDepth]]


### PR DESCRIPTION
## Problem

When refactoring the variable system, the GLOBAL_ITERATION_INDEX support was removed. 

## Solution

When calculating a value in the new system, the variable GLOBAL_ITERATION_INDEX is intercepted and we assign the first iteration level inside (as an integer). 
If GLOBAL_ITERATION_INDEX is used in a string it must be cast into a string

Fix #725
Fix #724