### PR TITLE
fix: remove import.meta.env reference (test)

### DIFF
--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,3 +1,11 @@
 export function isTestEnv(): boolean {
-	return import.meta.env.MODE === 'test';
+	try {
+		// using vitest, process.env is defined
+		return /test/.test(`${process.env.npm_lifecycle_event}`);
+	} catch (e) {
+		// process.env is not defined
+		// so we are not running as test so we can return false
+		// process.env is not defined during storybook running/
+		return false;
+	}
 }


### PR DESCRIPTION
Actuellement, lors d'un projet react & react-scripts (sans vite), l'utilisation de `import.meta.env` provoque un problème à la "compilation", malgré le `// @ts-ignore`

Il y a encore des références à `import.meta.env`, mais elles sont retirées avec la nouvelle gestion des workers : https://github.com/InseeFr/Lunatic/pull/741
