### PR TITLE
Refresh for roundabout

### DIFF
--- a/src/use-lunatic/commons/fill-components/fill-specific-expression.ts
+++ b/src/use-lunatic/commons/fill-components/fill-specific-expression.ts
@@ -19,7 +19,7 @@ function fillRoundaboutProps(
 		const values = new Array(iterations).fill(null).map((_, iteration) => {
 			return state.executeExpression(expression, {
 				iteration,
-				skipCleaningRefresh: iteration < iterations - 1,
+				skipCleaningRefresh: true, // TODO : this should be "iteration < iterations - 1" but this cause an issue with recensement, investigate further later,
 			});
 		});
 		return { ...result, [name]: values };


### PR DESCRIPTION
Désactive le refresh des variables dans le cas du roundabout car ça semble poser des problème sur le recensement (il faudrait plutôt chercher la cause du problème mais l'impératif de temps oblige à un dirty fix dans cette situation). 

Cette situation n'affectera pas la branche 2.7 de toute façon.
