### PR TITLE
POC : Multiple variables with suggesters

### DIFF
--- a/src/components/Suggester/CustomSuggester.tsx
+++ b/src/components/Suggester/CustomSuggester.tsx
@@ -11,19 +11,22 @@ type Props = {
 	className?: string;
 	classNamePrefix?: string;
 	placeholder?: string;
-	onSelect: (s: string | null) => void;
+	onSelect: (
+		option: string | null | { id?: string; [key: string]: ReactNode }
+	) => void;
 	value: string | null;
 	labelRenderer: LunaticComponentProps<'Suggester'>['labelRenderer'];
 	optionRenderer: LunaticComponentProps<'Suggester'>['optionRenderer'];
 	disabled?: boolean;
 	readOnly?: boolean;
 	id?: string;
-	searching: (
+	searching?: (
 		s: string | null
 	) => Promise<{ results: ComboboxOptionType[]; search: string }>;
 	label?: ReactNode;
 	description?: ReactNode;
 	errors?: LunaticError[];
+	defaultOptions?: ComboboxOptionType[];
 };
 
 export const CustomSuggester = slottableComponent<Props>(
@@ -43,14 +46,17 @@ export const CustomSuggester = slottableComponent<Props>(
 		label,
 		description,
 		errors,
+		defaultOptions,
 	}) => {
 		const [search, setSearch] = useState('');
-		const [options, setOptions] = useState<Array<ComboboxOptionType>>([]);
+		const [options, setOptions] = useState<Array<ComboboxOptionType>>(
+			defaultOptions ?? []
+		);
 		const lastSearch = useRef('');
 
 		const handleSelect = useCallback(
-			function (id: string | null) {
-				onSelect(id ? id : null);
+			(id: string | null) => {
+				onSelect(id ? options.find((o) => o.id === id)! : null);
 			},
 			[onSelect]
 		);
@@ -67,7 +73,7 @@ export const CustomSuggester = slottableComponent<Props>(
 						onSelect(search);
 					}
 				} else {
-					setOptions([]);
+					setOptions(defaultOptions ?? []);
 					onSelect(null);
 					setSearch('');
 				}

--- a/src/components/shared/Combobox/Combobox.tsx
+++ b/src/components/shared/Combobox/Combobox.tsx
@@ -31,6 +31,7 @@ type Props = ComboboxSelectionProps &
 		errors?: LunaticError[];
 		onChange?: (s: string | null) => void;
 		onSelect: (s: string | null) => void;
+		onBlur?: () => void;
 		options: ComboboxOptionType[];
 		readOnly?: boolean;
 	};
@@ -56,6 +57,7 @@ function LunaticComboBox({
 	label,
 	description,
 	errors,
+	onBlur,
 }: Props) {
 	const [expanded, setExpanded] = useState(false);
 	const [focused, setFocused] = useState(false);
@@ -76,6 +78,7 @@ function LunaticComboBox({
 		if (disabled || readOnly) {
 			return;
 		}
+		onBlur?.();
 		setExpanded(false);
 		setFocused(false);
 	};

--- a/src/components/type.ts
+++ b/src/components/type.ts
@@ -216,6 +216,9 @@ type ComponentPropsByType = {
 		idbVersion?: string;
 		focused: boolean;
 		response: { name: string };
+		optionResponses?: { name: string; attribute: string }[];
+		executeExpression: LunaticState['executeExpression'];
+		iteration: LunaticState['pager']['iteration'];
 	};
 	Summary: LunaticBaseProps<string | null> & {
 		executeExpression: LunaticState['executeExpression'];

--- a/src/stories/suggester/fakeReferentiel.json
+++ b/src/stories/suggester/fakeReferentiel.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "brosse",
+    "label": "Brosse à cheveux",
+    "price": 20
+  },
+  {
+    "id": "balle",
+    "label": "Balle rebondissante",
+    "price": 10
+  }
+]

--- a/src/stories/suggester/fakeReferentiel.json
+++ b/src/stories/suggester/fakeReferentiel.json
@@ -1,12 +1,12 @@
 [
-  {
-    "id": "brosse",
-    "label": "Brosse à cheveux",
-    "price": 20
-  },
-  {
-    "id": "balle",
-    "label": "Balle rebondissante",
-    "price": 10
-  }
+	{
+		"id": "brosse",
+		"label": "Brosse à cheveux",
+		"price": 20
+	},
+	{
+		"id": "balle",
+		"label": "Balle rebondissante",
+		"price": 10
+	}
 ]

--- a/src/stories/suggester/source-option-responses.json
+++ b/src/stories/suggester/source-option-responses.json
@@ -1,0 +1,142 @@
+{
+	"suggesters": [
+		{
+			"name": "products",
+			"fields": [
+				{
+					"name": "label",
+					"rules": ["[\\w]+"],
+					"language": "French",
+					"min": 3,
+					"stemmer": false
+				}
+			],
+			"queryParser": {
+				"type": "tokenized",
+				"params": {
+					"language": "French",
+					"pattern": "[\\w.]+",
+					"min": 3,
+					"stemmer": false
+				}
+			},
+			"version": "1"
+		}
+	],
+	"components": [
+		{
+			"componentType": "Suggester",
+			"response": {
+				"name": "PRODUCT"
+			},
+			"optionResponses": [{
+				"name": "PRODUCT_NAME",
+				"attribute": "label"
+			},{
+				"name": "PRODUCT_PRICE",
+				"attribute": "price"
+			}],
+			"storeName": "products",
+			"conditionFilter": {
+				"type": "VTL",
+				"value": "true"
+			},
+			"id": "lt4ezymk",
+			"page": "1",
+			"label": {
+				"type": "VTL|MD",
+				"value": "\"➡ 1. \" || \"Quel est votre produit préféré ?\""
+			},
+			"mandatory": false,
+			"maxLength": 249
+		},
+		{
+			"componentType": "Input",
+			"response": {
+				"name": "NOM"
+			},
+			"conditionFilter": {
+				"type": "VTL",
+				"value": "true"
+			},
+			"id": "prenom",
+			"page": "2",
+			"label": {
+				"type": "VTL|MD",
+				"value": "\"➡ 2. Vous aimez \" || PRODUCT_NAME || \" mais quel est votre prénom ?\""
+			},
+			"mandatory": false,
+			"maxLength": 249
+		}
+	],
+	"pagination": "question",
+	"resizing": {},
+	"label": {
+		"type": "VTL|MD",
+		"value": "Suggester"
+	},
+	"lunaticModelVersion": "2.5.0",
+	"modele": "SUGGESTER",
+	"enoCoreVersion": "2.7.1",
+	"generatingDate": "27-02-2024 13:43:43",
+	"missing": false,
+	"id": "lt4f6mib",
+	"maxPage": "2",
+	"variables": [
+		{
+			"variableType": "COLLECTED",
+			"values": {
+				"COLLECTED": null,
+				"EDITED": null,
+				"INPUTED": null,
+				"FORCED": null,
+				"PREVIOUS": null
+			},
+			"name": "PRODUCT"
+		},
+		{
+			"variableType": "COLLECTED",
+			"values": {
+				"COLLECTED": null,
+				"EDITED": null,
+				"INPUTED": null,
+				"FORCED": null,
+				"PREVIOUS": null
+			},
+			"name": "PRODUCT_PRICE"
+		},
+		{
+			"variableType": "COLLECTED",
+			"values": {
+				"COLLECTED": null,
+				"EDITED": null,
+				"INPUTED": null,
+				"FORCED": null,
+				"PREVIOUS": null
+			},
+			"name": "PRODUCT_NAME"
+		},
+		{
+			"variableType": "COLLECTED",
+			"values": {
+				"COLLECTED": null,
+				"EDITED": null,
+				"INPUTED": null,
+				"FORCED": null,
+				"PREVIOUS": null
+			},
+			"name": "PRODUCT_PRICE"
+		},
+		{
+			"variableType": "COLLECTED",
+			"values": {
+				"COLLECTED": null,
+				"EDITED": null,
+				"INPUTED": null,
+				"FORCED": null,
+				"PREVIOUS": null
+			},
+			"name": "PRENOM"
+		}
+	]
+}

--- a/src/stories/suggester/source-option-responses.json
+++ b/src/stories/suggester/source-option-responses.json
@@ -29,13 +29,16 @@
 			"response": {
 				"name": "PRODUCT"
 			},
-			"optionResponses": [{
-				"name": "PRODUCT_NAME",
-				"attribute": "label"
-			},{
-				"name": "PRODUCT_PRICE",
-				"attribute": "price"
-			}],
+			"optionResponses": [
+				{
+					"name": "PRODUCT_NAME",
+					"attribute": "label"
+				},
+				{
+					"name": "PRODUCT_PRICE",
+					"attribute": "price"
+				}
+			],
 			"storeName": "products",
 			"conditionFilter": {
 				"type": "VTL",

--- a/src/stories/suggester/source-option-responses.json
+++ b/src/stories/suggester/source-option-responses.json
@@ -63,7 +63,7 @@
 			"page": "2",
 			"label": {
 				"type": "VTL|MD",
-				"value": "\"➡ 2. Vous aimez \" || PRODUCT_NAME || \" mais quel est votre prénom ?\""
+				"value": "\"➡ 2. Vous aimez \" || PRODUCT_NAME || \" à \" || cast(PRODUCT_PRICE, string) || \"€ mais quel est votre prénom ?\""
 			},
 			"mandatory": false,
 			"maxLength": 249

--- a/src/stories/suggester/suggester.stories.jsx
+++ b/src/stories/suggester/suggester.stories.jsx
@@ -3,6 +3,7 @@ import defaultArgTypes from '../utils/default-arg-types';
 import Orchestrator from '../utils/orchestrator';
 import { getReferentiel } from '../utils/referentiel';
 import source from './source';
+import sourceOptionResponses from './source-option-responses';
 
 const stories = {
 	title: 'Components/Suggester',
@@ -15,10 +16,27 @@ export default stories;
 const Template = (args) => <Orchestrator {...args} />;
 export const Default = Template.bind({});
 
+const getFakeReferentiel = async (name) => {
+	try {
+		return (await import(`./fakeReferentiel.json`)).default;
+	} catch (error) {
+		console.log('error', error);
+		throw new Error(`Unknown référentiel ${name}`);
+	}
+};
+
 Default.args = {
 	id: 'suggester',
 	source,
 	autoSuggesterLoading: true,
 	getReferentiel,
+	pagination: true,
+};
+export const OptionResponses = Template.bind({});
+OptionResponses.args = {
+	id: 'suggester-with-option',
+	source: sourceOptionResponses,
+	getReferentiel: getFakeReferentiel,
+	autoSuggesterLoading: true,
 	pagination: true,
 };


### PR DESCRIPTION
# POC

Démonstration d'une solution possible pour le cas d'un suggester qui permet de sélectionner plusieurs infos. 

## Modélisation

On ajouterais une propriété "optionResponses" au JSON qui permettrait d'associer une propriété du référentiel à une variable dans Lunatic.

```json
	"optionResponses": [{
		"name": "PRODUCT_NAME",
		"attribute": "label"
	},{
		"name": "PRODUCT_PRICE",
		"attribute": "price"
	}],
```

La clef "response" serait toujours utilisé pour sauvegardé l'id sélectionnée.

## Story

La nouvelle story est visible via http://localhost:9999/?path=/story/components-suggester--option-responses

## Related issues

- https://github.com/InseeFr/Pogues/issues/700