### PR TITLE
Disable cache for expression

### DIFF
--- a/src/use-lunatic/commons/execute-condition-filter.ts
+++ b/src/use-lunatic/commons/execute-condition-filter.ts
@@ -1,6 +1,6 @@
 import getCompatibleVTLExpression from './get-compatible-vtl-expression';
 import type { LunaticExpression, LunaticState } from '../type';
-import { firstItem } from '../../utils/array';
+import { firstValueItem } from '../../utils/array';
 
 function executeConditionFilter(
 	filter: LunaticExpression,
@@ -11,7 +11,7 @@ function executeConditionFilter(
 		const { value } = filter;
 		const result = execute(getCompatibleVTLExpression(value), { iteration });
 		// Todo : replace this with a casting system on execute
-		return Array.isArray(result) ? firstItem(result) : result;
+		return Array.isArray(result) ? firstValueItem(result) : result;
 	}
 	return undefined;
 }

--- a/src/use-lunatic/commons/fill-components/fill-component-expressions.ts
+++ b/src/use-lunatic/commons/fill-components/fill-component-expressions.ts
@@ -5,7 +5,7 @@ import type {
 	LunaticExpression,
 	LunaticState,
 } from '../../type';
-import { firstItem } from '../../../utils/array';
+import { firstValueItem } from '../../../utils/array';
 
 const VTL_ATTRIBUTES = [
 	'label',
@@ -61,7 +61,7 @@ function createCrawl({
 			return {
 				...object,
 				// Todo : replace this with a casting system on execute
-				[path]: Array.isArray(result) ? firstItem(result) : result,
+				[path]: Array.isArray(result) ? firstValueItem(result) : result,
 			};
 		} catch (e) {
 			return {

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
@@ -43,6 +43,7 @@ describe('lunatic-variables-store', () => {
 		variables.set('LASTNAME', 'Doe');
 		variables.setCalculated('FULLNAME', 'FIRSTNAME || " " || LASTNAME', {
 			dependencies: ['FIRSTNAME', 'LASTNAME'],
+			shapeFrom: 'FIRSTNAME',
 		});
 		expect(variables.get('FULLNAME')).toEqual('John Doe');
 		expect(variables.interpretCount).toBe(1);
@@ -61,9 +62,11 @@ describe('lunatic-variables-store', () => {
 		variables.set('AGE', '18');
 		variables.setCalculated('FULLNAME', 'FIRSTNAME || " " || LASTNAME', {
 			dependencies: ['FIRSTNAME', 'LASTNAME'],
+			shapeFrom: 'FIRSTNAME',
 		});
 		variables.setCalculated('LABEL', 'FULLNAME || " is " || AGE', {
 			dependencies: ['FULLNAME', 'AGE'],
+			shapeFrom: 'FULLNAME',
 		});
 		expect(variables.get('LABEL')).toEqual('John Doe is 18');
 		expect(variables.interpretCount).toBe(2);
@@ -91,7 +94,7 @@ describe('lunatic-variables-store', () => {
 		variables.set('LASTNAME', 'Doe');
 		expect(variables.run('FIRSTNAME || " " || LASTNAME')).toEqual('John Doe');
 		expect(variables.run('FIRSTNAME || " " || LASTNAME')).toEqual('John Doe');
-		expect(variables.interpretCount).toBe(1);
+		expect(variables.interpretCount).toBe(2);
 		variables.set('FIRSTNAME', 'Jane');
 		expect(variables.run('FIRSTNAME || " " || LASTNAME')).toEqual('Jane Doe');
 	});
@@ -219,7 +222,7 @@ describe('lunatic-variables-store', () => {
 			variables.run('"hello"', { iteration: [0] });
 			variables.run('"hello"', { iteration: [1] });
 			expect(variables.run('"hello"')).toEqual('hello');
-			expect(variables.interpretCount).toBe(1);
+			expect(variables.interpretCount).toBe(3);
 		});
 		it('should handle deep refresh', () => {
 			variables.set('LIENS', [

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.ts
@@ -268,7 +268,7 @@ class LunaticVariable {
 		if (Object.keys(bindings).length === 0) {
 			iteration = undefined;
 		}
-		if (!this.isOutdated(iteration)) {
+		if (this.shapeFrom && !this.isOutdated(iteration)) {
 			return this.getSavedValue(iteration);
 		}
 		if (isTestEnv()) {

--- a/src/utils/array.spec.ts
+++ b/src/utils/array.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resizeArray, setAtIndex } from './array';
+import { firstValueItem, resizeArray, setAtIndex } from './array';
 
 describe('array', () => {
 	describe('resizeArray()', () => {
@@ -39,5 +39,10 @@ describe('array', () => {
 		it('should work with deep and non array value', () => {
 			expect(setAtIndex([null], [1, 2], 10)).toEqual([null, [null, null, 10]]);
 		});
+	});
+	it('firstValueItem', () => {
+		expect(firstValueItem([0, 1, 2])).toBe(0);
+		expect(firstValueItem([null, 1, 2])).toBe(1);
+		expect(firstValueItem([null, undefined, false])).toBe(false);
 	});
 });

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -70,12 +70,15 @@ export function resizeArray<T = unknown>(
 		}, []);
 }
 
-export function firstItem<T = unknown>(items: T | T[]): T {
+/**
+ * Return the first non null/undefined value of an array
+ */
+export function firstValueItem<T = unknown>(items: T | T[]): T {
 	if (!Array.isArray(items)) {
 		return items;
 	}
 	for (const item of items) {
-		if (item !== undefined) {
+		if (item !== undefined && item !== null) {
 			return item;
 		}
 	}

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -73,16 +73,11 @@ export function resizeArray<T = unknown>(
 /**
  * Return the first non null/undefined value of an array
  */
-export function firstValueItem<T = unknown>(items: T | T[]): T {
+export function firstValueItem<T = unknown>(items: T | T[]): T | undefined {
 	if (!Array.isArray(items)) {
 		return items;
 	}
-	for (const item of items) {
-		if (item !== undefined && item !== null) {
-			return item;
-		}
-	}
-	return undefined as T;
+	return items.find((v) => v !== undefined && v !== null);
 }
 
 /**


### PR DESCRIPTION
Caching VTL expression evaluation cause problems since we can't predict the shape of the variable (we still keep the cache for calculated variable).

## Issue

We have an expression used to clean a global variable attached to a loop variable

```
  "cleaning": {
    "COMBIENA": {
      "QUESTION1": "(nvl(SUMA,0) > 0)"
    },
}
```

- COMBIENA is used in a loop
- SUMA is an aggregation

When filling the form, the cleaning assume we are cleaning each iteration individually, meaning we end up caching `(nvl(SUMA,0) > 0)` as an array. If I fill 0 for the first iteration then 1 for the second I end up with 

```
(nvl(SUMA,0) > 0) // [false, true]
```

Later when we use this same expression for a conditionFilter for instance the system cannot determine which value to use.

For **CALCULATED** variable the problem does not happens since we have a shapeFrom that helps use choosing if we need to deal with an array or a primitive value.

## Advanced solution

I prefer disabling the cache system for expression since it's the simplest solution but another solution would be to create shapeFrom on the fly (if an expression is used outside of a loop we could safely assume we are dealing with something that is not an array).