### PR TITLE
Fix/suggester responses order

### DIFF
--- a/src/components/suggester/searching/create-searching.ts
+++ b/src/components/suggester/searching/create-searching.ts
@@ -29,14 +29,16 @@ function createSearching(
 	workersBasePath?: string
 ) {
 	return async function (search: string | null) {
-		return new Promise<{ results: ComboBoxOptionType[] }>(function (resolve) {
-			const worker = getWorker(resolve, workersBasePath);
-			worker.postMessage({
-				search,
-				name,
-				version,
-			});
-		});
+		return new Promise<{ results: ComboBoxOptionType[]; search: string }>(
+			function (resolve) {
+				const worker = getWorker(resolve, workersBasePath);
+				worker.postMessage({
+					search,
+					name,
+					version,
+				});
+			}
+		);
 	};
 }
 export default createSearching;

--- a/src/stories/suggester/simple.json
+++ b/src/stories/suggester/simple.json
@@ -20,7 +20,10 @@
 		},
 		{
 			"name": "cog-communes",
-			"fields": [{ "name": "id", "rules": "soft" }],
+			"fields": [
+				{ "name": "id", "rules": "soft" },
+				{ "name": "label", "rules": "soft" }
+			],
 			"queryParser": { "type": "soft" },
 			"version": "1"
 		},
@@ -85,7 +88,7 @@
 				"name": "HELLO"
 			},
 			"missingResponse": { "name": "HELLO_MISSING" },
-			"page": "2"
+			"page": "1"
 		},
 		{
 			"id": "suggestions-inconnu",

--- a/src/utils/suggester-workers/searching/searching.worker.js
+++ b/src/utils/suggester-workers/searching/searching.worker.js
@@ -3,14 +3,9 @@ import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 import searching from './searching';
 
-let LAST_SEARCH = undefined;
-
 self.onmessage = function (e) {
 	const { search, name, version, meloto } = e.data;
-	LAST_SEARCH = search;
 	searching(search, { name, version, meloto }).then(function (result) {
-		if (search === LAST_SEARCH) {
-			self.postMessage(result);
-		}
+		self.postMessage(result);
 	});
 };

--- a/src/utils/suggester-workers/searching/searching.worker.js
+++ b/src/utils/suggester-workers/searching/searching.worker.js
@@ -3,9 +3,14 @@ import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 import searching from './searching';
 
+let LAST_SEARCH = undefined;
+
 self.onmessage = function (e) {
 	const { search, name, version, meloto } = e.data;
+	LAST_SEARCH = search;
 	searching(search, { name, version, meloto }).then(function (result) {
-		self.postMessage(result);
+		if (search === LAST_SEARCH) {
+			self.postMessage(result);
+		}
 	});
 };


### PR DESCRIPTION
Cette PR pour 2.6, pourrais vous interresser la 2.7. Les requetes idb peuvent etre plus ou moins longue. Parfois, les résultats peuvent ce croiser et au final une recherche affiche les résultats de la requete precedente. Apres pas mal d'essais, le plus simple est de regler cela directement en bas dans l'implementation html du suggester.

PS: il faudra veiller à n'instancier qu'une fois le worker pour rendre un peu de puissance au suggester, qui rame beaucoup maintenant