### PR TITLE
feat: internal link

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
 		"react-keyboard-event-handler": "^1.5.4",
 		"react-markdown": "^8.0.3",
 		"react-number-format": "^5.1.3",
-		"react-tooltip": "^4.2.15",
+		"react-tooltip": "^5.23.0",
 		"remove-accents": "^0.4.2",
 		"sass": "^1.58.3",
 		"snowball": "^0.3.1",

--- a/src/components/commons/components/md-label/link.tsx
+++ b/src/components/commons/components/md-label/link.tsx
@@ -1,8 +1,9 @@
-import { type PropsWithChildren } from 'react';
-import ReactTooltip from 'react-tooltip';
+import { Fragment, type PropsWithChildren, useId } from 'react';
+import { Tooltip } from 'react-tooltip';
+import ReactMarkdown from 'react-markdown';
+import routerLink from './router-link';
 
 type Props = PropsWithChildren<{ href: string; title: string }>;
-
 const Link = (props: Props) => {
 	const {
 		href,
@@ -10,46 +11,42 @@ const Link = (props: Props) => {
 		title,
 		// logFunction
 	} = props;
-	// TODO: reactivate
-	const listener = (/* link = true */) => () => {
-		// if (isFunction(logFunction))
-		// 	logFunction(
-		// 		createObjectEvent(
-		// 			link ? `link-${href}` : `tooltip-${title}`,
-		// 			link ? LINK_CATEGORY : TOOLTIP_CATEGORY,
-		// 			EVENT_CLICK
-		// 		)
-		// 	);
-	};
-	if (href.trim().startsWith('http'))
-		return (
-			<a
-				href={href}
-				target="_blank"
-				rel="noreferrer noopener"
-				onClick={listener()}
-			>
-				{children}
-			</a>
-		);
+
+	const id = useId();
+
+	const LinkComponent: React.FC<{
+		to?: string;
+		href?: string;
+		id: string;
+		'data-tooltip-id'?: string;
+	}> = (() => {
+		if (href.trim().startsWith('/')) {
+			return routerLink;
+		} else {
+			return 'a' as any;
+		}
+	})();
+
+	const linkProps = href.trim().startsWith('/')
+		? { to: href, id }
+		: { href, target: '_blank', rel: 'noopener noreferrer', id };
+
 	return (
-		<span className="link-md" onPointerUp={listener(/*false*/)}>
-			<span
-				data-for={`${title}-tooltip`}
-				data-tip={title}
-				data-multiline
-				className="field-md"
+		<>
+			<LinkComponent
+				{...linkProps}
+				{...(title
+					? { 'data-tooltip-id': `tooltip-${id}`, className: 'link-md' }
+					: {})}
 			>
 				{children}
-			</span>
-			<ReactTooltip
-				id={`${title}-tooltip`}
-				className="tooltip-content"
-				place="bottom"
-				effect="solid"
-				globalEventOff="click"
-			/>
-		</span>
+			</LinkComponent>
+			{title && (
+				<Tooltip className="tooltip-content" id={`tooltip-${id}`}>
+					<ReactMarkdown components={{ p: Fragment }}>{title}</ReactMarkdown>
+				</Tooltip>
+			)}
+		</>
 	);
 };
 

--- a/src/components/commons/components/md-label/link.tsx
+++ b/src/components/commons/components/md-label/link.tsx
@@ -1,7 +1,7 @@
 import { Fragment, type PropsWithChildren, useId } from 'react';
 import { Tooltip } from 'react-tooltip';
 import ReactMarkdown from 'react-markdown';
-import routerLink from './router-link';
+import RouterLink from './router-link';
 
 type Props = PropsWithChildren<{ href: string; title: string }>;
 const Link = (props: Props) => {
@@ -21,7 +21,7 @@ const Link = (props: Props) => {
 		'data-tooltip-id'?: string;
 	}> = (() => {
 		if (href.trim().startsWith('/')) {
-			return routerLink;
+			return RouterLink;
 		} else {
 			return 'a' as any;
 		}

--- a/src/components/commons/components/md-label/link.tsx
+++ b/src/components/commons/components/md-label/link.tsx
@@ -27,20 +27,18 @@ const Link = (props: Props) => {
 		}
 	})();
 
-	const linkProps = href.trim().startsWith('/')
-		? { to: href, id }
-		: { href, target: '_blank', rel: 'noopener noreferrer', id };
+	const linkProps = {
+		...(href.trim().startsWith('/')
+			? { to: href, id }
+			: { href, target: '_blank', rel: 'noopener noreferrer', id }),
+		...(title
+			? { 'data-tooltip-id': `tooltip-${id}`, className: 'link-md' }
+			: {}),
+	};
 
 	return (
 		<>
-			<LinkComponent
-				{...linkProps}
-				{...(title
-					? { 'data-tooltip-id': `tooltip-${id}`, className: 'link-md' }
-					: {})}
-			>
-				{children}
-			</LinkComponent>
+			<LinkComponent {...linkProps}>{children}</LinkComponent>
 			{title && (
 				<Tooltip className="tooltip-content" id={`tooltip-${id}`}>
 					<ReactMarkdown components={{ p: Fragment }}>{title}</ReactMarkdown>

--- a/src/components/commons/components/md-label/md-label.spec.tsx
+++ b/src/components/commons/components/md-label/md-label.spec.tsx
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest';
-import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, waitFor, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import MdLabel from './md-label';
 
 describe('md-label', () => {
@@ -50,6 +51,134 @@ describe('md-label', () => {
 			  <p>
 			    with multiple paragraphs
 			  </p>
+			</div>
+		`);
+	});
+	it('should render external link', () => {
+		const obj = render(
+			<MdLabel
+				expression={'This is a [link](https://inseefr.github.io/Lunatic/docs)'}
+			/>
+		);
+		return expect(obj.container).toMatchInlineSnapshot(`
+			<div>
+			  This is a 
+			  <a
+			    href="https://inseefr.github.io/Lunatic/docs"
+			    id=":r0:"
+			    rel="noopener noreferrer"
+			    target="_blank"
+			  >
+			    link
+			  </a>
+			</div>
+		`);
+	});
+
+	it('should render external link with tooltip', async () => {
+		const { container } = render(
+			<MdLabel
+				expression={
+					"This is a [link](https://inseefr.github.io/Lunatic/docs 'with a tooltip')"
+				}
+			/>
+		);
+		const link = screen.getByText('link'); // Get the link element by its text content
+		// Simulate hover event
+		await userEvent.hover(link);
+
+		let tooltip = null;
+
+		await waitFor(() => {
+			tooltip = screen.getByRole('tooltip');
+		});
+		expect(tooltip).toBeInTheDocument();
+		expect(container).toMatchInlineSnapshot(`
+			<div>
+			  This is a 
+			  <a
+			    class="link-md"
+			    data-tooltip-id="tooltip-:r1:"
+			    href="https://inseefr.github.io/Lunatic/docs"
+			    id=":r1:"
+			    rel="noopener noreferrer"
+			    target="_blank"
+			  >
+			    link
+			  </a>
+			  <div
+			    class="react-tooltip core-styles-module_tooltip__3vRRp styles-module_tooltip__mnnfp styles-module_dark__xNqje tooltip-content react-tooltip__place-top core-styles-module_show__Nt9eE react-tooltip__show"
+			    id="tooltip-:r1:"
+			    role="tooltip"
+			    style="left: 5px; top: -10px;"
+			  >
+			    with a tooltip
+			    <div
+			      class="react-tooltip-arrow core-styles-module_arrow__cvMwQ styles-module_arrow__K0L3T"
+			      style="left: -1px; bottom: -4px;"
+			    />
+			  </div>
+			</div>
+		`);
+	});
+
+	it('should render internal link', () => {
+		const obj = render(
+			<MdLabel expression={'This is an [internal link](/docs)'} />
+		);
+		return expect(obj.container).toMatchInlineSnapshot(`
+			<div>
+			  This is an 
+			  <a
+			    href="/docs"
+			    id=":r2:"
+			  >
+			    internal link
+			  </a>
+			</div>
+		`);
+	});
+
+	it('should render internal link with tooltip', async () => {
+		const { container } = render(
+			<MdLabel
+				expression={"This is an [internal link](/docs 'with a tooltip')"}
+			/>
+		);
+
+		const link = screen.getByText('internal link'); // Get the link element by its text content
+		// Simulate hover event
+		await userEvent.hover(link);
+
+		let tooltip = null;
+
+		await waitFor(() => {
+			tooltip = screen.getByRole('tooltip');
+		});
+		expect(tooltip).toBeInTheDocument();
+		expect(container).toMatchInlineSnapshot(`
+			<div>
+			  This is an 
+			  <a
+			    class="link-md"
+			    data-tooltip-id="tooltip-:r3:"
+			    href="/docs"
+			    id=":r3:"
+			  >
+			    internal link
+			  </a>
+			  <div
+			    class="react-tooltip core-styles-module_tooltip__3vRRp styles-module_tooltip__mnnfp styles-module_dark__xNqje tooltip-content react-tooltip__place-top core-styles-module_show__Nt9eE react-tooltip__show"
+			    id="tooltip-:r3:"
+			    role="tooltip"
+			    style="left: 5px; top: -10px;"
+			  >
+			    with a tooltip
+			    <div
+			      class="react-tooltip-arrow core-styles-module_arrow__cvMwQ styles-module_arrow__K0L3T"
+			      style="left: -1px; bottom: -4px;"
+			    />
+			  </div>
 			</div>
 		`);
 	});

--- a/src/components/commons/components/md-label/md-label.tsx
+++ b/src/components/commons/components/md-label/md-label.tsx
@@ -9,10 +9,9 @@ const DEFAULT_LOG_FUNCTION = voidFunction;
 type Props = { expression: string; logFunction?: typeof DEFAULT_LOG_FUNCTION };
 
 const MdLabel = ({ expression, logFunction = DEFAULT_LOG_FUNCTION }: Props) => (
-	<ReactMarkdown
-		children={expression}
-		components={renderComponentsFor(expression, { logFunction })}
-	/>
+	<ReactMarkdown components={renderComponentsFor(expression, { logFunction })}>
+		{expression}
+	</ReactMarkdown>
 );
 
 const renderComponentsFor = (

--- a/src/components/commons/components/md-label/router-link.tsx
+++ b/src/components/commons/components/md-label/router-link.tsx
@@ -1,0 +1,15 @@
+import type { ComponentProps } from 'react';
+import createCustomizableLunaticField from '../../create-customizable-field';
+
+type Props = Omit<ComponentProps<'a'>, 'href'> & { to: string };
+
+const RouterLink = (props: Props) => {
+	const { to, children, onClick, ref, ...rest } = props;
+	return (
+		<a href={to} onClick={onClick} ref={ref} {...rest}>
+			{children}
+		</a>
+	);
+};
+
+export default createCustomizableLunaticField(RouterLink, 'RouterLink');

--- a/src/components/commons/components/md-label/router-link.tsx
+++ b/src/components/commons/components/md-label/router-link.tsx
@@ -4,9 +4,9 @@ import createCustomizableLunaticField from '../../create-customizable-field';
 type Props = Omit<ComponentProps<'a'>, 'href'> & { to: string };
 
 const RouterLink = (props: Props) => {
-	const { to, children, onClick, ref, ...rest } = props;
+	const { to, children, ...rest } = props;
 	return (
-		<a href={to} onClick={onClick} ref={ref} {...rest}>
+		<a href={to} {...rest}>
 			{children}
 		</a>
 	);

--- a/src/components/commons/components/variable-status/variable-status.tsx
+++ b/src/components/commons/components/variable-status/variable-status.tsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { type PropsWithChildren, useState } from 'react';
-import ReactTooltip from 'react-tooltip';
+import { Tooltip } from 'react-tooltip';
 import { editedImg, forcedImg } from './img';
 import './variable-status.scss';
 
@@ -42,7 +42,7 @@ const VariableStatus = ({ id = '', children }: Props) => {
 				>
 					<img id={id} alt="img-tooltip" src={img[imgName] ?? ''} />
 				</span>
-				<ReactTooltip
+				<Tooltip
 					id={`${id}-management-tooltip`}
 					className="tooltip-text"
 					place="left"

--- a/src/components/index.scss
+++ b/src/components/index.scss
@@ -125,12 +125,30 @@
 		position: relative;
 	}
 
-	.link-md .field-md {
+	.link-md {
 		border-bottom: dashed 0.1em var(--color-primary-dark);
 		&:hover {
 			cursor: help;
 			color: var(--color-primary-contrast-text);
 			background-color: var(--color-primary-dark);
+		}
+	}
+
+	.tooltip-content {
+		min-width: 15em;
+		max-width: 25em;
+		background: var(--color-primary-dark);
+		color: var(--color-primary-contrast-text);
+		padding: 0.5em;
+		border-radius: 6px;
+		font-size: 1em;
+		&.place-bottom {
+			&::before {
+				border-bottom: 10px solid var(--color-primary-dark);
+			}
+			&::after {
+				content: none;
+			}
 		}
 	}
 }

--- a/src/stories/markdown/markdown.stories.jsx
+++ b/src/stories/markdown/markdown.stories.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import Orchestrator from '../utils/orchestrator';
+import defaultArgTypes from '../utils/default-arg-types';
+import source from './source.json';
+
+const stories = {
+	title: 'Components/Markdown',
+	component: Orchestrator,
+	argTypes: defaultArgTypes,
+};
+
+export default stories;
+
+const Template = (args) => <Orchestrator {...args} />;
+export const Default = Template.bind({});
+
+Default.args = {
+	id: 'markdown',
+	source: source,
+};

--- a/src/stories/markdown/source.json
+++ b/src/stories/markdown/source.json
@@ -1,0 +1,40 @@
+{
+	"maxPages": "1",
+	"components": [
+		{
+			"componentType": "Sequence",
+			"page": "1",
+			"conditionFilter": { "value": "true", "type": "VTL" },
+			"label": { "value": "\"Sequence example\"", "type": "VTL|MD" },
+			"declarations": [
+				{
+					"id": "kb9hi4j0-krnoclfe",
+					"declarationType": "INSTRUCTION",
+					"position": "BEFORE_QUESTION_TEXT",
+					"label": {
+						"value": "\"Déclaration Before with [internal link](/docs)\"",
+						"type": "VTL|MD"
+					}
+				},
+				{
+					"id": "kb9hi4j0-krnoclfe",
+					"declarationType": "INSTRUCTION",
+					"position": "AFTER_QUESTION_TEXT",
+					"label": {
+						"value": "\"Déclaration AFTER with [tooltip link](https://google.com 'une infobule avec du texte très très long pour voir ce que cela donne Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.') \"",
+						"type": "VTL|MD"
+					}
+				},
+				{
+					"id": "kb9hi4j0-krnoclfe",
+					"declarationType": "HELP",
+					"position": "DETACHABLE",
+					"label": {
+						"value": "\"Declaration Detachable with [external link](https://inseefr.github.io/Lunatic/)\"",
+						"type": "VTL|MD"
+					}
+				}
+			]
+		}
+	]
+}

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,4 +1,4 @@
-import { expect, afterEach } from 'vitest';
+import { expect, afterEach, vi } from 'vitest';
 import { cleanup } from '@testing-library/react';
 import * as matchers from 'vitest-dom/matchers';
 
@@ -14,3 +14,9 @@ afterEach(() => {
 (global as any).structuredClone = (val: any) => {
 	return JSON.parse(JSON.stringify(val));
 };
+
+global.ResizeObserver = vi.fn().mockImplementation(() => ({
+	observe: vi.fn(),
+	unobserve: vi.fn(),
+	disconnect: vi.fn(),
+}));

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -15,6 +15,7 @@ afterEach(() => {
 	return JSON.parse(JSON.stringify(val));
 };
 
+// We need ResizeObserver to test Tooltip
 global.ResizeObserver = vi.fn().mockImplementation(() => ({
 	observe: vi.fn(),
 	unobserve: vi.fn(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1457,7 +1457,7 @@
   dependencies:
     "@floating-ui/utils" "^0.1.3"
 
-"@floating-ui/dom@^1.5.1":
+"@floating-ui/dom@^1.0.0", "@floating-ui/dom@^1.5.1":
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.5.3.tgz#54e50efcb432c06c23cd33de2b575102005436fa"
   integrity sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==
@@ -5254,7 +5254,7 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz#6c370ab19f8a3394e318fe682686ec0ac684d107"
   integrity sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==
 
-classnames@^2.3.1:
+classnames@^2.3.0, classnames@^2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
   integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
@@ -11100,13 +11100,13 @@ react-style-singleton@^2.2.1:
     invariant "^2.2.4"
     tslib "^2.0.0"
 
-react-tooltip@^4.2.15:
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-4.5.1.tgz#77eccccdf16adec804132e558ec20ca5783b866a"
-  integrity sha512-Zo+CSFUGXar1uV+bgXFFDe7VeS2iByeIp5rTgTcc2HqtuOS5D76QapejNNfx320MCY91TlhTQat36KGFTqgcvw==
+react-tooltip@^5.23.0:
+  version "5.23.0"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-5.23.0.tgz#dbbc950194a10e00c1b3072e71cbe0b3fcb84dfe"
+  integrity sha512-MYqn6n+Af8NHHDL3zrSqzVSoK2LLqTNFp30CuuHCYlBEf+q88FWfg+8pSO+0GnDvOa5ZaryNDq9sAVQeNhnsgw==
   dependencies:
-    prop-types "^15.8.1"
-    uuid "^7.0.3"
+    "@floating-ui/dom" "^1.0.0"
+    classnames "^2.3.0"
 
 react-transition-group@^4.4.5:
   version "4.4.5"
@@ -12858,11 +12858,6 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
-
-uuid@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
-  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
 uuid@^8.3.2:
   version "8.3.2"


### PR DESCRIPTION
## Internal Link and Tooltip display

### Summary

This pull request enhances the Lunatic library by introducing a new feature: the ability to extract internal links from Markdown text. Additionally, improvements have been made to the display of tooltips, restoring it to the v1 Lunatic behavior.

### Changes Made

1. **Internal Link Extraction:**
   - Added functionality to extract internal links from Markdown text.
   - Internal links are now detected based on the classic Markdown link pattern starting with "/". Clients can customize the `RouterLink` component using the `custom` props to provide their own link.

2. **Tooltip Display:**
   - Corrected the display of tooltips to align with the behavior observed in Lunatic v1.
   - To create a tooltip, use the Markdown syntax: `[word](url 'tooltip content')`. If no URL is provided, use `[word](. 'tooltip content')`.

### Usage

To get the internal link extraction feature and the corrected tooltip display:

1. Update Lunatic to this branch.
2. In the Orchestrateur, customize the `RouterLink` component using the `custom` props and provide your own link.
3. Verify that internal links within Markdown text, starting with "/", are properly extracted and displayed.
4. Ensure tooltips now display as expected.

### Related Issues

Closes: Inseefr/Stromae#264

### Screenshots

<img width="385" alt="Capture d’écran 2023-11-21 à 14 35 08" src="https://github.com/InseeFr/Lunatic/assets/81740200/6b96dafe-a1bb-4346-b8bd-32689bacf5c6">

<img width="448" alt="Capture d’écran 2023-11-21 à 14 35 13" src="https://github.com/InseeFr/Lunatic/assets/81740200/8aebaa7c-8fc5-4fa0-a0de-1b425f86d6c5">

### Test

The tests use a snapshot and the Link component `useId` hook, which is not mocked, making them fragile.
