### PR TITLE
DRAFT: add conditionFilter on lists

### DIFF
--- a/src/stories/checkbox-group/checkbox-group.stories.jsx
+++ b/src/stories/checkbox-group/checkbox-group.stories.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Orchestrator from '../utils/orchestrator';
 import source from './source';
 import sourceComponentset from './sourceComponentset';
+import sourceWithCondition from './sourceWithCondition.json';
 import sourceLoop from './sourceLoop';
 import defaultArgTypes from '../utils/default-arg-types';
 
@@ -41,4 +42,11 @@ export const Loop = Template.bind({});
 Loop.args = {
 	...Default.args,
 	source: sourceLoop,
+};
+
+export const WithCondition = Template.bind({});
+
+WithCondition.args = {
+	...Default.args,
+	source: sourceWithCondition,
 };

--- a/src/stories/checkbox-group/sourceWithCondition.json
+++ b/src/stories/checkbox-group/sourceWithCondition.json
@@ -1,0 +1,232 @@
+{
+	"components": [
+		{
+			"id": "number",
+			"componentType": "InputNumber",
+			"page": "1",
+			"label": {
+				"value": "\"Votre age\"",
+				"type": "VTL|MD"
+			},
+			"response": {
+				"name": "AGE"
+			}
+		},
+		{
+			"id": "checkboxes",
+			"componentType": "CheckboxGroup",
+			"page": "2",
+			"label": {
+				"value": "\"Pour quelle raison principale n’étiez-vous pas disponible ?\"",
+				"type": "VTL|MD"
+			},
+			"responses": [
+				{
+					"id": "kmort6x9-QOP-kmosa98y",
+					"label": {
+						"value": "\"Vous suiviez (ou aviez le projet de suivre) des études ou une formation\"",
+						"type": "VTL"
+					},
+					"response": { "name": "CHECK1" }
+				},
+				{
+					"id": "kmort6x9-QOP-kmos360k",
+					"label": {
+						"value": "\"Vous aviez des problèmes de santé ou étiez en situation de handicap\"",
+						"type": "VTL"
+					},
+					"response": { "name": "CHECK2" }
+				},
+				{
+					"id": "new_id_1",
+					"label": {
+						"value": "\"Vous étiez sur le point d’avoir un enfant\"",
+						"type": "VTL"
+					},
+					"conditionFilter": { "value": "cast(AGE, number) <= 50", "type": "VTL" },
+					"response": { "name": "CHECK3" }
+				},
+				{
+					"id": "new_id_2",
+					"label": {
+						"value": "\"Vous vous occupiez de vos enfants ou d’un proche\"",
+						"type": "VTL"
+					},
+					"response": { "name": "CHECK4" }
+				},
+				{
+					"id": "new_id_3",
+					"label": {
+						"value": "\"Vous étiez en vacances, preniez du temps pour vous ou réfléchissiez à votre avenir\"",
+						"type": "VTL"
+					},
+					"response": { "name": "CHECK5" }
+				},
+				{
+					"id": "new_id_4",
+					"label": {
+						"value": "\"Vous étiez à la retraite ou proche de la retraite\"",
+						"type": "VTL"
+					},
+					"conditionFilter": { "value": "cast(AGE, number) >= 50", "type": "VTL" },
+					"response": { "name": "CHECK6" }
+				},
+				{
+					"id": "new_id_5",
+					"label": {
+						"value": "\"Vous aviez des difficultés pour vous déplacer (pas le permis de conduire, voiture en panne, pas de transport à proximité…)\"",
+						"type": "VTL"
+					},
+					"response": { "name": "CHECK7" }
+				},
+				{
+					"id": "new_id_6",
+					"label": {
+						"value": "\"Vous déménagiez\"",
+						"type": "VTL"
+					},
+					"response": { "name": "CHECK8" }
+				},
+				{
+					"id": "new_id_7",
+					"label": {
+						"value": "\"Vous aviez des problèmes de papier / titre de séjour\"",
+						"type": "VTL"
+					},
+					"response": { "name": "CHECK9" }
+				},
+				{
+					"id": "new_id_8",
+					"label": {
+						"value": "\"Pour une autre raison\"",
+						"type": "VTL"
+					},
+					"response": { "name": "CHECK10" }
+				}
+			]
+		}
+	],
+	"variables": [
+		{
+			"variableType": "COLLECTED",
+			"name": "CHECK1",
+			"values": {
+				"PREVIOUS": null,
+				"COLLECTED": null,
+				"FORCED": null,
+				"EDITED": null,
+				"INPUTED": null
+			}
+		},
+		{
+			"variableType": "COLLECTED",
+			"name": "CHECK2",
+			"values": {
+				"PREVIOUS": null,
+				"COLLECTED": null,
+				"FORCED": null,
+				"EDITED": null,
+				"INPUTED": null
+			}
+		},
+		{
+			"variableType": "COLLECTED",
+			"name": "CHECK3",
+			"values": {
+				"PREVIOUS": null,
+				"COLLECTED": null,
+				"FORCED": null,
+				"EDITED": null,
+				"INPUTED": null
+			}
+		},
+		{
+			"variableType": "COLLECTED",
+			"name": "CHECK4",
+			"values": {
+				"PREVIOUS": null,
+				"COLLECTED": null,
+				"FORCED": null,
+				"EDITED": null,
+				"INPUTED": null
+			}
+		},
+		{
+			"variableType": "COLLECTED",
+			"name": "CHECK5",
+			"values": {
+				"PREVIOUS": null,
+				"COLLECTED": null,
+				"FORCED": null,
+				"EDITED": null,
+				"INPUTED": null
+			}
+		},
+		{
+			"variableType": "COLLECTED",
+			"name": "CHECK6",
+			"values": {
+				"PREVIOUS": null,
+				"COLLECTED": null,
+				"FORCED": null,
+				"EDITED": null,
+				"INPUTED": null
+			}
+		},
+		{
+			"variableType": "COLLECTED",
+			"name": "CHECK7",
+			"values": {
+				"PREVIOUS": null,
+				"COLLECTED": null,
+				"FORCED": null,
+				"EDITED": null,
+				"INPUTED": null
+			}
+		},
+		{
+			"variableType": "COLLECTED",
+			"name": "CHECK8",
+			"values": {
+				"PREVIOUS": null,
+				"COLLECTED": null,
+				"FORCED": null,
+				"EDITED": null,
+				"INPUTED": null
+			}
+		},
+		{
+			"variableType": "COLLECTED",
+			"name": "CHECK9",
+			"values": {
+				"PREVIOUS": null,
+				"COLLECTED": null,
+				"FORCED": null,
+				"EDITED": null,
+				"INPUTED": null
+			}
+		},
+		{
+			"variableType": "COLLECTED",
+			"name": "CHECK10",
+			"values": {
+				"PREVIOUS": null,
+				"COLLECTED": null,
+				"FORCED": null,
+				"EDITED": null,
+				"INPUTED": null
+			}
+		},
+		{
+			"variableType": "COLLECTED",
+			"name": "AGE",
+			"values": {
+				"PREVIOUS": null,
+				"COLLECTED": null,
+				"FORCED": null,
+				"EDITED": null,
+				"INPUTED": null
+			}
+		}
+	]
+}

--- a/src/stories/checkbox-group/sourceWithCondition.json
+++ b/src/stories/checkbox-group/sourceWithCondition.json
@@ -43,7 +43,10 @@
 						"value": "\"Vous étiez sur le point d’avoir un enfant\"",
 						"type": "VTL"
 					},
-					"conditionFilter": { "value": "cast(AGE, number) <= 50", "type": "VTL" },
+					"conditionFilter": {
+						"value": "cast(AGE, number) <= 50",
+						"type": "VTL"
+					},
 					"response": { "name": "CHECK3" }
 				},
 				{
@@ -68,7 +71,10 @@
 						"value": "\"Vous étiez à la retraite ou proche de la retraite\"",
 						"type": "VTL"
 					},
-					"conditionFilter": { "value": "cast(AGE, number) >= 50", "type": "VTL" },
+					"conditionFilter": {
+						"value": "cast(AGE, number) >= 50",
+						"type": "VTL"
+					},
 					"response": { "name": "CHECK6" }
 				},
 				{

--- a/src/stories/checkbox-one/checkboxOne.stories.jsx
+++ b/src/stories/checkbox-one/checkboxOne.stories.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Orchestrator from '../utils/orchestrator';
 import source from './source';
+import sourceWithCondition from './sourceWithCondition.json';
 import defaultArgTypes from '../utils/default-arg-types';
 
 const stories = {
@@ -19,6 +20,13 @@ const stories = {
 export default stories;
 
 const Template = (args) => <Orchestrator {...args} />;
-export const Default = Template.bind({});
 
+export const Default = Template.bind({});
 Default.args = { id: 'checkboxOne', source, shortcut: false };
+
+export const WithCondition = Template.bind({});
+WithCondition.args = {
+	id: 'checkboxOneCondition',
+	source: sourceWithCondition,
+	shortcut: false,
+};

--- a/src/stories/checkbox-one/sourceWithCondition.json
+++ b/src/stories/checkbox-one/sourceWithCondition.json
@@ -1,150 +1,150 @@
 {
-  "components": [
-    {
-      "id": "number",
-      "componentType": "InputNumber",
-      "page": "1",
-      "label": {
-        "value": "\"Votre age\"",
-        "type": "VTL|MD"
-      },
-      "response": {
-        "name": "AGE"
-      }
-    },
-    {
-      "response": {
-        "name": "CHECK"
-      },
-      "id": "checkboxes",
-      "componentType": "CheckboxOne",
-      "page": "2",
-      "label": {
-        "value": "\"Pour quelle raison principale n’étiez-vous pas disponible ?\"",
-        "type": "VTL|MD"
-      },
-      "options": [
-        {
-          "id": "check1",
-          "label": {
-            "value": "\"Vous suiviez (ou aviez le projet de suivre) des études ou une formation\"",
-            "type": "VTL"
-          },
-          "value": "CHECK1"
-        },
-        {
-          "id": "check2",
-          "label": {
-            "value": "\"Vous aviez des problèmes de santé ou étiez en situation de handicap\"",
-            "type": "VTL"
-          },
-          "value": "CHECK2"
-        },
-        {
-          "id": "check3",
-          "label": {
-            "value": "\"Vous étiez sur le point d’avoir un enfant\"",
-            "type": "VTL"
-          },
-          "conditionFilter": {
-            "value": "cast(AGE, number) <= 50",
-            "type": "VTL"
-          },
-          "value": "CHECK3",
-          "description": {
-            "value": "\"AGE <= 50\"",
-            "type": "VTL|MD"
-          }
-        },
-        {
-          "id": "check4",
-          "label": {
-            "value": "\"Vous vous occupiez de vos enfants ou d’un proche\"",
-            "type": "VTL"
-          },
-          "value": "CHECK4"
-        },
-        {
-          "id": "check5",
-          "label": {
-            "value": "\"Vous étiez en vacances, preniez du temps pour vous ou réfléchissiez à votre avenir\"",
-            "type": "VTL"
-          },
-          "value": "CHECK5"
-        },
-        {
-          "id": "check6",
-          "label": {
-            "value": "\"Vous étiez à la retraite ou proche de la retraite\"",
-            "type": "VTL"
-          },
-          "conditionFilter": {
-            "value": "cast(AGE, number) >= 50",
-            "type": "VTL"
-          },
-          "value": "CHECK6",
-          "description": {
-            "value": "\"AGE >= 50\"",
-            "type": "VTL|MD"
-          }
-        },
-        {
-          "id": "check7",
-          "label": {
-            "value": "\"Vous aviez des difficultés pour vous déplacer (pas le permis de conduire, voiture en panne, pas de transport à proximité…)\"",
-            "type": "VTL"
-          },
-          "value": "CHECK7"
-        },
-        {
-          "id": "check8",
-          "label": {
-            "value": "\"Vous déménagiez\"",
-            "type": "VTL"
-          },
-          "value": "CHECK8"
-        },
-        {
-          "id": "check9",
-          "label": {
-            "value": "\"Vous aviez des problèmes de papier / titre de séjour\"",
-            "type": "VTL"
-          },
-          "value": "CHECK9"
-        },
-        {
-          "id": "check10",
-          "label": {
-            "value": "\"Pour une autre raison\"",
-            "type": "VTL"
-          },
-          "value": "CHECK10"
-        }
-      ]
-    }
-  ],
-  "variables": [
-    {
-      "variableType": "COLLECTED",
-      "name": "CHECK",
-      "values": {
-        "PREVIOUS": null,
-        "COLLECTED": null,
-        "FORCED": null,
-        "EDITED": null,
-        "INPUTED": null
-      }
-    },
-    {
-      "variableType": "COLLECTED",
-      "name": "AGE",
-      "values": {
-        "PREVIOUS": null,
-        "COLLECTED": null,
-        "FORCED": null,
-        "EDITED": null,
-        "INPUTED": null
-      }
-    }
-  ]
+	"components": [
+		{
+			"id": "number",
+			"componentType": "InputNumber",
+			"page": "1",
+			"label": {
+				"value": "\"Votre age\"",
+				"type": "VTL|MD"
+			},
+			"response": {
+				"name": "AGE"
+			}
+		},
+		{
+			"response": {
+				"name": "CHECK"
+			},
+			"id": "checkboxes",
+			"componentType": "CheckboxOne",
+			"page": "2",
+			"label": {
+				"value": "\"Pour quelle raison principale n’étiez-vous pas disponible ?\"",
+				"type": "VTL|MD"
+			},
+			"options": [
+				{
+					"id": "check1",
+					"label": {
+						"value": "\"Vous suiviez (ou aviez le projet de suivre) des études ou une formation\"",
+						"type": "VTL"
+					},
+					"value": "CHECK1"
+				},
+				{
+					"id": "check2",
+					"label": {
+						"value": "\"Vous aviez des problèmes de santé ou étiez en situation de handicap\"",
+						"type": "VTL"
+					},
+					"value": "CHECK2"
+				},
+				{
+					"id": "check3",
+					"label": {
+						"value": "\"Vous étiez sur le point d’avoir un enfant\"",
+						"type": "VTL"
+					},
+					"conditionFilter": {
+						"value": "cast(AGE, number) <= 50",
+						"type": "VTL"
+					},
+					"value": "CHECK3",
+					"description": {
+						"value": "\"AGE <= 50\"",
+						"type": "VTL|MD"
+					}
+				},
+				{
+					"id": "check4",
+					"label": {
+						"value": "\"Vous vous occupiez de vos enfants ou d’un proche\"",
+						"type": "VTL"
+					},
+					"value": "CHECK4"
+				},
+				{
+					"id": "check5",
+					"label": {
+						"value": "\"Vous étiez en vacances, preniez du temps pour vous ou réfléchissiez à votre avenir\"",
+						"type": "VTL"
+					},
+					"value": "CHECK5"
+				},
+				{
+					"id": "check6",
+					"label": {
+						"value": "\"Vous étiez à la retraite ou proche de la retraite\"",
+						"type": "VTL"
+					},
+					"conditionFilter": {
+						"value": "cast(AGE, number) >= 50",
+						"type": "VTL"
+					},
+					"value": "CHECK6",
+					"description": {
+						"value": "\"AGE >= 50\"",
+						"type": "VTL|MD"
+					}
+				},
+				{
+					"id": "check7",
+					"label": {
+						"value": "\"Vous aviez des difficultés pour vous déplacer (pas le permis de conduire, voiture en panne, pas de transport à proximité…)\"",
+						"type": "VTL"
+					},
+					"value": "CHECK7"
+				},
+				{
+					"id": "check8",
+					"label": {
+						"value": "\"Vous déménagiez\"",
+						"type": "VTL"
+					},
+					"value": "CHECK8"
+				},
+				{
+					"id": "check9",
+					"label": {
+						"value": "\"Vous aviez des problèmes de papier / titre de séjour\"",
+						"type": "VTL"
+					},
+					"value": "CHECK9"
+				},
+				{
+					"id": "check10",
+					"label": {
+						"value": "\"Pour une autre raison\"",
+						"type": "VTL"
+					},
+					"value": "CHECK10"
+				}
+			]
+		}
+	],
+	"variables": [
+		{
+			"variableType": "COLLECTED",
+			"name": "CHECK",
+			"values": {
+				"PREVIOUS": null,
+				"COLLECTED": null,
+				"FORCED": null,
+				"EDITED": null,
+				"INPUTED": null
+			}
+		},
+		{
+			"variableType": "COLLECTED",
+			"name": "AGE",
+			"values": {
+				"PREVIOUS": null,
+				"COLLECTED": null,
+				"FORCED": null,
+				"EDITED": null,
+				"INPUTED": null
+			}
+		}
+	]
 }

--- a/src/stories/checkbox-one/sourceWithCondition.json
+++ b/src/stories/checkbox-one/sourceWithCondition.json
@@ -1,0 +1,150 @@
+{
+  "components": [
+    {
+      "id": "number",
+      "componentType": "InputNumber",
+      "page": "1",
+      "label": {
+        "value": "\"Votre age\"",
+        "type": "VTL|MD"
+      },
+      "response": {
+        "name": "AGE"
+      }
+    },
+    {
+      "response": {
+        "name": "CHECK"
+      },
+      "id": "checkboxes",
+      "componentType": "CheckboxOne",
+      "page": "2",
+      "label": {
+        "value": "\"Pour quelle raison principale n’étiez-vous pas disponible ?\"",
+        "type": "VTL|MD"
+      },
+      "options": [
+        {
+          "id": "check1",
+          "label": {
+            "value": "\"Vous suiviez (ou aviez le projet de suivre) des études ou une formation\"",
+            "type": "VTL"
+          },
+          "value": "CHECK1"
+        },
+        {
+          "id": "check2",
+          "label": {
+            "value": "\"Vous aviez des problèmes de santé ou étiez en situation de handicap\"",
+            "type": "VTL"
+          },
+          "value": "CHECK2"
+        },
+        {
+          "id": "check3",
+          "label": {
+            "value": "\"Vous étiez sur le point d’avoir un enfant\"",
+            "type": "VTL"
+          },
+          "conditionFilter": {
+            "value": "cast(AGE, number) <= 50",
+            "type": "VTL"
+          },
+          "value": "CHECK3",
+          "description": {
+            "value": "\"AGE <= 50\"",
+            "type": "VTL|MD"
+          }
+        },
+        {
+          "id": "check4",
+          "label": {
+            "value": "\"Vous vous occupiez de vos enfants ou d’un proche\"",
+            "type": "VTL"
+          },
+          "value": "CHECK4"
+        },
+        {
+          "id": "check5",
+          "label": {
+            "value": "\"Vous étiez en vacances, preniez du temps pour vous ou réfléchissiez à votre avenir\"",
+            "type": "VTL"
+          },
+          "value": "CHECK5"
+        },
+        {
+          "id": "check6",
+          "label": {
+            "value": "\"Vous étiez à la retraite ou proche de la retraite\"",
+            "type": "VTL"
+          },
+          "conditionFilter": {
+            "value": "cast(AGE, number) >= 50",
+            "type": "VTL"
+          },
+          "value": "CHECK6",
+          "description": {
+            "value": "\"AGE >= 50\"",
+            "type": "VTL|MD"
+          }
+        },
+        {
+          "id": "check7",
+          "label": {
+            "value": "\"Vous aviez des difficultés pour vous déplacer (pas le permis de conduire, voiture en panne, pas de transport à proximité…)\"",
+            "type": "VTL"
+          },
+          "value": "CHECK7"
+        },
+        {
+          "id": "check8",
+          "label": {
+            "value": "\"Vous déménagiez\"",
+            "type": "VTL"
+          },
+          "value": "CHECK8"
+        },
+        {
+          "id": "check9",
+          "label": {
+            "value": "\"Vous aviez des problèmes de papier / titre de séjour\"",
+            "type": "VTL"
+          },
+          "value": "CHECK9"
+        },
+        {
+          "id": "check10",
+          "label": {
+            "value": "\"Pour une autre raison\"",
+            "type": "VTL"
+          },
+          "value": "CHECK10"
+        }
+      ]
+    }
+  ],
+  "variables": [
+    {
+      "variableType": "COLLECTED",
+      "name": "CHECK",
+      "values": {
+        "PREVIOUS": null,
+        "COLLECTED": null,
+        "FORCED": null,
+        "EDITED": null,
+        "INPUTED": null
+      }
+    },
+    {
+      "variableType": "COLLECTED",
+      "name": "AGE",
+      "values": {
+        "PREVIOUS": null,
+        "COLLECTED": null,
+        "FORCED": null,
+        "EDITED": null,
+        "INPUTED": null
+      }
+    }
+  ]
+}

--- a/src/stories/dropdown/dropdown.stories.jsx
+++ b/src/stories/dropdown/dropdown.stories.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Orchestrator from '../utils/orchestrator';
 import source from './source';
+import sourceWithCondition from './sourceWithCondition.json';
 import data from './data';
 import defaultArgTypes from '../utils/default-arg-types';
 
@@ -14,11 +15,19 @@ export default stories;
 
 const Template = (args) => <Orchestrator {...args} />;
 export const Default = Template.bind({});
-
 Default.args = {
 	id: 'dropdown',
 	source,
 	data,
+	disabled: false,
+	editable: false,
+	writable: true,
+};
+
+export const WithCondition = Template.bind({});
+Default.args = {
+	id: 'dropdown',
+	source: sourceWithCondition,
 	disabled: false,
 	editable: false,
 	writable: true,

--- a/src/stories/dropdown/sourceWithCondition.json
+++ b/src/stories/dropdown/sourceWithCondition.json
@@ -1,0 +1,150 @@
+{
+	"components": [
+		{
+			"id": "number",
+			"componentType": "InputNumber",
+			"page": "1",
+			"label": {
+				"value": "\"Votre age\"",
+				"type": "VTL|MD"
+			},
+			"response": {
+				"name": "AGE"
+			}
+		},
+		{
+			"response": {
+				"name": "DROPDOWN"
+			},
+			"id": "checkboxes",
+			"componentType": "Dropdown",
+			"page": "2",
+			"label": {
+				"value": "\"Pour quelle raison principale n’étiez-vous pas disponible ?\"",
+				"type": "VTL|MD"
+			},
+			"options": [
+				{
+					"id": "check1",
+					"label": {
+						"value": "\"Vous suiviez (ou aviez le projet de suivre) des études ou une formation\"",
+						"type": "VTL"
+					},
+					"value": "1"
+				},
+				{
+					"id": "check2",
+					"label": {
+						"value": "\"Vous aviez des problèmes de santé ou étiez en situation de handicap\"",
+						"type": "VTL"
+					},
+					"value": "2"
+				},
+				{
+					"id": "check3",
+					"label": {
+						"value": "\"Vous étiez sur le point d’avoir un enfant\"",
+						"type": "VTL"
+					},
+					"conditionFilter": {
+						"value": "cast(AGE, number) <= 50",
+						"type": "VTL"
+					},
+					"value": "3",
+					"description": {
+						"value": "\"AGE <= 50\"",
+						"type": "VTL|MD"
+					}
+				},
+				{
+					"id": "check4",
+					"label": {
+						"value": "\"Vous vous occupiez de vos enfants ou d’un proche\"",
+						"type": "VTL"
+					},
+					"value": "4"
+				},
+				{
+					"id": "check5",
+					"label": {
+						"value": "\"Vous étiez en vacances, preniez du temps pour vous ou réfléchissiez à votre avenir\"",
+						"type": "VTL"
+					},
+					"value": "5"
+				},
+				{
+					"id": "check6",
+					"label": {
+						"value": "\"Vous étiez à la retraite ou proche de la retraite\"",
+						"type": "VTL"
+					},
+					"conditionFilter": {
+						"value": "cast(AGE, number) >= 50",
+						"type": "VTL"
+					},
+					"value": "6",
+					"description": {
+						"value": "\"AGE >= 50\"",
+						"type": "VTL|MD"
+					}
+				},
+				{
+					"id": "check7",
+					"label": {
+						"value": "\"Vous aviez des difficultés pour vous déplacer (pas le permis de conduire, voiture en panne, pas de transport à proximité…)\"",
+						"type": "VTL"
+					},
+					"value": "7"
+				},
+				{
+					"id": "check8",
+					"label": {
+						"value": "\"Vous déménagiez\"",
+						"type": "VTL"
+					},
+					"value": "8"
+				},
+				{
+					"id": "check9",
+					"label": {
+						"value": "\"Vous aviez des problèmes de papier / titre de séjour\"",
+						"type": "VTL"
+					},
+					"value": "9"
+				},
+				{
+					"id": "check10",
+					"label": {
+						"value": "\"Pour une autre raison\"",
+						"type": "VTL"
+					},
+					"value": "10"
+				}
+			]
+		}
+	],
+	"variables": [
+		{
+			"variableType": "COLLECTED",
+			"name": "DROPDOWN",
+			"values": {
+				"PREVIOUS": null,
+				"COLLECTED": null,
+				"FORCED": null,
+				"EDITED": null,
+				"INPUTED": null
+			}
+		},
+		{
+			"variableType": "COLLECTED",
+			"name": "AGE",
+			"values": {
+				"PREVIOUS": null,
+				"COLLECTED": null,
+				"FORCED": null,
+				"EDITED": null,
+				"INPUTED": null
+			}
+		}
+	]
+}

--- a/src/use-lunatic/commons/fill-components/fill-specific-expression.ts
+++ b/src/use-lunatic/commons/fill-components/fill-specific-expression.ts
@@ -152,6 +152,30 @@ function fillCheckboxGroup(
 }
 
 /**
+ * For Radio / CheckboxOne some options can be filtered via a conditionFilter
+ */
+function fillRadio(
+	component: DeepTranslateExpression<
+		LunaticComponentDefinition<'CheckboxOne' | 'Radio'>
+	>,
+	state: LunaticState
+) {
+	if (!('options' in component)) {
+		return component;
+	}
+	return {
+		...component,
+		options: component.options.filter((o) => {
+			if (!('conditionFilter' in o)) {
+				return true;
+			}
+
+			return state.executeExpression(o.conditionFilter);
+		}),
+	};
+}
+
+/**
  * Fill component specific props (RoundAbout for instance)
  */
 function fillSpecificExpressions(
@@ -172,6 +196,9 @@ function fillSpecificExpressions(
 			return fillTable(component, state);
 		case 'CheckboxGroup':
 			return fillCheckboxGroup(component, state);
+		case 'Radio':
+		case 'CheckboxOne':
+			return fillRadio(component, state);
 		default:
 			return component;
 	}

--- a/src/use-lunatic/commons/fill-components/fill-specific-expression.ts
+++ b/src/use-lunatic/commons/fill-components/fill-specific-expression.ts
@@ -131,6 +131,27 @@ function fillTable(
 }
 
 /**
+ * For CheckboxGroup some responses can be filtered via a conditionFilter
+ */
+function fillCheckboxGroup(
+	component: DeepTranslateExpression<
+		LunaticComponentDefinition<'CheckboxGroup'>
+	>,
+	state: LunaticState
+) {
+	return {
+		...component,
+		responses: component.responses.filter((response) => {
+			if (!('conditionFilter' in response)) {
+				return true;
+			}
+
+			return state.executeExpression(response.conditionFilter);
+		}),
+	};
+}
+
+/**
  * Fill component specific props (RoundAbout for instance)
  */
 function fillSpecificExpressions(
@@ -149,6 +170,8 @@ function fillSpecificExpressions(
 			return fillPairwise(component, state);
 		case 'Table':
 			return fillTable(component, state);
+		case 'CheckboxGroup':
+			return fillCheckboxGroup(component, state);
 		default:
 			return component;
 	}

--- a/src/use-lunatic/commons/fill-components/fill-specific-expression.ts
+++ b/src/use-lunatic/commons/fill-components/fill-specific-expression.ts
@@ -156,13 +156,10 @@ function fillCheckboxGroup(
  */
 function fillRadio(
 	component: DeepTranslateExpression<
-		LunaticComponentDefinition<'CheckboxOne' | 'Radio'>
+		LunaticComponentDefinition<'CheckboxOne' | 'Radio' | 'Dropdown'>
 	>,
 	state: LunaticState
 ) {
-	if (!('options' in component)) {
-		return component;
-	}
 	return {
 		...component,
 		options: component.options.filter((o) => {
@@ -198,6 +195,7 @@ function fillSpecificExpressions(
 			return fillCheckboxGroup(component, state);
 		case 'Radio':
 		case 'CheckboxOne':
+		case 'Dropdown':
 			return fillRadio(component, state);
 		default:
 			return component;

--- a/src/use-lunatic/type-source.ts
+++ b/src/use-lunatic/type-source.ts
@@ -218,6 +218,7 @@ export type ComponentCheckboxGroupType = {
 		label: LabelType;
 		response: ResponseType;
 		id: string;
+		conditionFilter?: ConditionFilterType;
 	}>;
 };
 

--- a/src/use-lunatic/type-source.ts
+++ b/src/use-lunatic/type-source.ts
@@ -3,6 +3,12 @@
  */
 export type LabelType = { value: string; type: 'VTL' | 'VTL|MD' };
 
+type ComponentOption = {
+	value: string;
+	label: LabelType;
+	conditionFilter?: ConditionFilterType;
+};
+
 export type ComponentTypeEnum =
 	| 'Sequence'
 	| 'Subsequence'
@@ -130,9 +136,6 @@ export type ComponentType =
 	| (ComponentTypeBase & ComponentSuggesterType)
 	| (ComponentTypeBase & ComponentInputOrTextareaType)
 	| (ComponentTypeBase & {
-			componentType: 'CheckboxOne';
-	  })
-	| (ComponentTypeBase & {
 			componentType: 'ConfirmationModal';
 	  })
 	| (ComponentTypeBase & ComponentComponentSetType)
@@ -229,15 +232,15 @@ export type ComponentCheckboxBooleanType = {
 };
 
 export type ComponentRadioType = {
-	componentType: 'Radio';
-	options: { value: string; label: LabelType }[];
+	componentType: 'Radio' | 'CheckboxOne';
+	options: ComponentOption[];
 	response: ResponseType;
 	missingResponse?: ResponseType;
 };
 
 export type ComponentDropdownType = {
 	componentType: 'Dropdown';
-	options: { value: string; label: LabelType }[];
+	options: ComponentOption[];
 	response: ResponseType;
 	missingResponse?: ResponseType;
 };


### PR DESCRIPTION
This is a DRAFT that serves as a proof of concept on how to handle filter in list for various component in Lunatic

Bowie Issue https://github.com/InseeFr/Concevoir-Workplace/issues/65

## CheckboxGroup

For checkbox group we could add a new conditionFilter for every `response` in `responses` 

```diff
{
	"id": "new_id_4",
	"label": {
		"value": "\"Vous étiez à la retraite ou proche de la retraite\"",
		"type": "VTL"
	},
+	"conditionFilter": { "value": "cast(AGE, number) >= 50", "type": "VTL" },
	"response": { "name": "CHECK6" }
},
```

## CheckboxOne / Radio / Dropdown

For unique checkbox / radio we could add a new conditionFilter for every `option` in `options` 

```diff
{
  "id": "check6",
  "label": {
    "value": "\"Vous étiez à la retraite ou proche de la retraite\"",
    "type": "VTL"
  },
+ "conditionFilter": {
+   "value": "cast(AGE, number) >= 50",
+   "type": "VTL"
+ },
  "value": "CHECK6"
},
```