### PR TITLE
📦️ Ajout du build au format ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@inseefr/lunatic",
-	"version": "0.2.3-prisme",
-	"workersVersion": "0.2.4-experimental",
+	"version": "0.3.0-prisme",
 	"description": "Library of questionnaire components",
 	"repository": {
 		"type": "git",
@@ -24,7 +23,13 @@
 	],
 	"license": "MIT",
 	"main": "lib/index.js",
-	"module": "src/index.js",
+	"module": "lib/index.esm.js",
+	"exports": {
+		".": {
+			"main": "./lib/index.js",
+			"module": "./lib/index.esm.js"
+		}
+	},
 	"files": [
 		"lib",
 		"src"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,16 +10,28 @@ const { dependencies } = require('./package.json');
 
 const config = {
 	input: 'src/components/index.js',
-	output: {
-		name: 'lunatic',
-		file: 'lib/index.js',
-		format: 'cjs',
-		strict: false,
-		globals: {
-			react: 'React',
+	output: [
+		{
+			name: 'lunatic',
+			file: 'lib/index.js',
+			format: 'cjs',
+			strict: false,
+			globals: {
+				react: 'React',
+			},
+			sourcemap: true,
 		},
-		sourcemap: true,
-	},
+		{
+			name: 'lunatic',
+			file: 'lib/index.esm.js',
+			format: 'esm',
+			strict: false,
+			globals: {
+				react: 'React',
+			},
+			sourcemap: true,
+		},
+	],
 	plugins: [
 		resolve(),
 		babel({


### PR DESCRIPTION
Bonjour,
Nous sommes passés à Vite.js et Node 20.
Vite attends que les modules soient en ESM par défaut
L'export en ESM était mal configuré dans Lunatic (il pointait vers un fichier qui n'existe pas : `src/index.js`)
J'ai ajouté un export ESM spécifique.