### PR TITLE
fix: cleaning on initial value

### DIFF
--- a/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
@@ -264,6 +264,21 @@ describe('lunatic-variables-store', () => {
 			variables.set('READY', false, { iteration: [1] });
 			expect(variables.get('PRENOM')).toEqual(['John', null, 'Marc']);
 		});
+		it('should clean variables with initial value at specific iteration', () => {
+			variables.set('PRENOM', ['John', 'Jane', 'Marc']);
+			variables.set('READY', [true, true, true]);
+			cleaningBehaviour(
+				variables,
+				{
+					READY: {
+						PRENOM: 'READY',
+					},
+				},
+				{ PRENOM: [null] }
+			);
+			variables.set('READY', false, { iteration: [1] });
+			expect(variables.get('PRENOM')).toEqual(['John', null, 'Marc']);
+		});
 	});
 
 	describe('missing', () => {


### PR DESCRIPTION
Cleaning was not using the index when setting the initial value so an array could be transformed incorrectly when a cleaning happened at a specific iteration

For instance a PRENOM with an initial [null] value would end up like this

```json
["John", "Jane", "Marc"] 
// Cleaning happened at index 1
["John", [null], "Marc"] 
``` 

A new test was added for this specific case.

Fix #817