### PR TITLE
chore: remove unused positioning property

### DIFF
--- a/src/stories/behaviour/others/V2_QuestSimple_Boucles.json
+++ b/src/stories/behaviour/others/V2_QuestSimple_Boucles.json
@@ -1063,7 +1063,6 @@
 			"componentType": "Table",
 			"mandatory": false,
 			"page": "23",
-			"positioning": "HORIZONTAL",
 			"label": {
 				"value": "\"➡ 5. \" || \"Question à choix multiple - réponse oui/non case à cocher\"",
 				"type": "VTL|MD"
@@ -1206,7 +1205,6 @@
 			"componentType": "Table",
 			"mandatory": false,
 			"page": "24",
-			"positioning": "HORIZONTAL",
 			"label": {
 				"value": "\"➡ 6. \" || \"Question à choix multiple - réponse oui/non radio\"",
 				"type": "VTL|MD"
@@ -1374,7 +1372,6 @@
 			"componentType": "Table",
 			"mandatory": false,
 			"page": "26",
-			"positioning": "HORIZONTAL",
 			"label": {
 				"value": "\"➡ 1. \" || \"Tableau un axe simple, une mesure\"",
 				"type": "VTL|MD"
@@ -1505,7 +1502,6 @@
 			"componentType": "Table",
 			"mandatory": false,
 			"page": "27",
-			"positioning": "HORIZONTAL",
 			"label": {
 				"value": "\"➡ 2. \" || \"Tableau un axe simple, plusieurs mesures\"",
 				"type": "VTL|MD"
@@ -1772,7 +1768,6 @@
 			"componentType": "Table",
 			"mandatory": false,
 			"page": "28",
-			"positioning": "HORIZONTAL",
 			"label": {
 				"value": "\"➡ 3. \" || \"Tableau 2 axes\"",
 				"type": "VTL|MD"
@@ -2180,7 +2175,6 @@
 			"componentType": "Table",
 			"mandatory": false,
 			"page": "29",
-			"positioning": "HORIZONTAL",
 			"label": {
 				"value": "\"➡ 4. \" || \"Tableau 1 axe avec hiérarchie , 1 mesure\"",
 				"type": "VTL|MD"
@@ -2244,7 +2238,6 @@
 			"componentType": "Table",
 			"mandatory": false,
 			"page": "30",
-			"positioning": "HORIZONTAL",
 			"label": {
 				"value": "\"➡ 5. \" || \"Tableau dynamique\"",
 				"type": "VTL|MD"

--- a/src/stories/overview/sourceWithHierarchy.json
+++ b/src/stories/overview/sourceWithHierarchy.json
@@ -854,7 +854,6 @@
 			"componentType": "Table",
 			"mandatory": false,
 			"page": "20",
-			"positioning": "HORIZONTAL",
 			"label": {
 				"value": "\"➡ \" || \"Does Jay like the following ice cream flavours?\"",
 				"type": "VTL|MD"
@@ -983,7 +982,6 @@
 			"componentType": "Table",
 			"mandatory": false,
 			"page": "21",
-			"positioning": "HORIZONTAL",
 			"label": {
 				"value": "\"➡ \" || \"Which character works in the nuclear power plant?\"",
 				"type": "VTL|MD"
@@ -1107,7 +1105,6 @@
 			"componentType": "Table",
 			"mandatory": false,
 			"page": "22",
-			"positioning": "HORIZONTAL",
 			"label": {
 				"value": "\"➡ \" || \"In which city each character was born?\"",
 				"type": "VTL|MD"
@@ -1393,7 +1390,6 @@
 			"componentType": "Table",
 			"mandatory": false,
 			"page": "24",
-			"positioning": "HORIZONTAL",
 			"label": {
 				"value": "\"➡ \" || \"Please, specify the percentage of Jay’s expenses in the Kwik-E-Mart for each product?\"",
 				"type": "VTL|MD"
@@ -1596,7 +1592,6 @@
 			"componentType": "Table",
 			"mandatory": false,
 			"page": "25",
-			"positioning": "HORIZONTAL",
 			"label": {
 				"value": "\"➡ \" || \"Please specify if Jay has bought each product in his last food shopping\"",
 				"type": "VTL|MD"
@@ -1937,7 +1932,6 @@
 			"componentType": "Table",
 			"mandatory": false,
 			"page": "26",
-			"positioning": "HORIZONTAL",
 			"label": {
 				"value": "\"➡ \" || \"Who did these clownings and tell us what you remember?\"",
 				"type": "VTL|MD"
@@ -2197,7 +2191,6 @@
 			"componentType": "Table",
 			"mandatory": false,
 			"page": "27",
-			"positioning": "HORIZONTAL",
 			"label": {
 				"value": "\"➡ \" || \"Which of the following means of transport were used by the hero and in which country?\"",
 				"type": "VTL|MD"
@@ -2496,7 +2489,6 @@
 			"componentType": "Table",
 			"mandatory": false,
 			"page": "29",
-			"positioning": "HORIZONTAL",
 			"label": {
 				"value": "\"➡ \" || \"Please, complete the following grid with your favourite characters\"",
 				"type": "VTL|MD"
@@ -2987,7 +2979,6 @@
 			"componentType": "Table",
 			"mandatory": false,
 			"page": "30",
-			"positioning": "HORIZONTAL",
 			"label": {
 				"value": "\"➡ \" || \"How has your feeling about the following characters evolved over time?\"",
 				"type": "VTL|MD"
@@ -3134,7 +3125,6 @@
 			"componentType": "Table",
 			"mandatory": false,
 			"page": "31",
-			"positioning": "HORIZONTAL",
 			"label": {
 				"value": "\"➡ \" || \"Can you tell how long Bart Simpson has been on leave for each type and whether there has been another type?\"",
 				"type": "VTL|MD"

--- a/src/stories/questionnaires/logement/source-sequence.json
+++ b/src/stories/questionnaires/logement/source-sequence.json
@@ -10609,7 +10609,6 @@
 			"componentType": "Table",
 			"mandatory": false,
 			"page": "5",
-			"positioning": "HORIZONTAL",
 			"label": {
 				"value": "\"➡ \" || \"Combien avez-vous de W-C ?\"",
 				"type": "VTL|MD"
@@ -10768,7 +10767,6 @@
 			"componentType": "Table",
 			"mandatory": false,
 			"page": "5",
-			"positioning": "HORIZONTAL",
 			"label": {
 				"value": "\"➡ \" || \"Combien avez-vous de salle d’eau ou salle de bain ?\"",
 				"type": "VTL|MD"
@@ -11181,7 +11179,6 @@
 			"componentType": "Table",
 			"mandatory": false,
 			"page": "6",
-			"positioning": "HORIZONTAL",
 			"label": {
 				"value": "\"➡ \" || \"Votre logement présente-t-il les défauts suivants ?\"",
 				"type": "VTL|MD"
@@ -11330,7 +11327,6 @@
 			"componentType": "Table",
 			"mandatory": false,
 			"page": "6",
-			"positioning": "HORIZONTAL",
 			"label": {
 				"value": "\"➡ \" || \"Votre logement présente-t-il les autres défauts suivants ?\"",
 				"type": "VTL|MD"
@@ -11470,7 +11466,6 @@
 			"componentType": "Table",
 			"mandatory": false,
 			"page": "6",
-			"positioning": "HORIZONTAL",
 			"label": {
 				"value": "\"➡ \" || \"L’environnement de votre logement présente-t-il les défauts suivants ?\"",
 				"type": "VTL|MD"
@@ -11858,7 +11853,6 @@
 			"componentType": "Table",
 			"mandatory": false,
 			"page": "6",
-			"positioning": "HORIZONTAL",
 			"label": {
 				"value": "\"➡ \" || \"Auprès de qui \" || libOIH || \" déposé cette demande de HLM ?\"",
 				"type": "VTL|MD"

--- a/src/stories/questionnaires/logement/source-sum.json
+++ b/src/stories/questionnaires/logement/source-sum.json
@@ -19608,7 +19608,6 @@
 		{
 			"componentType": "Table",
 			"bindingDependencies": ["HUTDEF1", "HUTDEF2", "HUTDEF3", "HUTDEF4"],
-			"positioning": "HORIZONTAL",
 			"hierarchy": {
 				"sequence": {
 					"id": "jojuy3c4",
@@ -22943,7 +22942,6 @@
 					"id": "kmeu61l4-CI-0"
 				}
 			],
-			"positioning": "HORIZONTAL",
 			"hierarchy": {
 				"sequence": {
 					"id": "jojuy3c4",
@@ -23227,7 +23225,6 @@
 					"id": "kksgd6fv-CI-0"
 				}
 			],
-			"positioning": "HORIZONTAL",
 			"hierarchy": {
 				"sequence": {
 					"id": "jojuy3c4",
@@ -23757,7 +23754,6 @@
 		{
 			"componentType": "Table",
 			"bindingDependencies": ["OLAR11", "OLAR12", "OLAR13", "OLAR14", "OLAR15"],
-			"positioning": "HORIZONTAL",
 			"hierarchy": {
 				"sequence": {
 					"id": "joicksrx",
@@ -23951,7 +23947,6 @@
 		{
 			"componentType": "Table",
 			"bindingDependencies": ["OLAR21", "OLAR22", "OLAR23", "OLAR24", "OLAR25"],
-			"positioning": "HORIZONTAL",
 			"hierarchy": {
 				"sequence": {
 					"id": "joicksrx",
@@ -24145,7 +24140,6 @@
 		{
 			"componentType": "Table",
 			"bindingDependencies": ["OLAR31", "OLAR32", "OLAR33"],
-			"positioning": "HORIZONTAL",
 			"hierarchy": {
 				"sequence": {
 					"id": "joicksrx",

--- a/src/stories/questionnaires/logement/source.json
+++ b/src/stories/questionnaires/logement/source.json
@@ -10617,7 +10617,6 @@
 			"componentType": "Table",
 			"mandatory": false,
 			"page": "95",
-			"positioning": "HORIZONTAL",
 			"label": {
 				"value": "\"➡ \" || \"Combien avez-vous de W-C ?\"",
 				"type": "VTL|MD"
@@ -10776,7 +10775,6 @@
 			"componentType": "Table",
 			"mandatory": false,
 			"page": "97",
-			"positioning": "HORIZONTAL",
 			"label": {
 				"value": "\"➡ \" || \"Combien avez-vous de salle d’eau ou salle de bain ?\"",
 				"type": "VTL|MD"
@@ -11189,7 +11187,6 @@
 			"componentType": "Table",
 			"mandatory": false,
 			"page": "103",
-			"positioning": "HORIZONTAL",
 			"label": {
 				"value": "\"➡ \" || \"Votre logement présente-t-il les défauts suivants ?\"",
 				"type": "VTL|MD"
@@ -11338,7 +11335,6 @@
 			"componentType": "Table",
 			"mandatory": false,
 			"page": "104",
-			"positioning": "HORIZONTAL",
 			"label": {
 				"value": "\"➡ \" || \"Votre logement présente-t-il les autres défauts suivants ?\"",
 				"type": "VTL|MD"
@@ -11478,7 +11474,6 @@
 			"componentType": "Table",
 			"mandatory": false,
 			"page": "105",
-			"positioning": "HORIZONTAL",
 			"label": {
 				"value": "\"➡ \" || \"L’environnement de votre logement présente-t-il les défauts suivants ?\"",
 				"type": "VTL|MD"
@@ -11866,7 +11861,6 @@
 			"componentType": "Table",
 			"mandatory": false,
 			"page": "110",
-			"positioning": "HORIZONTAL",
 			"label": {
 				"value": "\"➡ \" || \"Auprès de qui \" || libOIH || \" déposé cette demande de HLM ?\"",
 				"type": "VTL|MD"

--- a/src/stories/questionnaires/simpsons/source.json
+++ b/src/stories/questionnaires/simpsons/source.json
@@ -2550,7 +2550,6 @@
 			"components": [
 				{
 					"componentType": "Table",
-					"positioning": "HORIZONTAL",
 					"hierarchy": {
 						"sequence": {
 							"id": "j6qe0h9q",
@@ -2676,7 +2675,6 @@
 			"components": [
 				{
 					"componentType": "Table",
-					"positioning": "HORIZONTAL",
 					"hierarchy": {
 						"sequence": {
 							"id": "j6qe0h9q",
@@ -2794,7 +2792,6 @@
 			"components": [
 				{
 					"componentType": "Table",
-					"positioning": "HORIZONTAL",
 					"hierarchy": {
 						"sequence": {
 							"id": "j6qe0h9q",
@@ -3258,7 +3255,6 @@
 							"id": "j4nwc63q-CI-0"
 						}
 					],
-					"positioning": "HORIZONTAL",
 					"hierarchy": {
 						"sequence": {
 							"id": "j4nw88h2",
@@ -3445,7 +3441,6 @@
 			"components": [
 				{
 					"componentType": "Table",
-					"positioning": "HORIZONTAL",
 					"hierarchy": {
 						"sequence": {
 							"id": "j4nw88h2",
@@ -3728,7 +3723,6 @@
 			"components": [
 				{
 					"componentType": "Table",
-					"positioning": "HORIZONTAL",
 					"hierarchy": {
 						"sequence": {
 							"id": "j4nw88h2",
@@ -3955,7 +3949,6 @@
 			"components": [
 				{
 					"componentType": "Table",
-					"positioning": "HORIZONTAL",
 					"hierarchy": {
 						"sequence": {
 							"id": "j4nw88h2",
@@ -4188,7 +4181,6 @@
 							"maxLength": 249
 						}
 					],
-					"positioning": "HORIZONTAL",
 					"hierarchy": {
 						"sequence": {
 							"id": "j6qfx9qe",
@@ -4224,7 +4216,6 @@
 			"components": [
 				{
 					"componentType": "Table",
-					"positioning": "HORIZONTAL",
 					"hierarchy": {
 						"sequence": {
 							"id": "j6qfx9qe",
@@ -4487,7 +4478,6 @@
 							"id": "jvxwy68n-RDOP-kewv511d-format-decimal"
 						}
 					],
-					"positioning": "HORIZONTAL",
 					"hierarchy": {
 						"sequence": {
 							"id": "j6qfx9qe",

--- a/src/stories/suggester/source-multiline.json
+++ b/src/stories/suggester/source-multiline.json
@@ -222,7 +222,6 @@
 							"componentType": "InputNumber"
 						}
 					],
-					"positioning": "HORIZONTAL",
 					"componentType": "RosterForLoop"
 				}
 			],

--- a/src/stories/switch/README.md
+++ b/src/stories/switch/README.md
@@ -12,7 +12,6 @@
 |  handleChange   |  func  |                    -                     |    ✓     | Handler of the checkbox                 |
 |    disabled     |  bool  |                  false                   |          | Is the checkbox options disabled        |
 |     focused     |  bool  |                  false                   |          | Is the checkbox options focused         |
-| positioning \*  | string |                "DEFAULT"                 |          | Checkbox options positioning            |
 | declarations \* | array  |                    []                    |          | Declarations of the checkbox            |
 |    features     | array  |                   [ ]                    |          | Component features for labels           |
 |    bindings     | object |                   [ ]                    |          | Questionnaire bindings                  |
@@ -22,7 +21,6 @@
 - `preferences` props has to be an ordered array of `COLLECTED`, `FORCED` or `EDITED`
 - `response` props has to be a shape of `{name: string, values: object}`
 - `options` props has to be an array made by objects with a shape of `{label: string, value: string}`
-- `positioning` props has to be one of `DEFAULT`, `HORIZONTAL` or `VERTICAL`
 - `declarations` are documented in the `Declarations` component
 - `style` props has to be composed of `fieldsetStyle` and `modalityStyle`
 

--- a/src/stories/table/source-colspan.json
+++ b/src/stories/table/source-colspan.json
@@ -6,7 +6,6 @@
 			"id": "j4nwc63q",
 			"componentType": "Table",
 			"mandatory": false,
-			"positioning": "HORIZONTAL",
 			"label": {
 				"value": "\"➡ \" || \"Please, specify the percentage of Jay’s expenses in the Kwik-E-Mart for each product?\"",
 				"type": "VTL|MD"

--- a/src/stories/table/table-dynamique.json
+++ b/src/stories/table/table-dynamique.json
@@ -17,7 +17,6 @@
 		{
 			"componentType": "Table",
 			"bindingDependencies": ["Q11"],
-			"positioning": "HORIZONTAL",
 			"hierarchy": {
 				"sequence": {
 					"id": "kanya0cm",

--- a/src/stories/text/source-roster.json
+++ b/src/stories/text/source-roster.json
@@ -134,7 +134,6 @@
 					"id": "lvp6l8rw-RDOP-lvp74mc4-format-decimal"
 				}
 			],
-			"positioning": "HORIZONTAL",
 			"header": [
 				{
 					"label": {

--- a/src/stories/text/source-table.json
+++ b/src/stories/text/source-table.json
@@ -120,7 +120,6 @@
 	"components": [
 		{
 			"componentType": "Table",
-			"positioning": "HORIZONTAL",
 			"header": [
 				{
 					"label": {

--- a/src/stories/utils/options.js
+++ b/src/stories/utils/options.js
@@ -1,9 +1,3 @@
-export const positioningOptions = {
-	Default: 'DEFAULT',
-	Horizontal: 'HORIZONTAL',
-	Vertical: 'VERTICAL',
-};
-
 export const labelPositionOptions = {
 	Default: 'DEFAULT',
 	Top: 'TOP',


### PR DESCRIPTION
## Summary

A `"positioning"` property was defined in many Table or RosterForLoop objects in test questionnaires.

This property is actually not used (its value was always `"HORIZONTAL"`).

Some entry in the docs was mentionning it.

## Done

Remove references of the unused prop.
