### PR TITLE
Cast variable as primitive

### DIFF
--- a/src/use-lunatic/commons/execute-condition-filter.ts
+++ b/src/use-lunatic/commons/execute-condition-filter.ts
@@ -1,5 +1,6 @@
 import getCompatibleVTLExpression from './get-compatible-vtl-expression';
 import type { LunaticExpression, LunaticState } from '../type';
+import { firstItem } from '../../utils/array';
 
 function executeConditionFilter(
 	filter: LunaticExpression,
@@ -8,7 +9,9 @@ function executeConditionFilter(
 ) {
 	if (filter && typeof execute === 'function') {
 		const { value } = filter;
-		return execute(getCompatibleVTLExpression(value), { iteration });
+		const result = execute(getCompatibleVTLExpression(value), { iteration });
+		// Todo : replace this with a casting system on execute
+		return Array.isArray(result) ? firstItem(result) : result;
 	}
 	return undefined;
 }

--- a/src/use-lunatic/commons/fill-components/fill-component-expressions.ts
+++ b/src/use-lunatic/commons/fill-components/fill-component-expressions.ts
@@ -5,6 +5,7 @@ import type {
 	LunaticExpression,
 	LunaticState,
 } from '../../type';
+import { firstItem } from '../../../utils/array';
 
 const VTL_ATTRIBUTES = [
 	'label',
@@ -54,11 +55,13 @@ function createCrawl({
 	function executeAndFillObject(object: Record<string, unknown>, path: string) {
 		const candidate = object[path];
 		try {
+			const result = executeExpression(candidate, {
+				iteration: linksIterations ?? iteration,
+			});
 			return {
 				...object,
-				[path]: executeExpression(candidate, {
-					iteration: linksIterations ?? iteration,
-				}),
+				// Todo : replace this with a casting system on execute
+				[path]: Array.isArray(result) ? firstItem(result) : result,
 			};
 		} catch (e) {
 			return {

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -69,3 +69,15 @@ export function resizeArray<T = unknown>(
 			return index < array.length ? array[index] : value;
 		}, []);
 }
+
+export function firstItem<T = unknown>(items: T | T[]): T {
+	if (!Array.isArray(items)) {
+		return items;
+	}
+	for (const item of items) {
+		if (item !== undefined) {
+			return item;
+		}
+	}
+	return undefined as T;
+}


### PR DESCRIPTION
In some case calculated variables are resolved as array since they were calculated at a specific iteration. 
When resolving variables in some context we expect primitive variables (label, conditionFilter...) so we be smart and cast value to primitive.

Fix #864

## Evolution

We could add a casting system on executeExpression cause in many situation we know what to expect (label, min, max, iterations...).

```js
executeExpression(expr, {
    type: Boolean
})
```