### PR TITLE
onVariableChange parameter for useLunatic

### DIFF
--- a/src/components/LunaticComponents.tsx
+++ b/src/components/LunaticComponents.tsx
@@ -39,7 +39,7 @@ type Props<V = unknown> = {
 
 const LunaticComponentWrapper = slottableComponent(
 	'ComponentWrapper',
-	({ children }: PropsWithChildren) => {
+	({ children }: PropsWithChildren<LunaticComponentProps>) => {
 		return <div className="lunatic lunatic-component">{children}</div>;
 	}
 );

--- a/src/components/RosterForLoop/RosterForLoop.tsx
+++ b/src/components/RosterForLoop/RosterForLoop.tsx
@@ -99,11 +99,12 @@ export const RosterForLoop = (
 											id: `${c.id}-${n}`,
 											errors,
 										})}
-										wrapper={({ children }) => <Td>{children}</Td>}
+										wrapper={(props) => <Td {...props} />}
 									/>
 								</Tr>
 								{hasLineErrors && (
 									<Tr className="lunatic-errors">
+										{/* @ts-ignore-next-line */}
 										<Td colSpan={cols}>
 											<ComponentErrors errors={lineErrors} />
 										</Td>

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -38,15 +38,13 @@ export function Table(props: LunaticComponentProps<'Table'>) {
 								}>
 							>
 								components={row}
-								wrapper={({ children, index, colspan, rowspan }) => (
+								wrapper={({ colspan, rowspan, ...props }) => (
 									<Td
 										row={rowIndex}
-										index={index}
 										colSpan={colspan}
 										rowSpan={rowspan}
-									>
-										{children}
-									</Td>
+										{...props}
+									/>
 								)}
 							/>
 						</Tr>

--- a/src/components/shared/Table/Td.spec.tsx
+++ b/src/components/shared/Table/Td.spec.tsx
@@ -15,6 +15,7 @@ describe('Td', () => {
 				<tbody>
 					<tr>
 						<Td
+							id="a"
 							row={row}
 							index={index}
 							className={className}

--- a/src/components/shared/Table/Td.tsx
+++ b/src/components/shared/Table/Td.tsx
@@ -1,14 +1,17 @@
 import classnames from 'classnames';
 import type { PropsWithChildren } from 'react';
 import { slottableComponent } from '../HOC/slottableComponent';
+import type { LunaticComponentProps } from '../../type';
 
-type Props = PropsWithChildren<{
-	className?: string;
-	row?: string | number;
-	index?: string | number;
-	colSpan?: number;
-	rowSpan?: number;
-}>;
+type Props = PropsWithChildren<
+	{
+		className?: string;
+		row?: string | number;
+		index?: string | number;
+		colSpan?: number;
+		rowSpan?: number;
+	} & LunaticComponentProps
+>;
 
 function LunaticTd({
 	children,

--- a/src/stories/utils/orchestrator.jsx
+++ b/src/stories/utils/orchestrator.jsx
@@ -141,7 +141,7 @@ function OrchestratorForStories({
 		initialPage,
 		features,
 		preferences,
-		onChange: onLogChange,
+		onVariableChange: (e) => console.log('eee', e),
 		autoSuggesterLoading,
 		getReferentiel,
 		management,

--- a/src/stories/utils/orchestrator.jsx
+++ b/src/stories/utils/orchestrator.jsx
@@ -141,7 +141,7 @@ function OrchestratorForStories({
 		initialPage,
 		features,
 		preferences,
-		onVariableChange: (e) => console.log('eee', e),
+		onChange: onLogChange,
 		autoSuggesterLoading,
 		getReferentiel,
 		management,

--- a/src/use-lunatic/actions.ts
+++ b/src/use-lunatic/actions.ts
@@ -14,6 +14,7 @@ export type ActionHandleChanges = {
 			name: string;
 			value: unknown;
 			iteration?: number[];
+			[extra: string]: unknown;
 		}[];
 	};
 };

--- a/src/use-lunatic/commons/variables/behaviours/cleaning-behaviour.ts
+++ b/src/use-lunatic/commons/variables/behaviours/cleaning-behaviour.ts
@@ -48,6 +48,7 @@ export function cleaningBehaviour(
 					getValueAtIteration(initialValues[variableName], variableIteration),
 					{
 						iteration: variableIteration,
+						cause: 'cleaning',
 					}
 				);
 			} catch (e) {

--- a/src/use-lunatic/commons/variables/behaviours/resizing-behaviour.ts
+++ b/src/use-lunatic/commons/variables/behaviours/resizing-behaviour.ts
@@ -43,7 +43,9 @@ export function resizingBehaviour(
 		for (const variableName of resizingInfo.variables) {
 			const value = store.get(variableName);
 			if (!Array.isArray(value) || value.length !== newSize) {
-				store.set(variableName, resizeArrayVariable(value, newSize, null));
+				store.set(variableName, resizeArrayVariable(value, newSize, null), {
+					cause: 'resizing',
+				});
 			}
 		}
 	});

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
@@ -251,6 +251,8 @@ describe('lunatic-variables-store', () => {
 		it('should resize variables', () => {
 			variables.set('PRENOM', ['John', 'Jane']);
 			variables.set('NOM', ['Doe']);
+			const spy = vi.fn();
+			variables.on('change', (e) => spy(e.detail));
 			resizingBehaviour(variables, {
 				PRENOM: {
 					size: 'count(PRENOM)',
@@ -260,6 +262,11 @@ describe('lunatic-variables-store', () => {
 			variables.set('PRENOM', ['John', 'Jane', 'Marc']);
 			expect((variables.get('PRENOM') as string[]).length).toEqual(3);
 			expect((variables.get('NOM') as string[]).length).toEqual(3);
+			expect(spy).toHaveBeenLastCalledWith({
+				name: 'NOM',
+				value: ['Doe', null, null],
+				cause: 'resizing',
+			});
 		});
 		it('should resize pairwise with the array syntax', () => {
 			variables.set('PRENOM', []);

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.ts
@@ -25,6 +25,8 @@ export type EventArgs = {
 		iteration?: IterationLevel | undefined;
 		// What triggered this change
 		cause?: 'resizing' | 'cleaning';
+		// Extra sent when setting the variable
+		[extra: string]: unknown;
 	};
 };
 export type LunaticVariablesStoreEvent<T extends keyof EventArgs> = {

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.ts
@@ -1,13 +1,13 @@
 import { interpretVTL, parseVTLVariables } from '../../../utils/vtl';
 import { isTestEnv } from '../../../utils/env';
-import type { LunaticSource } from '../../type';
-import type { LunaticData } from '../../type';
+import type { LunaticData, LunaticOptions, LunaticSource } from '../../type';
 import { getInitialVariableValue } from '../../../utils/variables';
 import { resizingBehaviour } from './behaviours/resizing-behaviour';
 import { cleaningBehaviour } from './behaviours/cleaning-behaviour';
 import { missingBehaviour } from './behaviours/missing-behaviour';
 import { setAtIndex, subArrays, times } from '../../../utils/array';
 import { isNumber } from '../../../utils/number';
+import type { RefObject } from 'react';
 
 // Interpret counter, used for testing purpose
 let interpretCount = 0;
@@ -44,7 +44,7 @@ export class LunaticVariablesStore {
 	public static makeFromSource(
 		source: LunaticSource,
 		data: LunaticData,
-		changeHandler?: (args: EventArgs['change']) => void
+		changeHandler: RefObject<LunaticOptions['onVariableChange']>
 	) {
 		const store = new LunaticVariablesStore();
 		if (!source.variables) {
@@ -77,9 +77,7 @@ export class LunaticVariablesStore {
 					break;
 			}
 		}
-		if (changeHandler) {
-			store.on('change', (e) => changeHandler(e.detail));
-		}
+		store.on('change', (e) => changeHandler?.current?.(e.detail));
 		cleaningBehaviour(store, source.cleaning, initialValues);
 		resizingBehaviour(store, source.resizing);
 		missingBehaviour(store, source.missingBlock);

--- a/src/use-lunatic/reducer/reduce-handle-changes.ts
+++ b/src/use-lunatic/reducer/reduce-handle-changes.ts
@@ -19,8 +19,10 @@ export function reduceHandleChanges(
 
 	// Update all variables in the store
 	for (const response of action.payload.responses) {
-		state.updateBindings(response.name, response.value, {
-			iteration: getIteration(response.iteration),
+		const { name, value, iteration, ...extra } = response;
+		state.updateBindings(name, value, {
+			...extra,
+			iteration: getIteration(iteration),
 		});
 	}
 

--- a/src/use-lunatic/reducer/reducerInitializer.tsx
+++ b/src/use-lunatic/reducer/reducerInitializer.tsx
@@ -1,5 +1,9 @@
-import type { LunaticSource } from '../type';
-import type { LunaticData, LunaticOptions, LunaticReducerState } from '../type';
+import type {
+	LunaticData,
+	LunaticOptions,
+	LunaticReducerState,
+	LunaticSource,
+} from '../type';
 import { LunaticVariablesStore } from '../commons/variables/lunatic-variables-store';
 import { checkLoops, createMapPages } from '../commons';
 import { getExpressionAsString, getExpressionType } from '../../utils/vtl';
@@ -9,6 +13,7 @@ import { getPagerFromPageTag } from '../commons/page-tag';
 import { buildOverview } from './overview/overviewOnInit';
 import { forceInt } from '../../utils/number';
 import { registerSuggesters } from '../../utils/search/SuggestersDatabase';
+import type { RefObject } from 'react';
 
 const basePager = {
 	page: 1,
@@ -48,7 +53,7 @@ export function reducerInitializer({
 	lastReachedPage?: LunaticOptions['lastReachedPage'];
 	withOverview?: LunaticOptions['withOverview'];
 	getReferentiel?: LunaticOptions['getReferentiel'];
-	onVariableChange?: LunaticOptions['onVariableChange'];
+	onVariableChange: RefObject<LunaticOptions['onVariableChange']>;
 }): LunaticReducerState {
 	const variables = LunaticVariablesStore.makeFromSource(
 		source,

--- a/src/use-lunatic/reducer/reducerInitializer.tsx
+++ b/src/use-lunatic/reducer/reducerInitializer.tsx
@@ -39,6 +39,7 @@ export function reducerInitializer({
 	lastReachedPage = undefined,
 	withOverview = false,
 	getReferentiel,
+	onVariableChange,
 }: {
 	source: LunaticSource;
 	data: LunaticData;
@@ -47,8 +48,13 @@ export function reducerInitializer({
 	lastReachedPage?: LunaticOptions['lastReachedPage'];
 	withOverview?: LunaticOptions['withOverview'];
 	getReferentiel?: LunaticOptions['getReferentiel'];
+	onVariableChange?: LunaticOptions['onVariableChange'];
 }): LunaticReducerState {
-	const variables = LunaticVariablesStore.makeFromSource(source, data);
+	const variables = LunaticVariablesStore.makeFromSource(
+		source,
+		data,
+		onVariableChange
+	);
 	const pages = checkLoops(createMapPages(source));
 
 	if (!source || !data) {

--- a/src/use-lunatic/type.ts
+++ b/src/use-lunatic/type.ts
@@ -8,7 +8,10 @@ import type {
 	VTLExpression,
 	VTLScalarExpression,
 } from '../type.source';
-import type { LunaticVariablesStore } from './commons/variables/lunatic-variables-store';
+import type {
+	EventArgs as LunaticVariablesStoreEvents,
+	LunaticVariablesStore,
+} from './commons/variables/lunatic-variables-store';
 import type { IndexEntry } from '../utils/search/SearchInterface';
 import type { InterpretedLunaticOverviewItem } from './hooks/useOverview';
 import type { LunaticComponentProps } from '../components/type';
@@ -134,6 +137,7 @@ export type LunaticOptions = {
 	preferences?: ['COLLECTED'];
 	savingType?: 'COLLECTED';
 	onChange?: LunaticChangesHandler;
+	onVariableChange?: (event: LunaticVariablesStoreEvents['change']) => void;
 	management?: boolean;
 	// enable shortcut on radio/checkbox/missing buttons
 	shortcut?: boolean;

--- a/src/use-lunatic/use-lunatic.ts
+++ b/src/use-lunatic/use-lunatic.ts
@@ -28,6 +28,7 @@ import { getComponentsFromState } from './commons/get-components-from-state';
 import { fillComponents } from './commons/fill-components/fill-components';
 import { reducer } from './reducer/reducer';
 import { mergeDefault } from '../utils/object';
+import { useRefSync } from '../hooks/useRefSync';
 
 const empty = {}; // Keep the same empty object (to avoid problem with useEffect dependencies)
 const DEFAULT_DATA = empty as LunaticData;
@@ -80,7 +81,12 @@ function useLunatic(
 	} = options;
 	const [state, dispatch] = useReducer(
 		reducer,
-		{ ...options, source, data },
+		{
+			...options,
+			source,
+			data,
+			onVariableChange: useRefSync(options.onVariableChange),
+		},
 		reducerInitializer
 	);
 

--- a/src/use-lunatic/use-lunatic.ts
+++ b/src/use-lunatic/use-lunatic.ts
@@ -43,6 +43,7 @@ const defaultOptions = {
 	preferences: DEFAULT_PREFERENCES,
 	savingType: COLLECTED,
 	onChange: () => {},
+	onVariableChange: () => {},
 	management: false,
 	shortcut: false,
 	initialPage: '1' as PageTag,


### PR DESCRIPTION
Nouveau paramètre pour `useLunatic()` qui permet de détecter quand une variable change. Contrairement à `onChange`, `onVariableChange` se déclenche aussi lors d'effet de bord comme le **cleaning** ou **resizing**. 

Ce hook sera plus fin pour le poste de reprise 