### PR TITLE
fix: Do no render empty declarations

### DIFF
--- a/src/components/shared/Declarations/Declarations.spec.tsx
+++ b/src/components/shared/Declarations/Declarations.spec.tsx
@@ -83,4 +83,19 @@ describe('Declarations component', () => {
 		const declarationsElement = queryByTestId('declarations-1-DETACHABLE')!;
 		expect(declarationsElement.nextElementSibling).toBeNull();
 	});
+
+	it('renders null with empty Declaration', () => {
+		const declarationstest = [
+			{
+				id: '3',
+				label: '',
+				declarationType: 'COMMENT' as const,
+				position: 'DETACHABLE',
+			},
+		];
+		const { container } = render(
+			<Declarations id="1" type="DETACHABLE" declarations={declarationstest} />
+		);
+		expect(container).toMatchInlineSnapshot(`<div />`);
+	});
 });

--- a/src/components/shared/Declarations/Declarations.tsx
+++ b/src/components/shared/Declarations/Declarations.tsx
@@ -46,7 +46,8 @@ function LunaticDeclarations({
 	type = 'AFTER_QUESTION_TEXT',
 	declarations,
 }: Props) {
-	const filtered = declarations?.filter((d) => d.position === type) ?? [];
+	const filtered =
+		declarations?.filter((d) => d.position === type && d.label) ?? [];
 
 	if (filtered.length === 0) {
 		return null;

--- a/src/use-lunatic/reducer/reducerInitializer.tsx
+++ b/src/use-lunatic/reducer/reducerInitializer.tsx
@@ -84,7 +84,8 @@ export function reducerInitializer({
 			if (
 				features.includes(MD) &&
 				expressionType.includes(MD) &&
-				typeof result === 'string'
+				typeof result === 'string' &&
+				result !== ''
 			) {
 				return <MDLabel expression={result} />;
 			}


### PR DESCRIPTION
We do not want to render declaration component when there is not label. 

Today, this declaration will render a div without text : 

```json
{
  "declarations": [
    {
      "label": {
        "type": "VTL|MD",
        "value": '""',
      },
      "position": "BEFORE_QUESTION_TEXT",
    },
  ]
}
```

This PR resolve this issue https://github.com/InseeFr/Lunatic-DSFR/issues/174