### PR TITLE
Dynamic unit

### DIFF
--- a/src/stories/input-number/source-euros.json
+++ b/src/stories/input-number/source-euros.json
@@ -4,10 +4,32 @@
 			"id": "kze792d8",
 			"componentType": "InputNumber",
 			"mandatory": false,
-			"page": "2",
+			"page": "1",
 			"min": 0,
 			"max": 10,
 			"decimals": 0,
+			"unit": { "value": "\"€\"", "type": "VTL|MD" },
+			"label": { "value": "\"➡ 1. \" || \"NB \"", "type": "VTL|MD" },
+			"conditionFilter": { "value": "true", "type": "VTL" },
+			"hierarchy": {
+				"sequence": {
+					"id": "ksyjs7vy",
+					"page": "1",
+					"label": { "value": "S0", "type": "VTL|MD" }
+				}
+			},
+			"bindingDependencies": ["NB"],
+			"response": { "name": "NB" }
+		},
+		{
+			"id": "kze792d8",
+			"componentType": "InputNumber",
+			"mandatory": false,
+			"page": "1",
+			"min": 0,
+			"max": 10,
+			"decimals": 0,
+			"unit": "$",
 			"label": { "value": "\"➡ 1. \" || \"NB \"", "type": "VTL|MD" },
 			"conditionFilter": { "value": "true", "type": "VTL" },
 			"hierarchy": {

--- a/src/use-lunatic/commons/fill-components/fill-component-expressions.ts
+++ b/src/use-lunatic/commons/fill-components/fill-component-expressions.ts
@@ -15,6 +15,7 @@ const VTL_ATTRIBUTES = [
 	'hierarchy.subSequence.label',
 	'declarations.label',
 	'description',
+	'unit',
 	'responses.description',
 	'options.description',
 	// Disable controls compilation


### PR DESCRIPTION
We don't need another field we can use the same "unit" field that can be a simple value or an expression.

Fix #668