### PR TITLE
fix: roster for loop props drilling

### DIFF
--- a/src/components/loop/roster-for-loop/__snapshots__/roster-for-loop.spec.tsx.snap
+++ b/src/components/loop/roster-for-loop/__snapshots__/roster-for-loop.spec.tsx.snap
@@ -1,0 +1,86 @@
+// Vitest Snapshot v1
+
+exports[`RosterForLoop > renders the right number of columns 1`] = `
+<div>
+  <table
+    class="lunatic-table"
+    id="table-table"
+  >
+    <tbody
+      class="lunatic-table-tbody"
+      id="lunatic-table-tbody-table"
+    >
+      <tr
+        class="lunatic-table-tr"
+        id="lunatic-table-tr-table-0"
+      >
+        <td
+          class="lunatic-table-td"
+          id="lunatic-table-td-jrc3ye5q-QOP-lo6tcvvx-0-0-undefined-undefined"
+        >
+          <div
+            class="field-container"
+          >
+            <div
+              class="field"
+            >
+              <div
+                class="lunatic-input"
+              >
+                <input
+                  aria-labelledby="label-jrc3ye5q-QOP-lo6tcvvx-0"
+                  autocomplete="off"
+                  id="jrc3ye5q-QOP-lo6tcvvx-0"
+                  maxlength="249"
+                  type="text"
+                  value="azeaze"
+                />
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="lunatic-table-tr"
+        id="lunatic-table-tr-table-1"
+      >
+        <td
+          class="lunatic-table-td"
+          id="lunatic-table-td-jrc3ye5q-QOP-lo6tcvvx-1-1-undefined-undefined"
+        >
+          <div
+            class="field-container"
+          >
+            <div
+              class="field"
+            >
+              <div
+                class="lunatic-input"
+              >
+                <input
+                  aria-labelledby="label-jrc3ye5q-QOP-lo6tcvvx-1"
+                  autocomplete="off"
+                  id="jrc3ye5q-QOP-lo6tcvvx-1"
+                  maxlength="249"
+                  type="text"
+                  value="azeaze"
+                />
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <input
+    class="button-lunatic"
+    type="button"
+    value="Ceci est un test"
+  />
+  <input
+    class="button-lunatic"
+    type="button"
+    value="Remove row"
+  />
+</div>
+`;

--- a/src/components/loop/roster-for-loop/roster-for-loop.spec.tsx
+++ b/src/components/loop/roster-for-loop/roster-for-loop.spec.tsx
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { RosterForLoop } from './roster-for-loop';
+import type { FilledLunaticComponentProps } from '../../../use-lunatic/commons/fill-components/fill-components';
+
+describe('RosterForLoop', () => {
+	const mockOnChange = vi.fn();
+
+	beforeEach(() => {
+		mockOnChange.mockClear();
+	});
+
+	const getComponents = (iteration: number) => [
+		{
+			componentType: 'Input',
+			maxLength: 249,
+			id: 'jrc3ye5q-QOP-lo6tcvvx',
+			response: {
+				name: 'TABDYN1',
+			},
+			iteration: iteration,
+			value: 'azeaze',
+		} as FilledLunaticComponentProps,
+	];
+
+	it('renders the right number of columns', () => {
+		const { container } = render(
+			<RosterForLoop
+				value={{ name: ['John Doe', 'Jane Doe'] }}
+				handleChange={mockOnChange}
+				label="Ceci est un test"
+				id="table"
+				lines={{ min: 1, max: 3 }}
+				iterations={2}
+				getComponents={getComponents}
+				executeExpression={() => null as any}
+			/>
+		);
+		expect(container).toMatchSnapshot();
+		expect(screen.getAllByRole('row')).toHaveLength(2);
+	});
+});

--- a/src/components/loop/roster-for-loop/roster-for-loop.tsx
+++ b/src/components/loop/roster-for-loop/roster-for-loop.tsx
@@ -32,6 +32,7 @@ export const RosterForLoop = createCustomizableLunaticField<
 		iterations,
 		id,
 		getComponents,
+		...otherProps // These props will be passed down to the child components
 	} = props;
 	const min = lines?.min || DEFAULT_MIN_ROWS;
 	const max = lines?.max || DEFAULT_MAX_ROWS;
@@ -69,10 +70,14 @@ export const RosterForLoop = createCustomizableLunaticField<
 				<TableHeader header={headers} id={id} />
 				<Tbody id={id}>
 					{times(nbRows, (n) => (
-						<Tr id={props.id} row={n}>
+						<Tr id={props.id} row={n} key={n}>
 							<LunaticComponents
 								components={getComponents(n)}
-								componentProps={(c) => ({ ...props, ...c, id: `${c.id}-${n}` })}
+								componentProps={(c) => ({
+									...otherProps,
+									...c,
+									id: `${c.id}-${n}`,
+								})}
 								wrapper={({ id, children }) => (
 									<Td id={`${id}-${n}`}>{children}</Td>
 								)}


### PR DESCRIPTION
## Issue

RosterForLoop props were passed down to each child component (which included label, declarations...) that caused unexpected rendering : 

![image](https://github.com/InseeFr/Lunatic/assets/395137/96af01e1-8e47-436f-a6cc-6e4ef865b7bc)

## Result 

![image](https://github.com/InseeFr/Lunatic/assets/395137/da7186a6-0a81-4182-b7b2-d370bee525f9)


Helps #409