### PR TITLE
the worker now only answer to the last request

### DIFF
--- a/src/utils/suggester-workers/searching/searching.worker.js
+++ b/src/utils/suggester-workers/searching/searching.worker.js
@@ -3,9 +3,14 @@ import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 import searching from './searching';
 
+let LAST_SEARCH = undefined;
+
 self.onmessage = function (e) {
 	const { search, name, version, meloto } = e.data;
+	LAST_SEARCH = search;
 	searching(search, { name, version, meloto }).then(function (result) {
-		self.postMessage(result);
+		if (search === LAST_SEARCH) {
+			self.postMessage(result);
+		}
 	});
 };


### PR DESCRIPTION
l'enchainement de 2 requêtes utilisateurs peut provoquer des affichages étranges : le résultat d'une requête avec la recherche d'une autre. Dorénavant, le worker n'envoie la réponse que pour la dernière recherche émise.
A tester pour voir s'il n'y a pas d'effet de bord