### PR TITLE
fix: calculation of variable mixing array and aggregates

### DIFF
--- a/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
@@ -204,6 +204,17 @@ describe('lunatic-variables-store', () => {
 			);
 			expect(variables.get('FULLNAME')).toEqual(['John 1', 'Jane 2']);
 		});
+		it('should handle aggregate functions', () => {
+			variables.set('AGE', [1, 2, 3]);
+			variables.setCalculated('MAXAGE', 'max(AGE)');
+			variables.setCalculated('AGE_AND_MAX', 'AGE + MAXAGE', {
+				shapeFrom: 'AGE',
+			});
+			expect(variables.get('AGE_AND_MAX', [0])).toEqual(4);
+			variables.set('AGE', 12, { iteration: [1] });
+			expect(variables.get('AGE', [1])).toEqual(12);
+			expect(variables.get('AGE_AND_MAX', [0])).toEqual(13);
+		});
 	});
 
 	describe('resizing', () => {

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.ts
@@ -395,7 +395,12 @@ class LunaticVariable {
 			0,
 			...this.getDependencies().map(
 				(dep) =>
-					this.dictionary?.get(dep)?.updatedAt.get(iteration?.join('.')) ?? 0
+					// Check when a value at the same iteration was calculated
+					this.dictionary?.get(dep)?.updatedAt.get(iteration?.join('.')) ??
+					// For aggregated value (max / min) look the global updatedAt time
+					this.dictionary?.get(dep)?.updatedAt.get(undefined) ??
+					// Otherwise this is a static value that never changes
+					0
 			)
 		);
 		return (


### PR DESCRIPTION
When calculating a variable, we check if the updated time of the dependencies for a specific iteration. Unfortunately, for aggregate aggregate function there is no "updated time at index X". 

If a variable calculated inside a loop used aggregate variable it was not working as expected. I added a new test to handle this use case.

Fix #848