### PR TITLE
Add arbitrary option for checkboxOne

### DIFF
--- a/e2e/checkbox.spec.ts
+++ b/e2e/checkbox.spec.ts
@@ -37,4 +37,15 @@ test.describe('Checkboxes', () => {
 			await expectCollectedData(page, 'MOIS2', null);
 		});
 	});
+
+	test.describe('CheckboxOne', () => {
+		test(`Allow detail selection`, async ({ page }) => {
+			await goToStory(page, 'components-checkboxone--with-detail');
+			await expect(page.getByRole('radio', { name: 'Autre' })).toBeVisible();
+			await page.getByRole('radio', { name: 'Autre' }).click();
+			await page.getByRole('textbox', { name: 'Précisez' }).fill('Bonjour');
+			await expectCollectedData(page, 'Q2', '3');
+			await expectCollectedData(page, 'Q3', 'Bonjour');
+		});
+	});
 });

--- a/lunatic-schema.json
+++ b/lunatic-schema.json
@@ -890,7 +890,7 @@
 					"const": "CheckboxOne"
 				},
 				"options": {
-					"$ref": "#/$defs/Options"
+					"$ref": "#/$defs/OptionsWithDetail"
 				}
 			},
 			"required": ["componentType", "options"],
@@ -1081,7 +1081,7 @@
 								"EDITED": {
 									"$ref": "#/$defs/VariableValue"
 								},
-								"INPUTTED": {
+								"INPUTED": {
 									"$ref": "#/$defs/VariableValue"
 								}
 							},
@@ -1090,7 +1090,7 @@
 								"COLLECTED",
 								"FORCED",
 								"EDITED",
-								"INPUTTED"
+								"INPUTED"
 							]
 						}
 					},
@@ -1245,6 +1245,49 @@
 					},
 					"description": {
 						"$ref": "#/$defs/VTLExpression"
+					}
+				},
+				"required": ["value", "label"]
+			}
+		},
+		"OptionsWithDetail": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"value": {
+						"oneOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "boolean"
+							}
+						]
+					},
+					"label": {
+						"$ref": "#/$defs/VTLExpression"
+					},
+					"description": {
+						"$ref": "#/$defs/VTLExpression"
+					},
+					"detail": {
+						"type": "object",
+						"properties": {
+							"label": {
+								"$ref": "#/$defs/VTLExpression"
+							},
+							"response": {
+								"type": "object",
+								"properties": {
+									"name": {
+										"type": "string"
+									}
+								},
+								"required": ["name"]
+							}
+						},
+						"required": ["label", "response"]
 					}
 				},
 				"required": ["value", "label"]

--- a/src/components/CheckboxOne/CheckboxOne.spec.tsx
+++ b/src/components/CheckboxOne/CheckboxOne.spec.tsx
@@ -1,22 +1,22 @@
 import { render, fireEvent } from '@testing-library/react';
 import { CheckboxOne } from './CheckboxOne';
 import { describe, it, expect, vi } from 'vitest';
+import type { InterpretedOption } from '../../use-lunatic/props/propOptions';
 describe('CheckboxOne component', () => {
+	const onCheck = vi.fn();
 	const options = [
-		{ label: 'Option 1', value: 'option-1' },
-		{ label: 'Option 2', value: 'option-2' },
-		{ label: 'Option 3', value: 'option-3' },
-	];
-	const onSelect = vi.fn();
+		{ label: 'Option 1', value: 'option-1', onCheck: onCheck, checked: false },
+		{ label: 'Option 2', value: 'option-2', onCheck: onCheck, checked: false },
+		{ label: 'Option 3', value: 'option-3', onCheck: onCheck, checked: false },
+	] satisfies InterpretedOption[];
 
 	it('renders the component with correct props', () => {
 		const { getByText } = render(
 			<CheckboxOne
-				response={{ name: 'demo' }}
 				options={options}
 				value="option-1"
 				id="checkbox-one"
-				handleChanges={onSelect}
+				handleChanges={onCheck}
 			/>
 		);
 
@@ -28,21 +28,17 @@ describe('CheckboxOne component', () => {
 	it('calls onSelect when an option is selected', () => {
 		const { getByText } = render(
 			<CheckboxOne
-				response={{ name: 'demo' }}
 				options={options}
 				value="option-1"
 				id="checkbox-one"
 				label="Checkbox One"
 				description="Choose one option"
-				handleChanges={onSelect}
+				handleChanges={onCheck}
 			/>
 		);
 
 		fireEvent.click(getByText('Option 2'));
 
-		expect(onSelect).toHaveBeenCalledTimes(1);
-		expect(onSelect).toHaveBeenCalledWith([
-			{ name: 'demo', value: 'option-2' },
-		]);
+		expect(onCheck).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/components/CheckboxOne/CheckboxOne.tsx
+++ b/src/components/CheckboxOne/CheckboxOne.tsx
@@ -11,12 +11,10 @@ export function CheckboxOne({
 	id,
 	label,
 	description,
-	handleChanges,
 	errors,
 	disabled,
 	readOnly,
 	shortcut,
-	response,
 	declarations,
 }: LunaticComponentProps<'CheckboxOne'>) {
 	return (
@@ -30,9 +28,6 @@ export function CheckboxOne({
 			errors={getComponentErrors(errors, id)}
 			label={label}
 			description={description}
-			onSelect={(value: string | null) =>
-				handleChanges([{ name: response.name, value }])
-			}
 			checkboxStyle={true}
 			shortcut={shortcut}
 			declarations={declarations}

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -10,8 +10,6 @@ function LunaticRadio(props: LunaticComponentProps<'Radio'>) {
 		value,
 		checkboxStyle,
 		errors,
-		handleChanges,
-		response,
 		label,
 		shortcut,
 		className = 'lunatic-radio-group',
@@ -26,7 +24,6 @@ function LunaticRadio(props: LunaticComponentProps<'Radio'>) {
 			options={options}
 			value={value}
 			description={description}
-			onSelect={(value) => handleChanges([{ name: response.name, value }])}
 			checkboxStyle={checkboxStyle}
 			errors={getComponentErrors(errors, id)}
 			label={label}

--- a/src/components/shared/Radio/RadioGroup.tsx
+++ b/src/components/shared/Radio/RadioGroup.tsx
@@ -23,7 +23,6 @@ export type RadioGroupProps = Pick<
 	| 'declarations'
 > & {
 	errors?: LunaticError[];
-	onSelect: (v: string | null) => void;
 	clearable?: boolean;
 };
 
@@ -36,17 +35,15 @@ function LunaticRadioGroup({
 	id,
 	label,
 	description,
-	onSelect,
 	checkboxStyle = false,
 	errors,
 	className,
 	shortcut,
 	disabled,
 	readOnly,
-	clearable,
 	declarations,
 }: RadioGroupProps) {
-	const onKeyDown = useListKeyboardHandler(options, onSelect);
+	const onKeyDown = useListKeyboardHandler(options);
 	const maxIndex = options.length;
 	return (
 		<Fieldset className={className} legend={label} description={description}>
@@ -61,7 +58,6 @@ function LunaticRadioGroup({
 						id={radioId}
 						index={index}
 						checked={value === option.value}
-						onClick={onSelect}
 						onKeyDown={onKeyDown}
 						checkboxStyle={checkboxStyle}
 						codeModality={shortcut ? codeModality : undefined}

--- a/src/components/shared/Radio/RadioOption.spec.tsx
+++ b/src/components/shared/Radio/RadioOption.spec.tsx
@@ -17,7 +17,7 @@ describe('RadioOption', () => {
 			<RadioOption
 				id="radio-option"
 				label="Test Option"
-				onClick={onClickMock}
+				onCheck={onClickMock}
 			/>
 		);
 		const option = screen.getByRole('radio');

--- a/src/components/shared/Radio/RadioOption.tsx
+++ b/src/components/shared/Radio/RadioOption.tsx
@@ -8,11 +8,11 @@ import type { InterpretedOption } from '../../../use-lunatic/props/propOptions';
 
 export type Props = {
 	id: string;
+	onKeyDown?: (v: { key: string; index: number }) => void;
 	checkboxStyle?: boolean;
 	shortcut?: boolean;
 	disabled?: boolean;
 	readOnly?: boolean;
-	onKeyDown?: (v: { key: string; index: number }) => void;
 	index?: number;
 	labelledBy?: string;
 	codeModality?: string;

--- a/src/components/shared/Radio/RadioOption.tsx
+++ b/src/components/shared/Radio/RadioOption.tsx
@@ -8,52 +8,52 @@ import { slottableComponent } from '../HOC/slottableComponent';
 import { useKeyboardKey } from '../../../hooks/useKeyboardKey';
 import { Label } from '../Label/Label';
 import classnames from 'classnames';
+import { CustomInput } from '../../Input/Input';
+import type { InterpretedOption } from '../../../use-lunatic/props/propOptions';
 
 export type Props = {
 	id: string;
-	value?: string | null;
-	description?: ReactNode;
-	onClick?: (v: string | null) => void;
 	checkboxStyle?: boolean;
 	shortcut?: boolean;
-	checked?: boolean;
 	disabled?: boolean;
 	readOnly?: boolean;
 	onKeyDown?: (v: { key: string; index: number }) => void;
 	index?: number;
 	labelledBy?: string;
-	label?: ReactNode;
 	codeModality?: string;
 	invalid?: boolean;
-};
+} & InterpretedOption;
 
 function LunaticRadioOption({
 	checked,
 	disabled,
 	readOnly,
 	checkboxStyle,
-	onClick,
 	value,
 	onKeyDown,
 	index,
 	shortcut,
 	codeModality,
-	invalid,
 	id,
 	labelledBy,
 	description,
 	label,
+	onDetailChange,
+	detailLabel,
+	detailValue,
+	onCheck,
 }: Props) {
 	const divEl = useRef<HTMLDivElement>(null);
 	const tabIndex = checked ? 0 : -1;
 	const isEnabled = !disabled && !readOnly;
 	const isRadio = !checkboxStyle;
+	const hasDetail = !!onDetailChange;
+	const detailId = `${id}-detail`;
 	const onClickOption = () => {
-		if (!isEnabled || !onClick) {
+		if (!isEnabled || !onCheck) {
 			return;
 		}
-		// on checkboxStyle, clicking on checked value unchecks it, so it acts as if empty answer was clicked
-		checkboxStyle && checked ? onClick(null) : onClick(value ?? null);
+		onCheck();
 	};
 
 	const handleKeyDown: KeyboardEventHandler<HTMLDivElement> = (e) => {
@@ -82,41 +82,52 @@ function LunaticRadioOption({
 	);
 
 	return (
-		<div
-			id={id}
-			role="radio"
-			aria-disabled={disabled}
-			className={classnames(
-				'lunatic-input-checkbox',
-				isRadio && 'lunatic-input-radio'
-			)}
-			aria-checked={checked}
-			tabIndex={tabIndex}
-			onClick={onClickOption}
-			onKeyDown={handleKeyDown}
-			aria-labelledby={labelledBy}
-			ref={divEl}
-		>
-			<div className="lunatic-input-checkbox__icon">
-				{checked && checkboxStyle && (
-					<svg
-						xmlns="http://www.w3.org/2000/svg"
-						fill="none"
-						viewBox="0 0 14 11"
-					>
-						<path
-							d="M5 11 0 6l1.4-1.4L5 8.2 12.6.6 14 2l-9 9Z"
-							fill="currentColor"
-						/>
-					</svg>
+		<div className="lunatic-input-checkbox-wrapper">
+			<div
+				id={id}
+				role="radio"
+				aria-disabled={disabled}
+				className={classnames(
+					'lunatic-input-checkbox',
+					isRadio && 'lunatic-input-radio'
 				)}
+				aria-checked={checked}
+				tabIndex={tabIndex}
+				onClick={onClickOption}
+				onKeyDown={handleKeyDown}
+				aria-labelledby={labelledBy}
+				ref={divEl}
+			>
+				<div className="lunatic-input-checkbox__icon">
+					{checked && checkboxStyle && (
+						<svg
+							xmlns="http://www.w3.org/2000/svg"
+							fill="none"
+							viewBox="0 0 14 11"
+						>
+							<path
+								d="M5 11 0 6l1.4-1.4L5 8.2 12.6.6 14 2l-9 9Z"
+								fill="currentColor"
+							/>
+						</svg>
+					)}
+				</div>
+				<Label id={labelledBy} htmlFor={id} description={description}>
+					{codeModality && (
+						<span className="code-modality">{codeModality.toUpperCase()}</span>
+					)}
+					{label}
+				</Label>
 			</div>
-			<Label id={labelledBy} htmlFor={id} description={description}>
-				{codeModality && (
-					<span className="code-modality">{codeModality.toUpperCase()}</span>
-				)}
-				{label}
-			</Label>
+			{hasDetail && checked && (
+				<CustomInput
+					id="detailId"
+					label={detailLabel ?? 'Précisez :'}
+					value={typeof detailValue === 'string' ? detailValue : ''}
+					onChange={onDetailChange}
+					disabled={disabled}
+				/>
+			)}
 		</div>
 	);
 }

--- a/src/components/shared/Radio/RadioOption.tsx
+++ b/src/components/shared/Radio/RadioOption.tsx
@@ -1,9 +1,4 @@
-import {
-	type KeyboardEventHandler,
-	type ReactNode,
-	useEffect,
-	useRef,
-} from 'react';
+import { type KeyboardEventHandler, useEffect, useRef } from 'react';
 import { slottableComponent } from '../HOC/slottableComponent';
 import { useKeyboardKey } from '../../../hooks/useKeyboardKey';
 import { Label } from '../Label/Label';
@@ -48,7 +43,7 @@ function LunaticRadioOption({
 	const isEnabled = !disabled && !readOnly;
 	const isRadio = !checkboxStyle;
 	const hasDetail = !!onDetailChange;
-	const detailId = `${id}-detail`;
+
 	const onClickOption = () => {
 		if (!isEnabled || !onCheck) {
 			return;

--- a/src/components/type.ts
+++ b/src/components/type.ts
@@ -7,6 +7,7 @@ import type {
 	LunaticOptions,
 	LunaticReducerState,
 } from '../use-lunatic/type';
+import type { InterpretedOption } from '../use-lunatic/props/propOptions';
 
 type Formats = 'PTnHnM' | 'PnYnM';
 export type VtlExpression = {
@@ -168,12 +169,7 @@ export type ComponentPropsByType = {
 		componentType?: 'CheckboxGroup';
 	};
 	CheckboxOne: LunaticBaseProps<string | null> & {
-		options: Array<{
-			description?: ReactNode;
-			label: ReactNode;
-			value: string;
-		}>;
-		response: { name: string };
+		options: Array<InterpretedOption>;
 		componentType?: 'CheckboxOne';
 	};
 	Switch: LunaticBaseProps<boolean> & {
@@ -186,11 +182,7 @@ export type ComponentPropsByType = {
 		componentType?: 'CheckboxBoolean';
 	};
 	Radio: LunaticBaseProps<string | null> & {
-		options: Array<{
-			description?: ReactNode;
-			label: ReactNode;
-			value: string;
-		}>;
+		options: Array<InterpretedOption>;
 		checkboxStyle?: boolean;
 		response: { name: string };
 		componentType?: 'Radio';

--- a/src/hooks/useListKeyboardHandler.ts
+++ b/src/hooks/useListKeyboardHandler.ts
@@ -4,7 +4,7 @@ import { useCallback } from 'react';
  * Handle navigating a list with arrow keys
  */
 export function useListKeyboardHandler(
-	options: { value: string; onCheck: () => void }[]
+	options: { value?: string; onCheck?: () => void }[]
 ) {
 	return useCallback(
 		({ key, index }: { key: string; index: number }) => {
@@ -12,10 +12,16 @@ export function useListKeyboardHandler(
 
 			if (key === 'ArrowRight' || key === 'ArrowDown') {
 				const next = index === length - 1 ? 0 : index + 1;
-				options[next].onCheck();
+				const option = options[next];
+				if (option.onCheck) {
+					option.onCheck();
+				}
 			} else if (key === 'ArrowLeft' || key === 'ArrowUp') {
 				const next = index === 0 ? length - 1 : index - 1;
-				options[next].onCheck();
+				const option = options[next];
+				if (option.onCheck) {
+					option.onCheck();
+				}
 			}
 		},
 		[options]

--- a/src/hooks/useListKeyboardHandler.ts
+++ b/src/hooks/useListKeyboardHandler.ts
@@ -4,21 +4,20 @@ import { useCallback } from 'react';
  * Handle navigating a list with arrow keys
  */
 export function useListKeyboardHandler(
-	options: { value: string }[],
-	onClick: (s: string) => void
+	options: { value: string; onCheck: () => void }[]
 ) {
 	return useCallback(
-		function ({ key, index }: { key: string; index: number }) {
+		({ key, index }: { key: string; index: number }) => {
 			const { length } = options;
 
 			if (key === 'ArrowRight' || key === 'ArrowDown') {
 				const next = index === length - 1 ? 0 : index + 1;
-				onClick(options[next].value);
+				options[next].onCheck();
 			} else if (key === 'ArrowLeft' || key === 'ArrowUp') {
 				const next = index === 0 ? length - 1 : index - 1;
-				onClick(options[next].value);
+				options[next].onCheck();
 			}
 		},
-		[onClick, options]
+		[options]
 	);
 }

--- a/src/stories/checkbox-one/checkboxOne.stories.jsx
+++ b/src/stories/checkbox-one/checkboxOne.stories.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Orchestrator from '../utils/orchestrator';
 import source from './source';
+import sourceWithDetail from './sourceDetail';
 import defaultArgTypes from '../utils/default-arg-types';
 
 const stories = {
@@ -22,3 +23,10 @@ const Template = (args) => <Orchestrator {...args} />;
 export const Default = Template.bind({});
 
 Default.args = { id: 'checkboxOne', source, shortcut: false };
+
+export const WithDetail = Template.bind({});
+WithDetail.args = {
+	id: 'checkboxOne',
+	source: sourceWithDetail,
+	shortcut: false,
+};

--- a/src/stories/checkbox-one/source.json
+++ b/src/stories/checkbox-one/source.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "../../../lunatic-schema.json",
 	"components": [
 		{
 			"id": "checkboxone",

--- a/src/stories/checkbox-one/sourceDetail.json
+++ b/src/stories/checkbox-one/sourceDetail.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "../../../lunatic-schema.json",
+  "components": [
+    {
+      "id": "checkboxone",
+      "componentType": "CheckboxOne",
+      "mandatory": false,
+      "page": "3",
+      "label": {
+        "value": "\"checkboxone ONE component\"",
+        "type": "VTL|MD"
+      },
+      "description": {
+        "value": "\"true or false\"",
+        "type": "VTL|MD"
+      },
+      "conditionFilter": { "value": "true", "type": "VTL" },
+      "options": [
+        {
+          "value": "1",
+          "description": {
+            "value": "\"Déclaration oui\"",
+            "type": "VTL|MD"
+          },
+          "label": { "value": "\"oui\"", "type": "VTL|MD" }
+        },
+
+        {
+          "value": "2",
+          "description": {
+            "value": "\"Déclaration non\"",
+            "type": "VTL|MD"
+          },
+          "label": { "value": "\"non\"", "type": "VTL|MD" }
+        },
+
+        {
+          "value": "3",
+          "label": { "value": "\"Autre\"", "type": "VTL|MD" },
+          "detail": {
+            "label": {
+              "value": "\"Préciser : \"",
+              "type": "VTL"
+            },
+            "response": {
+              "name": "Q3"
+            }
+          }
+        }
+      ],
+      "response": { "name": "Q2" }
+    }
+  ],
+  "variables": [
+    {
+      "variableType": "COLLECTED",
+      "name": "Q2",
+      "values": {
+        "PREVIOUS": null,
+        "COLLECTED": null,
+        "FORCED": null,
+        "EDITED": null,
+        "INPUTED": null
+      }
+    },
+    {
+      "variableType": "COLLECTED",
+      "name": "Q3",
+      "values": {
+        "PREVIOUS": null,
+        "COLLECTED": null,
+        "FORCED": null,
+        "EDITED": null,
+        "INPUTED": null
+      }
+    }
+  ]
+}

--- a/src/stories/checkbox-one/sourceDetail.json
+++ b/src/stories/checkbox-one/sourceDetail.json
@@ -1,78 +1,78 @@
 {
-  "$schema": "../../../lunatic-schema.json",
-  "components": [
-    {
-      "id": "checkboxone",
-      "componentType": "CheckboxOne",
-      "mandatory": false,
-      "page": "3",
-      "label": {
-        "value": "\"checkboxone ONE component\"",
-        "type": "VTL|MD"
-      },
-      "description": {
-        "value": "\"true or false\"",
-        "type": "VTL|MD"
-      },
-      "conditionFilter": { "value": "true", "type": "VTL" },
-      "options": [
-        {
-          "value": "1",
-          "description": {
-            "value": "\"Déclaration oui\"",
-            "type": "VTL|MD"
-          },
-          "label": { "value": "\"oui\"", "type": "VTL|MD" }
-        },
+	"$schema": "../../../lunatic-schema.json",
+	"components": [
+		{
+			"id": "checkboxone",
+			"componentType": "CheckboxOne",
+			"mandatory": false,
+			"page": "3",
+			"label": {
+				"value": "\"checkboxone ONE component\"",
+				"type": "VTL|MD"
+			},
+			"description": {
+				"value": "\"true or false\"",
+				"type": "VTL|MD"
+			},
+			"conditionFilter": { "value": "true", "type": "VTL" },
+			"options": [
+				{
+					"value": "1",
+					"description": {
+						"value": "\"Déclaration oui\"",
+						"type": "VTL|MD"
+					},
+					"label": { "value": "\"oui\"", "type": "VTL|MD" }
+				},
 
-        {
-          "value": "2",
-          "description": {
-            "value": "\"Déclaration non\"",
-            "type": "VTL|MD"
-          },
-          "label": { "value": "\"non\"", "type": "VTL|MD" }
-        },
+				{
+					"value": "2",
+					"description": {
+						"value": "\"Déclaration non\"",
+						"type": "VTL|MD"
+					},
+					"label": { "value": "\"non\"", "type": "VTL|MD" }
+				},
 
-        {
-          "value": "3",
-          "label": { "value": "\"Autre\"", "type": "VTL|MD" },
-          "detail": {
-            "label": {
-              "value": "\"Préciser : \"",
-              "type": "VTL"
-            },
-            "response": {
-              "name": "Q3"
-            }
-          }
-        }
-      ],
-      "response": { "name": "Q2" }
-    }
-  ],
-  "variables": [
-    {
-      "variableType": "COLLECTED",
-      "name": "Q2",
-      "values": {
-        "PREVIOUS": null,
-        "COLLECTED": null,
-        "FORCED": null,
-        "EDITED": null,
-        "INPUTED": null
-      }
-    },
-    {
-      "variableType": "COLLECTED",
-      "name": "Q3",
-      "values": {
-        "PREVIOUS": null,
-        "COLLECTED": null,
-        "FORCED": null,
-        "EDITED": null,
-        "INPUTED": null
-      }
-    }
-  ]
+				{
+					"value": "3",
+					"label": { "value": "\"Autre\"", "type": "VTL|MD" },
+					"detail": {
+						"label": {
+							"value": "\"Préciser : \"",
+							"type": "VTL"
+						},
+						"response": {
+							"name": "Q3"
+						}
+					}
+				}
+			],
+			"response": { "name": "Q2" }
+		}
+	],
+	"variables": [
+		{
+			"variableType": "COLLECTED",
+			"name": "Q2",
+			"values": {
+				"PREVIOUS": null,
+				"COLLECTED": null,
+				"FORCED": null,
+				"EDITED": null,
+				"INPUTED": null
+			}
+		},
+		{
+			"variableType": "COLLECTED",
+			"name": "Q3",
+			"values": {
+				"PREVIOUS": null,
+				"COLLECTED": null,
+				"FORCED": null,
+				"EDITED": null,
+				"INPUTED": null
+			}
+		}
+	]
 }

--- a/src/stories/utils/SchemaValidator.jsx
+++ b/src/stories/utils/SchemaValidator.jsx
@@ -13,7 +13,6 @@ export function SchemaValidator({ source }) {
 		const validator = ajv.compile(LunaticSchema);
 		const isSourceValid = validator(structuredClone(source)); // ajv mutate the object, send a clone
 		if (!isSourceValid) {
-			console.log(validator.errors, source);
 			return validator.errors;
 		}
 		return null;

--- a/src/type.source.ts
+++ b/src/type.source.ts
@@ -176,10 +176,21 @@ export type ComponentQuestionDefinition = ComponentQuestionDefinition1 & {
 export type ComponentQuestionDefinition1 = ComponentDefinitionBase;
 export type ComponentCheckboxOneDefinition = ComponentCheckboxOneDefinition1 & {
 	componentType: 'CheckboxOne';
-	options: Options;
+	options: OptionsWithDetail;
 };
 export type ComponentCheckboxOneDefinition1 =
 	ComponentDefinitionBaseWithResponse;
+export type OptionsWithDetail = {
+	value: string | boolean;
+	label: VTLExpression;
+	description?: VTLExpression;
+	detail?: {
+		label: VTLExpression;
+		response: {
+			name: string;
+		};
+	};
+}[];
 export type ComponentSuggesterDefinition = ComponentSuggesterDefinition1 & {
 	componentType: 'Suggester';
 	/**
@@ -248,7 +259,7 @@ export type Variable =
 				COLLECTED: VariableValue;
 				FORCED: VariableValue;
 				EDITED: VariableValue;
-				INPUTTED: VariableValue;
+				INPUTED: VariableValue;
 			};
 	  }
 	| {

--- a/src/use-lunatic/commons/fill-components/fill-component-expressions.ts
+++ b/src/use-lunatic/commons/fill-components/fill-component-expressions.ts
@@ -15,6 +15,7 @@ const VTL_ATTRIBUTES = [
 	['responses.label', null],
 	['responses.description', null],
 	['options.description', null],
+	['options.detail.label', null],
 	['controls.iterations', castNumber],
 	['items.label', null],
 	['items.body', null],

--- a/src/use-lunatic/commons/fill-components/fill-components.ts
+++ b/src/use-lunatic/commons/fill-components/fill-components.ts
@@ -11,6 +11,7 @@ import type { LunaticComponentProps } from '../../../components/type';
 import { getMissingResponseProp } from '../../props/propMissingResponse';
 import { getValueProp } from '../../props/propValue';
 import { getIterationsProp } from '../../props/propIterations';
+import { getOptionsProp } from '../../props/propOptions';
 
 type FillComponentArgs = {
 	handleChanges: LunaticChangesHandler;
@@ -33,6 +34,7 @@ export const fillComponent = (
 	state: FillComponentArgs
 ): LunaticComponentProps & { conditionFilter?: boolean } => {
 	const interpretedProps = fillComponentExpressions(component, state);
+	const value = getValueProp(component, state);
 	return {
 		...interpretedProps,
 		handleChanges: state.handleChanges,
@@ -44,10 +46,11 @@ export const fillComponent = (
 		goPreviousPage: state.goPreviousPage,
 		iteration: state.pager.iteration,
 		required: 'mandatory' in component ? component.mandatory : false,
-		value: getValueProp(component, state),
+		value: value,
 		missingResponse: getMissingResponseProp(component, state),
 		management: state.management,
 		iterations: getIterationsProp(component, state),
+		options: getOptionsProp(interpretedProps, state, value),
 		...getComponentTypeProps(interpretedProps, state),
 		// This is too dynamic to be typed correctly, so we allow any here
 	} as any;

--- a/src/use-lunatic/props/propOptions.ts
+++ b/src/use-lunatic/props/propOptions.ts
@@ -1,0 +1,57 @@
+import type { LunaticComponentDefinition } from '../type';
+import type { ReactNode } from 'react';
+import { fillComponent } from '../commons/fill-components/fill-components';
+import type { DeepTranslateExpression } from '../commons/fill-components/fill-component-expressions';
+import { isNumber } from '../../utils/number';
+
+export type InterpretedOption = {
+	label: ReactNode;
+	value: string;
+	checked: boolean;
+	detailLabel?: ReactNode;
+	description?: ReactNode;
+	detailValue?: unknown;
+	onDetailChange?: (value: string) => void;
+	onCheck: () => void;
+};
+
+/**
+ * Compute options for checkboxes / radios
+ */
+export function getOptionsProp(
+	definition: DeepTranslateExpression<LunaticComponentDefinition>,
+	state: Parameters<typeof fillComponent>[1],
+	value: unknown
+) {
+	if (!('options' in definition)) {
+		return [];
+	}
+	return definition.options.map((option) => ({
+		label: option.label,
+		description: option.description,
+		value: option.value,
+		checked: value === option.value,
+		onCheck: () => {
+			state.handleChanges([
+				{ name: definition.response.name, value: option.value },
+			]);
+		},
+		detailValue:
+			'detail' in option && option.detail
+				? state.variables.get(
+						option.detail.response.name,
+						isNumber(state.pager.iteration)
+							? [state.pager.iteration]
+							: undefined
+					)
+				: null,
+		onDetailChange:
+			'detail' in option && option.detail
+				? (value: string) => {
+						state.handleChanges([
+							{ name: option.detail!.response.name, value },
+						]);
+					}
+				: null,
+	}));
+}

--- a/src/use-lunatic/props/propOptions.ts
+++ b/src/use-lunatic/props/propOptions.ts
@@ -6,13 +6,13 @@ import { isNumber } from '../../utils/number';
 
 export type InterpretedOption = {
 	label: ReactNode;
-	value: string;
-	checked: boolean;
+	value?: string;
+	checked?: boolean;
 	detailLabel?: ReactNode;
 	description?: ReactNode;
 	detailValue?: unknown;
 	onDetailChange?: (value: string) => void;
-	onCheck: () => void;
+	onCheck?: () => void;
 };
 
 /**

--- a/src/utils/variables.spec.ts
+++ b/src/utils/variables.spec.ts
@@ -52,7 +52,7 @@ const loopCollectedVariable = {
 		PREVIOUS: [],
 		FORCED: [],
 		EDITED: [],
-		INPUTTED: [],
+		INPUTED: [],
 	},
 	name: 'PRENOMS',
 } as LunaticVariable;


### PR DESCRIPTION
## Issue

On some form we want to add an option to allow an additional answer for specific field

## Solution

There is not lunatic modelisation for this feature so this PR is a proof of concept and spec. The field is triggered adding extra properties on the "options" field : 

```diff
{
	"id": "kmort6x9-QOP-kmorue9d",
	"label": {
		"value": "\"Autre\"",
		"type": "VTL"
	},
	"response": { "name": "NATIO1N5" },
+	"detail": {
+		"label": {
+			"value": "\"Préciser : \"",
+			"type": "VTL"
+		},
+		"response": {
+			"name": "NATIO1N5DETAIL"
+		}
+	}
}
```

## Render 

![image](https://github.com/InseeFr/Lunatic/assets/395137/c6ec7f43-ebc7-4626-9485-f569c8747e83)

## Limitation

Since it's a POC it's only applied on `CheckboxOne` to see if the modelisation fit the need. 

Fix #204
Fix #951