### PR TITLE
fix: row control

### DIFF
--- a/src/use-lunatic/commons/compile-controls.ts
+++ b/src/use-lunatic/commons/compile-controls.ts
@@ -59,7 +59,6 @@ function checkComponents(
 				(c) => c.type === ControlTypeEnum.row
 			);
 			if (rowControls?.length) {
-				console.log('ERROR', component);
 				errors = checkComponentInLoop(
 					state,
 					{ ...component, controls: rowControls },

--- a/src/use-lunatic/reducer/commons/index.ts
+++ b/src/use-lunatic/reducer/commons/index.ts
@@ -1,3 +1,2 @@
 export { default as resizeArrayVariable } from './resize-array-variable';
-export { isLoopComponent } from './is-loop-component';
 export * from './validate-condition-filter';

--- a/src/use-lunatic/reducer/commons/is-loop-component.ts
+++ b/src/use-lunatic/reducer/commons/is-loop-component.ts
@@ -1,9 +1,0 @@
-import type { LunaticComponentDefinition } from '../../type';
-
-export const isLoopComponent = (
-	component: LunaticComponentDefinition
-): component is LunaticComponentDefinition & {
-	componentType: 'Loop' | 'RosterForLoop';
-} => {
-	return ['Loop', 'RosterForLoop'].includes(component.componentType);
-};


### PR DESCRIPTION
When compiling controls sometimes the component were already filled causing a problem with the check.

```js
// conditionFilter = true, and we interpret undefined, that return falsy value
if (component.conditionFilter && !interpret(component.conditionFilter.value)) {
    // Skip check
}
```

It was true since the component was already filled.

## Extra

I remove isLoopComponent external method since it was only used in this file.