### PR TITLE
fix: primitive interpretation in loop

### DIFF
--- a/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
@@ -215,6 +215,12 @@ describe('lunatic-variables-store', () => {
 			expect(variables.get('AGE', [1])).toEqual(12);
 			expect(variables.get('AGE_AND_MAX', [0])).toEqual(13);
 		});
+		it('should handle primitive value', () => {
+			variables.run('"hello"', { iteration: [0] });
+			variables.run('"hello"', { iteration: [1] });
+			expect(variables.run('"hello"')).toEqual('hello');
+			expect(variables.interpretCount).toBe(1);
+		});
 	});
 
 	describe('resizing', () => {

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.ts
@@ -263,6 +263,11 @@ class LunaticVariable {
 
 		// Calculate bindings first to refresh "updatedAt" on calculated dependencies
 		const bindings = this.getDependenciesValues(iteration);
+		// A variable without binding is a primitive (string, boolean...)
+		// it yields the same results for every iteration, so we can ignore iteration
+		if (Object.keys(bindings).length === 0) {
+			iteration = undefined;
+		}
 		if (!this.isOutdated(iteration)) {
 			return this.getSavedValue(iteration);
 		}


### PR DESCRIPTION
## Issue

When interpreting a variable we store the value to avoid having to recalculate. To handle loop we save every value calculated for every index. The expression "Oui" is saved like this

```
[0] Oui
[1] Oui
[2] Oui
```

Then when we asked for the value without specifying iteration the result was  `['Oui', 'Oui', 'Oui']`.

## Solution

Variable without bindings should ignore the iteration since they will return the same value everytime.


Fix #855