### PR TITLE
Skip cleaning error

### DIFF
--- a/src/use-lunatic/commons/variables/behaviours/cleaning-behaviour.ts
+++ b/src/use-lunatic/commons/variables/behaviours/cleaning-behaviour.ts
@@ -26,16 +26,21 @@ export function cleaningBehaviour(
 		}
 
 		for (const variableName in cleaningInfo) {
-			const skipCleaning = store.run(cleaningInfo[variableName], {
-				iteration: e.detail.iteration,
-			});
-			if (skipCleaning) {
-				continue;
-			}
+			try {
+				const skipCleaning = store.run(cleaningInfo[variableName], {
+					iteration: e.detail.iteration,
+				});
+				if (skipCleaning) {
+					continue;
+				}
 
-			store.set(variableName, initialValues[variableName] ?? null, {
-				iteration: e.detail.iteration,
-			});
+				store.set(variableName, initialValues[variableName] ?? null, {
+					iteration: e.detail.iteration,
+				});
+			} catch (e) {
+				// If we have an error, skip this cleaning
+				console.error(e);
+			}
 		}
 	});
 }

--- a/src/use-lunatic/commons/variables/get-questionnaire-data.ts
+++ b/src/use-lunatic/commons/variables/get-questionnaire-data.ts
@@ -58,7 +58,12 @@ export function getQuestionnaireData(
 				COLLECTED: store.get(variable.name),
 			};
 		} else {
-			result[variable.variableType][variable.name] = store.get(variable.name);
+			try {
+				result[variable.variableType][variable.name] = store.get(variable.name);
+			} catch (e) {
+				// Error can happen when calculating variable, send null to prevent crashing the mehod
+				result[variable.variableType][variable.name] = null;
+			}
 		}
 	}
 	return result;

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,7 +1,7 @@
 export function isTestEnv(): boolean {
 	try {
 		// using vitest, process.env is defined
-		return /test/.test(`${process.env.npm_lifecycle_event}`);
+		return `${process.env.VITEST}` === 'true';
 	} catch (e) {
 		// process.env is not defined
 		// so we are not running as test so we can return false


### PR DESCRIPTION
This MR fixes 2 issues

## Better error handling for resizing / cleaning

In a previous change we change the store behaviour to throw an error (so we can catch it to show the expression as label) instead of just returning null. These error were not handled when resizing / cleaning and getting data. I moved try / catch up to handle the errors (they are just skipped).

## Fix array size being reduced

When resizing an array down the new system was not resizing the internal value. 

```js
store.set('AGE', [1, 2, 3]);
store.get('AGE') // [1, 2, 3]
store.set('AGE', [1, 2]);
store.get('AGE') // [1, 2, 3], not good
```

I added new tests and fixed this issue.

