### PR TITLE
Fix IndexedDB deadlock Safari

### DIFF
--- a/public/demo.js
+++ b/public/demo.js
@@ -1,0 +1,8 @@
+setTimeout(() => {
+    console.log('done')
+    self.close()
+}, 5_000)
+
+let i = 0
+
+console.log('hello')

--- a/src/utils/store-tools/initStore.ts
+++ b/src/utils/store-tools/initStore.ts
@@ -15,6 +15,7 @@ export async function initStore(storeInfo: SuggesterType): Promise<boolean> {
 			CONSTANTES.STORE_INFO_NAME,
 			storeInfo
 		);
+		db.close();
 		return a && b && c;
 	}
 	return false;

--- a/src/utils/store-tools/open-or-create-store.ts
+++ b/src/utils/store-tools/open-or-create-store.ts
@@ -2,14 +2,13 @@
 import CONSTANTE from './constantes';
 import getIDB from '../idb-tools/get-idb';
 
-const IDB_REF = getIDB();
-
 function openStorage(name: string, idbVersion = 1): Promise<IDBDatabase> {
 	return new Promise(function (resolve, reject) {
-		if (!IDB_REF) {
+		const idb = getIDB();
+		if (!idb) {
 			reject('indexedDb not supported !');
 		}
-		const request = IDB_REF.open(name, idbVersion);
+		const request = idb.open(name, idbVersion);
 		let db: IDBDatabase;
 		let doIt = true;
 

--- a/src/utils/suggester-workers/append-to-index/append.worker.js
+++ b/src/utils/suggester-workers/append-to-index/append.worker.js
@@ -11,6 +11,7 @@ self.onmessage = function (e) {
 	append({ name, version, stopWords, fields }, version, entities, log).then(
 		function () {
 			self.postMessage('success');
+			self.close()
 		}
 	);
 };

--- a/src/utils/suggester-workers/append-to-index/append.worker.js
+++ b/src/utils/suggester-workers/append-to-index/append.worker.js
@@ -11,7 +11,6 @@ self.onmessage = function (e) {
 	append({ name, version, stopWords, fields }, version, entities, log).then(
 		function () {
 			self.postMessage('success');
-			self.close()
 		}
 	);
 };

--- a/src/utils/suggester-workers/searching/searching.js
+++ b/src/utils/suggester-workers/searching/searching.js
@@ -54,18 +54,26 @@ async function searching(search, { name, version = '1', meloto = true }) {
 	try {
 		if (isValideSearch(search)) {
 			const db = await getDb(name, version);
-			const info = await getEntity(db, CONSTANTES.STORE_INFO_NAME, name);
+			const info = await getEntity(db, CONSTANTES.STORE_INFO_NAME, name, 'readonly');
 			const { queryParser, max, order } = info;
 			const parser = await resolveQueryParser(queryParser);
+			const tokens = parser(search);
+
+			// Do not start a transaction if we have nothing to search
+			if (tokens.length === 0) {
+				return {
+					results: [],
+					search,
+					tokens
+				}
+			}
 			const transaction = db.transaction(
 				CONSTANTES.STORE_DATA_NAME,
 				'readonly'
 			);
 			const store = transaction.objectStore(CONSTANTES.STORE_DATA_NAME);
 			const index = store.index(CONSTANTES.STORE_INDEX_NAME);
-			const tokens = parser(search);
 			const documents = await searchTokens(tokens, index);
-
 			return {
 				results: prepare(
 					getOrderingFunction(order)(

--- a/src/utils/suggester-workers/searching/searching.js
+++ b/src/utils/suggester-workers/searching/searching.js
@@ -54,7 +54,7 @@ async function searching(search, { name, version = '1', meloto = true }) {
 	try {
 		if (isValideSearch(search)) {
 			const db = await getDb(name, version);
-			const info = await getEntity(db, CONSTANTES.STORE_INFO_NAME, name, 'readonly');
+			const info = await getEntity(db, CONSTANTES.STORE_INFO_NAME, name);
 			const { queryParser, max, order } = info;
 			const parser = await resolveQueryParser(queryParser);
 			const tokens = parser(search);


### PR DESCRIPTION
## Problème 

Sous certaines conditions le suggester se bloque sur Safari et la base de données IndexedDB se retrouvé verrouillé.

## Cause

Sur safari si une transactione est en cours elle bloque la base de données jusqu'à sa résolution. Il faut donc s'assurer de la mener au bout.

Dans le code de la recherche, une contrainte sur le nombre de caractère du token a été ajouté récemment sans prendre en compte l'impact dans le reste du code. Une transaction de recherche était créé mais n'était jamais éxécuté vu qu'il n'y avait pas de recherche.

## Solution

On vérifie avant de créer la transaction si il est nécessaire de faire une recherche.

## Remarque

Il est important lorsque l'on travaille avec IndexedDB et les workers de s'assurer de fermer les ressources qui sont utilisé. Cette MR s'assure aussi que les workers qui gère l'ajout à l'index soient fermée après l'indexation.

Fix #821