### PR TITLE
feat: add renovate scanning to 2.6 branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,5 +25,6 @@
 		}
 	],
 	"prConcurrentLimit": 5,
-	"dependencyDashboard": true
+	"dependencyDashboard": true,
+	"baseBranches" : ["$default", "2.6"]
 }


### PR DESCRIPTION
See docs of renovate : https://docs.renovatebot.com/configuration-options/#basebranches.

This a need to help users of 2.6 branch to maintain deps.