### PR TITLE
Better unquoted VTL handling

### DIFF
--- a/src/components/commons/components/combo-box/combo-box.stories.tsx
+++ b/src/components/commons/components/combo-box/combo-box.stories.tsx
@@ -19,7 +19,6 @@ const LabelRenderer = ({
 }) => <>{option?.label ?? placeholder}</>;
 
 const Template: typeof ComboBox = (args) => {
-	console.log({ args });
 	const [localValue, setLocalValue] = useState(args.value);
 	const [search, setSearch] = useState<string | null>('');
 	// Simulate a search

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
@@ -89,6 +89,10 @@ describe('lunatic-variables-store', () => {
 		expect(variables.run('FIRSTNAME || " " || LASTNAME')).toEqual('Jane Doe');
 	});
 
+	it('should throw an exception when calculated incorrect VTL', () => {
+		expect(() => variables.run('Hello world')).toThrowError();
+	});
+
 	describe('with iteration', () => {
 		it('should handle arrays', () => {
 			variables.set('FIRSTNAME', ['John', 'Jane']);

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.ts
@@ -315,10 +315,16 @@ class LunaticVariable {
 						isNumber(this.iterationDepth) && Array.isArray(iteration)
 							? [iteration[this.iterationDepth]]
 							: iteration;
-					return [
-						dep,
-						this.dictionary?.get(dep)?.getValue(dependencyIteration),
-					];
+
+					// The variable is not registered in the variable dictionary
+					// Happens when calculating unquoted VTL expression
+					if (!this.dictionary || !this.dictionary?.has(dep)) {
+						throw new Error(
+							`Unknown variable "${dep}" in expression ${this.expression}`
+						);
+					}
+
+					return [dep, this.dictionary.get(dep)?.getValue(dependencyIteration)];
 				})
 			);
 		} catch (e) {

--- a/src/use-lunatic/reducer/reduce-on-init.tsx
+++ b/src/use-lunatic/reducer/reduce-on-init.tsx
@@ -113,7 +113,7 @@ function reduceOnInit(state: LunaticState, action: ActionInit) {
 			return result as any;
 		} catch (e) {
 			// If there is an error interpreting a variable, return the raw expression
-			console.error(`Cannot interpret expression : ${expressionString}`);
+			console.error(`Cannot interpret expression : ${expressionString}`, e);
 			return expressionString;
 		}
 	};


### PR DESCRIPTION
## Issue

Some expression are not quoted correctly and the behaviour in 2.6- was to simply display the expression (on labels for instance). This behaviour was broken in 2.7+ 

## Source

When parsing an expression, dependencies are resolved

```
Hello world
```

Would be parsed with 2 dependencies : `Hello` and `world`. Unknown variable are resolved to `null` with the new system and the VTL becomes 

```
null null
```

Strangely within VTL `interpret("null null")` gives `null` without throwing an error.

## Solution

When resolving dependencies, throw an error if a variable is not already registered in the dictionnary instead of resolving to `null`.


Fix #761