### PR TITLE
Fix: handle shapeFrom on calculated variable

### DIFF
--- a/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
@@ -154,6 +154,7 @@ describe('lunatic-variables-store', () => {
 			variables.set('LASTNAME', ['Doe', 'Dae']);
 			variables.setCalculated('FULLNAME', 'FIRSTNAME || " " || LASTNAME', {
 				dependencies: ['FIRSTNAME', 'LASTNAME'],
+				shapeFrom: 'FIRSTNAME',
 			});
 			expect(variables.get('FULLNAME', [0])).toEqual('John Doe');
 			expect(variables.get('FULLNAME', [1])).toEqual('Jane Dae');
@@ -188,7 +189,8 @@ describe('lunatic-variables-store', () => {
 			variables.set('FIRSTNAME', ['John', 'Jane']);
 			variables.setCalculated(
 				'FULLNAME',
-				'FIRSTNAME || " " || cast(GLOBAL_ITERATION_INDEX, string)'
+				'FIRSTNAME || " " || cast(GLOBAL_ITERATION_INDEX, string)',
+				{ shapeFrom: 'FIRSTNAME' }
 			);
 			expect(variables.get('FULLNAME', [0])).toEqual('John 0');
 			expect(variables.get('FULLNAME', [1])).toEqual('Jane 1');


### PR DESCRIPTION
Dans la nouvelle version des variables, j'avais choisi d'ignorer le shapeFrom car à première vu une variable hors iteration ne pouvait pas être utilisé dans une expression de boucle.

Le calcul des variables CALCULATED est donc changé 

- Si il n'y a pas de `shapeFrom`, la variable est éxécuté sans prendre en compte le contexte d'itération
- Si il y a un `shapeFrom`, on regarde la valeur de la variable et si ce n'est pas un tableau on ignore le contexte d'itération

Fix #809