### PR TITLE
fix: cleaning when top level variable involved

### DIFF
--- a/src/use-lunatic/commons/variables/behaviours/cleaning-behaviour.ts
+++ b/src/use-lunatic/commons/variables/behaviours/cleaning-behaviour.ts
@@ -1,5 +1,6 @@
 import type { LunaticVariablesStore } from '../lunatic-variables-store';
 import type { LunaticSource } from '../../../type-source';
+import { depth } from '../../../../utils/array';
 
 /**
  * Cleaning behaviour for the store
@@ -35,11 +36,18 @@ export function cleaningBehaviour(
 					continue;
 				}
 
+				// Variable may be top level, so we need to deduce expected iteration
+				const variableDepth = depth(initialValues[variableName]);
+				const variableIteration =
+					variableDepth === 0
+						? undefined
+						: iteration?.slice(0, depth(initialValues[variableName]));
+
 				store.set(
 					variableName,
-					getValueAtIteration(initialValues[variableName], iteration),
+					getValueAtIteration(initialValues[variableName], variableIteration),
 					{
-						iteration,
+						iteration: variableIteration,
 					}
 				);
 			} catch (e) {

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
@@ -273,11 +273,15 @@ describe('lunatic-variables-store', () => {
 		it('should clean variables at a specific iteration', () => {
 			variables.set('PRENOM', ['John', 'Jane', 'Marc']);
 			variables.set('READY', [true, true, true]);
-			cleaningBehaviour(variables, {
-				READY: {
-					PRENOM: 'READY',
+			cleaningBehaviour(
+				variables,
+				{
+					READY: {
+						PRENOM: 'READY',
+					},
 				},
-			});
+				{ PRENOM: [null] }
+			);
 			variables.set('READY', false, { iteration: [1] });
 			expect(variables.get('PRENOM')).toEqual(['John', null, 'Marc']);
 		});
@@ -295,6 +299,21 @@ describe('lunatic-variables-store', () => {
 			);
 			variables.set('READY', false, { iteration: [1] });
 			expect(variables.get('PRENOM')).toEqual(['John', null, 'Marc']);
+		});
+		it('should clean root variables even when in an iteration', () => {
+			variables.set('PRENOM', 'John');
+			variables.set('READY', [true, true, true]);
+			cleaningBehaviour(
+				variables,
+				{
+					READY: {
+						PRENOM: 'READY',
+					},
+				},
+				{ PRENOM: null }
+			);
+			variables.set('READY', false, { iteration: [1] });
+			expect(variables.get('PRENOM')).toEqual(null);
 		});
 	});
 

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -81,3 +81,13 @@ export function firstItem<T = unknown>(items: T | T[]): T {
 	}
 	return undefined as T;
 }
+
+/**
+ * Calculates the depth of an array
+ */
+export function depth(arr: unknown, base = 0) {
+	if (!Array.isArray(arr)) {
+		return base;
+	}
+	return depth(arr[0], base + 1);
+}


### PR DESCRIPTION
Dans certains cas une cleaning se déroule à une iteration spécifique mais "clean" une variable de niveau supérieur. Le système ne prenait pas en compte ce cas et partait du principe que la variable nettoyé était au même niveau. 

Fix #873