### PR TITLE
Fix/controls not showing

### DIFF
--- a/src/use-lunatic/reducer/controls/check-base-control.ts
+++ b/src/use-lunatic/reducer/controls/check-base-control.ts
@@ -6,15 +6,19 @@ import type {
 } from '../../type';
 
 export function checkBaseControl(
-	control: LunaticControl,
+	controlItem: LunaticControl,
 	executeExpression: LunaticReducerState['executeExpression'],
 	pager: LunaticReducerState['pager']
 ): LunaticError | undefined {
 	const { iteration, linksIterations } = pager;
-	const { criticality, errorMessage, id, typeOfControl } = control;
-	const value = control?.control?.value ?? 'true';
+	const { criticality, errorMessage, id, typeOfControl, control } = controlItem;
 
-	const result = executeExpression(value, {
+	// There is no control expression for this control (this is unexpected)
+	if (!control) {
+		return undefined;
+	}
+
+	const result = executeExpression(control, {
 		iteration: linksIterations ?? iteration,
 	});
 
@@ -37,7 +41,7 @@ export function checkBaseControl(
 			typeOfControl,
 		};
 	} catch (e) {
-		console.warn(`Error on validating control ${value}`);
+		console.warn(`Error on validating control ${control.value}`);
 		return undefined;
 	}
 }


### PR DESCRIPTION
executeExpression expect an object with a type / value representing an expression (VTL / VTL|MD...) but in checkBaseControl it received a string. Before the introduction of a type "TXT" string expression where evaluated as VTL expression, but it's not the case anymore :

```js
// before
executeExpression('false') // false

// after "TXT" change
executeExpression('false') // "false"
```

But `"false" == true`, which cause the problem of controls being ignored after the "TXT" change. Maybe we should throw an error when receiving a string inside executeExpression (or log an error ?)