### PR TITLE
fix: calculated variable incorrectly initialized when empty

### DIFF
--- a/src/use-lunatic/__snapshots__/use-lunatic.test.ts.snap
+++ b/src/use-lunatic/__snapshots__/use-lunatic.test.ts.snap
@@ -19,7 +19,7 @@ exports[`use-lunatic() > getData() > should only return requested variables 1`] 
 exports[`use-lunatic() > getData() > should return calculated values 1`] = `
 {
   "CALCULATED": {
-    "FILTER_RESULT_AGE_CHAR": true,
+    "FILTER_RESULT_AGE_CHAR": [],
     "FILTER_RESULT_AUDIENCE_SHARE": true,
     "FILTER_RESULT_BIRTH_CHARACTER": true,
     "FILTER_RESULT_CITY": true,
@@ -35,15 +35,15 @@ exports[`use-lunatic() > getData() > should return calculated values 1`] = `
     "FILTER_RESULT_DURATIONM": true,
     "FILTER_RESULT_DURATIONY": true,
     "FILTER_RESULT_DURATIONYM": true,
-    "FILTER_RESULT_FAVCHAR": true,
+    "FILTER_RESULT_FAVCHAR": [],
     "FILTER_RESULT_FAVOURITE_CHAR": true,
     "FILTER_RESULT_FEELCHAREV": true,
     "FILTER_RESULT_ICE_FLAVOUR": true,
     "FILTER_RESULT_LAST_FOOD_SHOPPING": true,
     "FILTER_RESULT_LEAVDURATION": true,
     "FILTER_RESULT_MAYOR": true,
-    "FILTER_RESULT_MEMORY_CHAR": true,
-    "FILTER_RESULT_NAME_CHAR": true,
+    "FILTER_RESULT_MEMORY_CHAR": [],
+    "FILTER_RESULT_NAME_CHAR": [],
     "FILTER_RESULT_NB_CHAR": true,
     "FILTER_RESULT_NUCLEAR_CHARACTER": true,
     "FILTER_RESULT_PERCENTAGE_EXPENSES": true,
@@ -59,7 +59,7 @@ exports[`use-lunatic() > getData() > should return calculated values 1`] = `
   },
   "COLLECTED": {
     "AGE_CHAR": {
-      "COLLECTED": undefined,
+      "COLLECTED": [],
       "EDITED": [],
       "FORCED": [],
       "INPUTTED": [],
@@ -248,14 +248,14 @@ exports[`use-lunatic() > getData() > should return calculated values 1`] = `
       "PREVIOUS": null,
     },
     "FAVCHAR": {
-      "COLLECTED": undefined,
+      "COLLECTED": [],
       "EDITED": [],
       "FORCED": [],
       "INPUTTED": [],
       "PREVIOUS": [],
     },
     "FAVOURITE_CHAR1": {
-      "COLLECTED": undefined,
+      "COLLECTED": [],
       "EDITED": [],
       "FORCED": [],
       "INPUTTED": [],
@@ -451,14 +451,14 @@ exports[`use-lunatic() > getData() > should return calculated values 1`] = `
       "PREVIOUS": null,
     },
     "MEMORY_CHAR": {
-      "COLLECTED": undefined,
+      "COLLECTED": [],
       "EDITED": [],
       "FORCED": [],
       "INPUTTED": [],
       "PREVIOUS": [],
     },
     "NAME_CHAR": {
-      "COLLECTED": undefined,
+      "COLLECTED": [],
       "EDITED": [],
       "FORCED": [],
       "INPUTTED": [],

--- a/src/use-lunatic/__snapshots__/use-lunatic.test.ts.snap
+++ b/src/use-lunatic/__snapshots__/use-lunatic.test.ts.snap
@@ -798,7 +798,7 @@ exports[`use-lunatic() > getData() > should return every value 1`] = `
   "CALCULATED": {},
   "COLLECTED": {
     "AGE_CHAR": {
-      "COLLECTED": undefined,
+      "COLLECTED": [],
       "EDITED": [],
       "FORCED": [],
       "INPUTTED": [],
@@ -987,14 +987,14 @@ exports[`use-lunatic() > getData() > should return every value 1`] = `
       "PREVIOUS": null,
     },
     "FAVCHAR": {
-      "COLLECTED": undefined,
+      "COLLECTED": [],
       "EDITED": [],
       "FORCED": [],
       "INPUTTED": [],
       "PREVIOUS": [],
     },
     "FAVOURITE_CHAR1": {
-      "COLLECTED": undefined,
+      "COLLECTED": [],
       "EDITED": [],
       "FORCED": [],
       "INPUTTED": [],
@@ -1190,14 +1190,14 @@ exports[`use-lunatic() > getData() > should return every value 1`] = `
       "PREVIOUS": null,
     },
     "MEMORY_CHAR": {
-      "COLLECTED": undefined,
+      "COLLECTED": [],
       "EDITED": [],
       "FORCED": [],
       "INPUTTED": [],
       "PREVIOUS": [],
     },
     "NAME_CHAR": {
-      "COLLECTED": undefined,
+      "COLLECTED": [],
       "EDITED": [],
       "FORCED": [],
       "INPUTTED": [],

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
@@ -237,6 +237,14 @@ describe('lunatic-variables-store', () => {
 			variables.set('LIENS', '12', { iteration: [0, 0] });
 			expect(variables.get('IS_12', [0])).toBe(1);
 		});
+		it('should handle empty array for calculated', () => {
+			variables.set('AGE', []);
+			variables.setCalculated('MAJEUR', 'AGE > 18', {
+				dependencies: ['AGE'],
+				shapeFrom: 'AGE',
+			});
+			expect(variables.get('MAJEUR')).toEqual([]);
+		});
 	});
 
 	describe('resizing', () => {

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.ts
@@ -359,10 +359,17 @@ class LunaticVariable {
 		this[key].set(undefined, performance.now());
 	}
 
-	private setValueForArray(value: unknown[]) {
+	private setValueForArray(value: unknown[]): boolean {
 		const savedValue = this.getSavedValue();
 		const oldSize = Array.isArray(savedValue) ? savedValue.length : -1;
 		const newSize = value.length;
+
+		// We received an empty array, update value directly
+		if (newSize === 0) {
+			this.value = [];
+			return oldSize !== newSize;
+		}
+
 		// Update every item of the array and look if we changed one item
 		const oneValueChanged =
 			times(Math.max(oldSize, newSize), (k) =>


### PR DESCRIPTION
In a recent change `source.json` set empty array for collected variable. 

```diff
{
	"name": "T_PRENOM",
	"values": {
-		"COLLECTED": [null]
+		"COLLECTED": []
	}
}
```

This change created a cascade effect when a calculated variable was calculated outside of an iteration. This can happen when overview is used.

Fix #1015 