### PR TITLE
Handle update timestamp for 2D+ Arrays

### DIFF
--- a/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
@@ -221,6 +221,19 @@ describe('lunatic-variables-store', () => {
 			expect(variables.run('"hello"')).toEqual('hello');
 			expect(variables.interpretCount).toBe(1);
 		});
+		it('should handle deep refresh', () => {
+			variables.set('LIENS', [
+				['17', null],
+				[null, '17'],
+			]);
+			variables.setCalculated('IS_12', 'if ("12" in LIENS) then 1 else 0', {
+				dependencies: ['LIENS'],
+				shapeFrom: 'LIENS',
+			});
+			expect(variables.get('IS_12', [0])).toBe(0);
+			variables.set('LIENS', '12', { iteration: [0, 0] });
+			expect(variables.get('IS_12', [0])).toBe(1);
+		});
 	});
 
 	describe('resizing', () => {

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.ts
@@ -6,7 +6,7 @@ import { getInitialVariableValue } from '../../../utils/variables';
 import { resizingBehaviour } from './behaviours/resizing-behaviour';
 import { cleaningBehaviour } from './behaviours/cleaning-behaviour';
 import { missingBehaviour } from './behaviours/missing-behaviour';
-import { setAtIndex, times } from '../../../utils/array';
+import { setAtIndex, subArrays, times } from '../../../utils/array';
 import { isNumber } from '../../../utils/number';
 
 // Interpret counter, used for testing purpose
@@ -286,8 +286,7 @@ class LunaticVariable {
 				).toString()}`
 			);
 		}
-		this.calculatedAt.set(iteration?.join('.'), performance.now());
-		this.calculatedAt.set(undefined, performance.now());
+		this.updateTimestamps(iteration, 'calculatedAt');
 		return this.getSavedValue(iteration);
 	}
 
@@ -309,13 +308,19 @@ class LunaticVariable {
 		this.value = !Array.isArray(iteration)
 			? value
 			: setAtIndex(this.value, iteration, value);
-		if (value === undefined) {
-			this.updatedAt.delete(iteration?.join('.'));
-		} else {
-			this.updatedAt.set(iteration?.join('.'), performance.now());
-		}
-		this.updatedAt.set(undefined, performance.now());
+		this.updateTimestamps(iteration, 'updatedAt');
 		return true;
+	}
+
+	private updateTimestamps(
+		iteration: IterationLevel | undefined,
+		key: 'updatedAt' | 'calculatedAt'
+	) {
+		// Update parent iteration level timestamp
+		for (const subIteration of subArrays(iteration)) {
+			this[key].set(subIteration.join('.'), performance.now());
+		}
+		this[key].set(undefined, performance.now());
 	}
 
 	private setValueForArray(value: unknown[]) {

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -81,3 +81,23 @@ export function firstItem<T = unknown>(items: T | T[]): T {
 	}
 	return undefined as T;
 }
+
+/**
+ * Return a list of partial array
+ *
+ * Example :
+ * - subArray([1, 2, 3]) // [[1], [1, 2], [1, 2, 3]]
+ */
+export function subArrays<T = unknown>(items: T[] | T): T[][] {
+	if (!Array.isArray(items)) {
+		return [];
+	}
+	if (items.length === 1) {
+		return [items];
+	}
+	const arrays = [] as T[][];
+	for (let i = 1; i <= items.length; i++) {
+		arrays.push(items.slice(0, i));
+	}
+	return arrays;
+}


### PR DESCRIPTION
Quand un questionnaire contient un lien 2 à 2 le refresh des variables ne s'opéré pas correctement dans le cas d'une mise à jour en profondeur. Le test décrit le scénario qui était problématique.

Fix #862