### PR TITLE
feat: allow a list of variables for the shapeFrom

### DIFF
--- a/lunatic-schema.json
+++ b/lunatic-schema.json
@@ -787,6 +787,9 @@
 					"type": "string",
 					"const": "CheckboxGroup"
 				},
+				"orientation": {
+					"enum": ["horizontal", "vertical"]
+				},
 				"responses": {
 					"type": "array",
 					"items": {
@@ -1139,7 +1142,17 @@
 							}
 						},
 						"shapeFrom": {
-							"type": "string"
+							"oneOf": [
+								{
+									"type": "array",
+									"items": {
+										"type": "string"
+									}
+								},
+								{
+									"type": "string"
+								}
+							]
 						}
 					},
 					"required": ["variableType", "name", "expression"],

--- a/src/type.source.ts
+++ b/src/type.source.ts
@@ -124,7 +124,7 @@ export type ComponentTableDefinition = ComponentTableDefinition1 & {
 export type ComponentTableDefinition1 = ComponentDefinitionBase;
 export type ComponentNumberDefinition = ComponentNumberDefinition1 & {
 	componentType: 'InputNumber';
-	unit?: string;
+	unit?: string | VTLExpression;
 	min?: number;
 	max?: number;
 	decimals?: number;
@@ -274,7 +274,7 @@ export type Variable =
 			name: string;
 			expression: VTLExpression;
 			bindingDependencies?: string[];
-			shapeFrom?: string;
+			shapeFrom?: string[] | string;
 	  };
 export type VariableValue = VariableScalarValue | unknown[];
 export type VariableScalarValue = string | number | null;

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
@@ -172,6 +172,19 @@ describe('lunatic-variables-store', () => {
 			// Only the second iteration should be calculated
 			expect(variables.interpretCount).toBe(3);
 		});
+		it('should handle iteration with multiple shapeFrom', () => {
+			variables.set('FIRSTNAME', ['John']);
+			variables.set('LASTNAME', ['Doe', 'Dae']);
+			variables.setCalculated(
+				'FULLNAME',
+				'nvl(FIRSTNAME, "") || " " || nvl(LASTNAME, "")',
+				{
+					dependencies: ['FIRSTNAME', 'LASTNAME'],
+					shapeFrom: ['FIRSTNAME', 'LASTNAME'],
+				}
+			);
+			expect(variables.get('FULLNAME')).toEqual(['John Doe', ' Dae']);
+		});
 		it('should handle aggregation expression', () => {
 			variables.set('FIRSTNAME', ['John', 'Jane']);
 			expect(variables.run('count(FIRSTNAME)')).toEqual(2);

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.ts
@@ -5,7 +5,12 @@ import { getInitialVariableValue } from '../../../utils/variables';
 import { resizingBehaviour } from './behaviours/resizing-behaviour';
 import { cleaningBehaviour } from './behaviours/cleaning-behaviour';
 import { missingBehaviour } from './behaviours/missing-behaviour';
-import { setAtIndex, subArrays, times } from '../../../utils/array';
+import {
+	findLongest,
+	setAtIndex,
+	subArrays,
+	times,
+} from '../../../utils/array';
 import { isNumber } from '../../../utils/number';
 import type { RefObject } from 'react';
 import {
@@ -163,7 +168,7 @@ export class LunaticVariablesStore {
 		}: {
 			dependencies?: string[];
 			iterationDepth?: number;
-			shapeFrom?: string;
+			shapeFrom?: string | string[];
 		} = {}
 	): LunaticVariable {
 		if (this.dictionary.has(name)) {
@@ -257,7 +262,7 @@ class LunaticVariable {
 	// Specific iteration depth to get value from dependencies (used for yAxis for instance)
 	private readonly iterationDepth?: number;
 	// For calculated variable, shape is copied from another variable
-	private readonly shapeFrom?: string;
+	private readonly shapeFrom?: string[];
 	// Keep a record of variable name (optional, used for debug)
 	public readonly name?: string;
 	// Count the number of calculation
@@ -269,7 +274,7 @@ class LunaticVariable {
 			dependencies?: string[];
 			dictionary?: Map<string, LunaticVariable>;
 			iterationDepth?: number;
-			shapeFrom?: string;
+			shapeFrom?: string | string[];
 			name?: string;
 		} = {}
 	) {
@@ -282,7 +287,8 @@ class LunaticVariable {
 		this.dictionary = args.dictionary;
 		this.dependencies = args.dependencies;
 		this.iterationDepth = args.iterationDepth;
-		this.shapeFrom = args.shapeFrom;
+		this.shapeFrom =
+			typeof args.shapeFrom === 'string' ? [args.shapeFrom] : args.shapeFrom;
 		this.name = args.name ?? args.expression;
 	}
 
@@ -293,7 +299,9 @@ class LunaticVariable {
 		}
 
 		const shapeFromValue = this.shapeFrom
-			? this.dictionary?.get(this.shapeFrom)?.getValue()
+			? findLongest(
+					this.shapeFrom.map((v) => this.dictionary?.get(v)?.getValue())
+				)
 			: null;
 		// If we want the root value of a calculated array, loop using the shapeFrom value
 		if (!iteration && Array.isArray(shapeFromValue)) {

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -110,3 +110,21 @@ export function depth(arr: unknown, base = 0) {
 	}
 	return depth(arr[0], base + 1);
 }
+
+/**
+ * Find the longest array from a list of arrays
+ */
+export function findLongest<T>(arr: T[]): T {
+	let longest = arr[0];
+	let max = -1;
+	for (const item of arr) {
+		if (Array.isArray(item) && item.length > max) {
+			max = item.length;
+			longest = item;
+		}
+		if (!Array.isArray(item) && max < 0) {
+			longest = item;
+		}
+	}
+	return longest;
+}


### PR DESCRIPTION
L'objectif est de pouvoir utiliser plusieurs variables comme `shapeFrom` pour gérer le cas des tableaux dynamique. Le système prend alors la variable avec la taille la plus grande.

Proposition de fix pour l'issue eno https://github.com/InseeFr/Eno/issues/1079 