### PR TITLE
fix: shapeFrom handling

### DIFF
--- a/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
@@ -195,6 +195,15 @@ describe('lunatic-variables-store', () => {
 			expect(variables.get('FULLNAME', [0])).toEqual('John 0');
 			expect(variables.get('FULLNAME', [1])).toEqual('Jane 1');
 		});
+		it('should handle shapeFrom correctly', () => {
+			variables.set('FIRSTNAME', ['John', 'Jane']);
+			variables.setCalculated(
+				'FULLNAME',
+				'FIRSTNAME || " " || cast(GLOBAL_ITERATION_INDEX, string)',
+				{ shapeFrom: 'FIRSTNAME' }
+			);
+			expect(variables.get('FULLNAME')).toEqual(['John 0', 'Jane 1']);
+		});
 	});
 
 	describe('resizing', () => {

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.ts
@@ -244,11 +244,19 @@ class LunaticVariable {
 			return this.getSavedValue(iteration);
 		}
 
-		// For calculated variable, ignore iteration if the shapeFrom is not an array
+		const shapeFromValue = this.shapeFrom
+			? this.dictionary?.get(this.shapeFrom)?.getValue()
+			: null;
+		// If we want the root value of a calculated array, loop using the shapeFrom value
+		if (!iteration && Array.isArray(shapeFromValue)) {
+			return shapeFromValue.map((_, k) => this.getValue([k]));
+		}
+
+		// For calculated variable, ignore iteration if shapeFrom exists and is not an array
 		if (
+			// We have a calculated variable (not a simple expression)
 			this.name !== this.expression &&
-			(!this.shapeFrom ||
-				!Array.isArray(this.dictionary?.get(this.shapeFrom)?.getValue()))
+			!Array.isArray(shapeFromValue)
 		) {
 			iteration = undefined;
 		}


### PR DESCRIPTION
This is a complementary commit to fix the issue #809 

## Issue

We may want to get a calculated variable value at the end of a form with `getData()` for instance. But doing so we would en up getting a value 

```js
variables.set('FIRSTNAME', ['John', 'Jane']);
variables.set('LASTNAME', ['Doe', 'Dae']);
variables.setCalculated('FULLNAME', 'FIRSTNAME || " " || LASTNAME', {
    dependencies: ['FIRSTNAME', 'LASTNAME'],
    shapeFrom: 'FIRSTNAME',
});
variables.get('FULLNAME'); // Error since it cannot be calculated without specifying iteration
```

## Solution

Since we reintroduced shapeFrom we can now solve this issue using the `shapeFrom` value.

```js
variables.get('FULLNAME'); // ["John Doe", "Jane Dae"]
```