### PR TITLE
Allow Checkbox group in loop

### DIFF
--- a/src/components/loop/constant.ts
+++ b/src/components/loop/constant.ts
@@ -6,5 +6,4 @@ export const blockedInLoopComponents = [
 	'Loop',
 	'PairwiseLinks',
 	'Roundabout',
-	'CheckboxGroup',
 ];

--- a/src/utils/vtl.ts
+++ b/src/utils/vtl.ts
@@ -79,16 +79,17 @@ export function getExpressionType(expression: unknown): string {
 }
 
 export function getExpressionAsString(expression: unknown): string {
-	if (typeof expression === 'string') {
-		return expression;
+	if (typeof expression === 'string' || typeof expression === 'number') {
+		return expression.toString();
 	}
 	if (
 		expression &&
 		typeof expression === 'object' &&
 		'value' in expression &&
-		typeof expression.value === 'string'
+		(typeof expression.value === 'string' ||
+			typeof expression.value === 'number')
 	) {
-		return expression.value;
+		return expression.value.toString();
 	}
 	return '';
 }


### PR DESCRIPTION
Pour la version 2.7 j'ai mis en place un système qui bloque certains composant dans les boucles et j'avais ajouté les CheckboxGroup à cette liste (mais je ne me souviens plus pourquoi). J'ai retiré le composant de cette liste.

Aussi, dans la story CheckboxGroup/Loop on a une expression sous forme d'entier, ce cas n'était pas géré.

Fix #835