### PR TITLE
Navigation on empty loop

### DIFF
--- a/src/use-lunatic/reducer/commons/auto-explore-loop.ts
+++ b/src/use-lunatic/reducer/commons/auto-explore-loop.ts
@@ -17,6 +17,12 @@ export function autoExploreLoop(
 	const isForward = direction === 'forward';
 
 	const goInsideSubpage = (subPages: string[], nbIteration: number) => {
+		// For empty loop jump to the next page
+		if (nbIteration === 0) {
+			newPager.page += isForward ? 1 : -1;
+			hasExploredLoop = true;
+			return;
+		}
 		const maxSubPage = subPages.length;
 		const firstSubPage = pageStringToNumbers(
 			subPages[isForward ? 0 : maxSubPage - 1]


### PR DESCRIPTION
In a recent change default value was changed from [null] to [] and it triggered a bug when reaching a loop. The default behaviour was to enter at the first iteration by default but it now creates an issue since loops have no iterations :(

Fix #1031