### PR TITLE
Remove "headers" for table to match Lunatic model

### DIFF
--- a/src/components/loop/roster-for-loop/roster-for-loop.tsx
+++ b/src/components/loop/roster-for-loop/roster-for-loop.tsx
@@ -31,7 +31,7 @@ export const RosterForLoop = createCustomizableLunaticField<
 		handleChange,
 		declarations,
 		label,
-		headers,
+		header,
 		iterations,
 		id,
 		getComponents,
@@ -71,7 +71,7 @@ export const RosterForLoop = createCustomizableLunaticField<
 			<DeclarationsBeforeText declarations={declarations} id={id} />
 			<DeclarationsAfterText declarations={declarations} id={id} />
 			<Table id={id}>
-				<TableHeader header={headers} id={id} />
+				<TableHeader header={header} id={id} />
 				<Tbody id={id}>
 					{times(nbRows, (n) => {
 						const components = getComponents(n);

--- a/src/components/type.ts
+++ b/src/components/type.ts
@@ -94,7 +94,7 @@ type ComponentPropsByType = {
 		getComponents: (n: number) => FilledLunaticComponentProps[];
 		executeExpression: LunaticState['executeExpression'];
 		value: Record<string, unknown[]>;
-		headers?: Array<{ label: ReactNode }>;
+		header?: Array<{ label: ReactNode }>;
 		paginatedLoop?: boolean;
 	};
 	Loop: LunaticBaseProps<unknown> & {
@@ -103,7 +103,7 @@ type ComponentPropsByType = {
 		getComponents: (n: number) => FilledLunaticComponentProps[];
 		executeExpression: LunaticState['executeExpression'];
 		value: Record<string, unknown[]>;
-		headers?: Array<{ label: ReactNode }>;
+		header?: Array<{ label: ReactNode }>;
 		paginatedLoop?: boolean;
 	};
 	Table: LunaticBaseProps<unknown> & {

--- a/src/stories/loop/source-with-header.json
+++ b/src/stories/loop/source-with-header.json
@@ -14,7 +14,7 @@
 		{
 			"id": "loop-prenom",
 			"componentType": "RosterForLoop",
-			"headers": [
+			"header": [
 				{ "headerCell": true, "label": "Prénom" },
 				{ "headerCell": true, "label": "Age" }
 			],

--- a/src/use-lunatic/commons/fill-components/fill-component-expressions.ts
+++ b/src/use-lunatic/commons/fill-components/fill-component-expressions.ts
@@ -26,7 +26,6 @@ const VTL_ATTRIBUTES = [
 	'xAxisIterations',
 	'yAxisIterations',
 	'conditionFilter',
-	'headers.label',
 	'header.label',
 	'disabled',
 	'readOnly',


### PR DESCRIPTION
A simple cleaning to avoid having to support both "header" and "headers".