### PR TITLE
fix: "0" is wrongly considered as null in isEmpty function

### DIFF
--- a/src/use-lunatic/hooks/use-page-has-response.ts
+++ b/src/use-lunatic/hooks/use-page-has-response.ts
@@ -67,7 +67,7 @@ function isEmpty(value: unknown): boolean {
 	if (typeof value === 'object' && value !== null) {
 		return isEmpty(Object.values(value));
 	}
-	return !value;
+	return (value ?? '') === '';
 }
 
 /**


### PR DESCRIPTION
This PR resolves #831 