### PR TITLE
fix: prevent re-checking a radio

### DIFF
--- a/e2e/checkbox.spec.ts
+++ b/e2e/checkbox.spec.ts
@@ -1,5 +1,5 @@
-import { test, expect } from '@playwright/test';
-import { expectCollectedData, goToStory } from './utils';
+import { expect, test } from '@playwright/test';
+import { expectChanges, expectCollectedData, goToStory } from './utils';
 
 test.describe('Checkboxes', () => {
 	test.describe('CheckboxGroup', () => {
@@ -59,6 +59,35 @@ test.describe('Checkboxes', () => {
 			await page.getByRole('textbox', { name: 'Préciser' }).fill('Bonjour');
 			await expectCollectedData(page, 'Q2', '3');
 			await expectCollectedData(page, 'Q3', 'Bonjour');
+		});
+		test(`Clicking multiple time should not trigger onChange`, async ({
+			page,
+		}) => {
+			await goToStory(page, 'components-checkboxone--default');
+			await expect(page.getByRole('radio', { name: 'oui' })).toBeVisible();
+			await page.getByRole('radio', { name: 'oui' }).click();
+			await expectChanges(page, 0, () => {
+				return page.getByRole('radio', { name: 'oui' }).click();
+			});
+		});
+	});
+
+	test.describe('Radio', () => {
+		test(`Allow check a value`, async ({ page }) => {
+			await goToStory(page, 'components-radio--default');
+			await expect(page.getByRole('radio', { name: 'oui' })).toBeVisible();
+			await page.getByRole('radio', { name: 'oui' }).click();
+			await expectCollectedData(page, 'Q2', '1');
+		});
+		test(`Clicking multiple time should not trigger onChange`, async ({
+			page,
+		}) => {
+			await goToStory(page, 'components-radio--default');
+			await expect(page.getByRole('radio', { name: 'oui' })).toBeVisible();
+			await page.getByRole('radio', { name: 'oui' }).click();
+			await expectChanges(page, 0, () => {
+				return page.getByRole('radio', { name: 'oui' }).click();
+			});
 		});
 	});
 });

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -55,3 +55,18 @@ export async function expectCollectedData(
 export async function expectPageToHaveText(page: Page, text: string) {
 	await expect(page.getByText(text).nth(0)).toBeVisible();
 }
+
+export async function expectChanges(
+	page: Page,
+	expectedCount = 0,
+	cb: () => Promise<void>
+) {
+	let count = 0;
+	page.on('console', (msg) => {
+		if (msg.text().includes('onChange')) {
+			count++;
+		}
+	});
+	await cb();
+	expect(count, 'onChange() calls').toBe(expectedCount);
+}

--- a/src/components/shared/Radio/RadioOption.tsx
+++ b/src/components/shared/Radio/RadioOption.tsx
@@ -45,7 +45,7 @@ function LunaticRadioOption({
 	const hasDetail = !!onDetailChange;
 
 	const onClickOption = () => {
-		if (!isEnabled || !onCheck) {
+		if (!isEnabled || !onCheck || checked) {
 			return;
 		}
 		onCheck();


### PR DESCRIPTION
Prevent "onChange" from being called when checking an already checked radio

Fix #1011