### PR TITLE
fix: hasPageResponse for unchecked checkbox (2.7)

### DIFF
--- a/src/use-lunatic/hooks/use-page-has-response.ts
+++ b/src/use-lunatic/hooks/use-page-has-response.ts
@@ -83,7 +83,7 @@ function isEmpty(value: unknown): boolean {
 	if (typeof value === 'object' && value !== null) {
 		return isEmpty(Object.values(value));
 	}
-	return (value ?? '') === '';
+	return (value ?? '') === '' || value === false;
 }
 
 /**


### PR DESCRIPTION
Fix hasPageResponse() for empty checkbox on 2.7

Fix #946