### PR TITLE
Feat/public path worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ Lunatic uses webWorkers to take the load off the main execution frame (e.g. list
 
 Workers are normally installed when the library is installed (postinstall scripts). If this is not the case, you can always manually run the command `npx @inseefr/lunatic workers` at the root of your project to add Lunatic workers to your project.
 
-Lunatic workers are added to the `public/workers` folder of the current project when the library is installed.
+By default: Lunatic workers are added to the `public/workers` folder of the current project when the library is installed.
+If you want to install inside another folder, just run `npx @inseefr/lunatic workers my-custom-folder`. Workers will be available to the `my-custom-folder/workers` folder of the current project.
 
 If a new version of Lunatic offers new workers, they will be automatically updated.
 This ensures that you always have the right version of workers for the version of Lunatic you're using.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@inseefr/lunatic",
-	"version": "2.7.18",
+	"version": "2.7.19",
 	"workersVersion": "0.3.0",
 	"description": "Library of questionnaire components",
 	"repository": {

--- a/scripts/build/workers-paths.js
+++ b/scripts/build/workers-paths.js
@@ -3,7 +3,15 @@ const path = require('path');
 
 const version = lunaticPackageJson.workersVersion;
 
-const currentPublicFolder = path.resolve(`${process.cwd()}/public/workers`);
+/**
+ * process.argv return an array, for example, for this command "node ./my-script.js hello"
+ * process.argv = ["node", ""./my-script.js", "hello"]
+ */
+const getPublicFolder = () => process.argv[2] || 'public';
+
+const currentPublicFolder = path.resolve(
+	`${process.cwd()}/${getPublicFolder()}/workers`
+);
 const workersReleaseFolder = path.resolve(__dirname, '../../workers-release');
 
 const workersPath = {

--- a/scripts/build/workers-paths.js
+++ b/scripts/build/workers-paths.js
@@ -5,7 +5,7 @@ const version = lunaticPackageJson.workersVersion;
 
 /**
  * process.argv return an array, for example, for this command "node ./my-script.js hello"
- * process.argv = ["node", ""./my-script.js", "hello"]
+ * process.argv = ["node", "./my-script.js", "hello"], process.argv[2] = "hello" (or undefined if no argument)
  */
 const getPublicFolder = () => process.argv[2] || 'public';
 

--- a/src/utils/suggester-workers/worker-path.ts
+++ b/src/utils/suggester-workers/worker-path.ts
@@ -8,7 +8,7 @@ export enum WorkerEnum {
 
 const version = packageInfo.workersVersion;
 
-const DEFAULT_BASE_PATH = 'workers';
+const DEFAULT_BASE_PATH = `${window.location.origin}/workers`;
 const WORKER_PATH = {
 	APPEND: `lunatic-append-worker-${version}.js`,
 	SEARCH: `lunatic-search-worker-${version}.js`,


### PR DESCRIPTION
- By default: Lunatic workers are added to the `public/workers` folder of the current project when the library is installed.
If you want to install inside another folder, just run `npx @inseefr/lunatic workers my-custom-folder`. Workers will be available to the `my-custom-folder/workers` folder of the current project.

- If app is running under `http://localhost/absc/sdfs`, workers are loaded from `http://localhost/absc/sdfs/workers` instead of `http://localhost/workers`. This PR fix this issue.