### PR TITLE
fix(errors): pass through error on questions

### DIFF
--- a/src/components/Loop/Loop.tsx
+++ b/src/components/Loop/Loop.tsx
@@ -71,6 +71,7 @@ export function Loop({
 					componentProps={(c) => ({
 						...props,
 						...c,
+						iteration: n,
 						id: `${c.id}-${n}`,
 						errors,
 					})}

--- a/src/components/Question/Question.tsx
+++ b/src/components/Question/Question.tsx
@@ -8,15 +8,16 @@ import type { PropsWithChildren } from 'react';
  * Surround a question giving additional context with label / description / declarations
  */
 export const Question = (props: LunaticComponentProps<'Question'>) => {
-	const { errors, disabled, readOnly, components } = props;
+	const { errors, disabled, readOnly, components, iteration } = props;
 	return (
 		<CustomQuestion {...props}>
 			<LunaticComponents
 				components={components}
-				componentProps={() => ({
+				componentProps={(p) => ({
 					errors,
 					disabled,
 					readOnly,
+					id: iteration === undefined ? p.id : `${p.id}-${iteration}`,
 				})}
 			/>
 		</CustomQuestion>

--- a/src/components/RosterForLoop/RosterForLoop.tsx
+++ b/src/components/RosterForLoop/RosterForLoop.tsx
@@ -99,6 +99,7 @@ export const RosterForLoop = (
 											...otherProps,
 											...c,
 											id: `${c.id}-${n}`,
+											iteration: n,
 											errors,
 										})}
 										wrapper={(props) => <Td {...props} />}

--- a/src/components/type.ts
+++ b/src/components/type.ts
@@ -122,6 +122,7 @@ export type ComponentPropsByType = {
 		LunaticExtraProps & {
 			components: LunaticComponentProps[];
 			componentType?: 'Question';
+			iteration?: number;
 		};
 	RosterForLoop: LunaticBaseProps<unknown> &
 		LunaticExtraProps & {


### PR DESCRIPTION
## Problème

Il y a 2 problèmes : 

- Le premier, bien identifié par @QRuhier , est que les erreurs n'était pas compilée correctement (car on avait pas prévu le cas de composants dans composants dans composants)
- Le second, plus complexe, est que les ids des composants enfant de question dans une boucle perdait l'information concernant le numéro d'itération. 

Fix #1147