### PR TITLE
build: configure renovate to scan default branch & stable-branche

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
 	"extends": ["config:base"],
+	"baseBranches": ["$default", "/^(2\\.|3\\.).*/"],
 	"labels": ["dependencies"],
 	"assignees": ["ddecrulle"],
 	"packageRules": [


### PR DESCRIPTION
See docs of renovate : https://docs.renovatebot.com/configuration-options/#basebranches.

This a need to help users of 2.6 branch to maintain deps.
