### PR TITLE
fix: lastReachedPage update in loops

### DIFF
--- a/src/use-lunatic/commons/page-tag.ts
+++ b/src/use-lunatic/commons/page-tag.ts
@@ -49,8 +49,8 @@ export function getPagerFromPageTag(pageTag: string | number = 1) {
 
 export function isNewReachedPage(pager: LunaticReducerState['pager']): boolean {
 	const { lastReachedPage } = pager;
-	const pageTag = getPageTag(pager)
-	return pageTagComparator(pageTag, lastReachedPage ?? '0') > 0
+	const pageTag = getPageTag(pager);
+	return pageTagComparator(pageTag, lastReachedPage ?? '0') > 0;
 }
 
 export function getNewReachedPage(

--- a/src/use-lunatic/commons/page-tag.ts
+++ b/src/use-lunatic/commons/page-tag.ts
@@ -48,26 +48,9 @@ export function getPagerFromPageTag(pageTag: string | number = 1) {
 }
 
 export function isNewReachedPage(pager: LunaticReducerState['pager']): boolean {
-	const { lastReachedPage, page, subPage, iteration } = pager;
-	const reachedPager = getPagerFromPageTag(lastReachedPage ?? '0');
-
-	if (!reachedPager) {
-		return false;
-	}
-
-	if (page > reachedPager.page) {
-		return true;
-	}
-
-	if ((subPage ?? 0) > (reachedPager.subPage ?? 0)) {
-		return true;
-	}
-
-	if ((iteration ?? 0) > (reachedPager.iteration ?? 0)) {
-		return true;
-	}
-
-	return false;
+	const { lastReachedPage } = pager;
+	const pageTag = getPageTag(pager)
+	return pageTagComparator(pageTag, lastReachedPage ?? '0') > 0
 }
 
 export function getNewReachedPage(


### PR DESCRIPTION
- #1019

When checking if pager is a new reached page, that was comparing subPage values independently of page/iteration, and iteration independently of page (see change [there](https://github.com/InseeFr/Lunatic/commit/9485a8fe9c336b80f19d53dce9abbcb9122b6514#diff-7ccb656ad75e8d804c7a0b0752d654be060038599e5020010dab0aa502515b6eL52))

Instead of adding conditions, i directly used pageTageComparator that already handle the pages comparison