### PR TITLE
fix(errors): pass through error on questions

### DIFF
--- a/src/components/LunaticComponents.tsx
+++ b/src/components/LunaticComponents.tsx
@@ -88,6 +88,7 @@ export function LunaticComponents<V = unknown>({
 						const props = {
 							...component,
 							...componentProps?.(component),
+							propsTransformer: componentProps,
 						};
 						return (
 							<Fragment key={computeId(component, k)}>

--- a/src/components/Question/Question.tsx
+++ b/src/components/Question/Question.tsx
@@ -8,17 +8,12 @@ import type { PropsWithChildren } from 'react';
  * Surround a question giving additional context with label / description / declarations
  */
 export const Question = (props: LunaticComponentProps<'Question'>) => {
-	const { errors, disabled, readOnly, components, iteration } = props;
+	const { components, propsTransformer } = props;
 	return (
 		<CustomQuestion {...props}>
 			<LunaticComponents
 				components={components}
-				componentProps={(p) => ({
-					errors,
-					disabled,
-					readOnly,
-					id: iteration === undefined ? p.id : `${p.id}-${iteration}`,
-				})}
+				componentProps={propsTransformer}
 			/>
 		</CustomQuestion>
 	);

--- a/src/components/type.ts
+++ b/src/components/type.ts
@@ -51,6 +51,8 @@ export type LunaticBaseProps<ValueType = unknown> = {
 	goNextPage?: () => void;
 	goPreviousPage?: () => void;
 	meta?: Record<string, unknown>;
+	// Function used by the wrapper to transform props, can be used to pass transformation through component (Loop, Question...)
+	propsTransformer?: (v: any) => any;
 };
 
 export type SuggesterOption = {
@@ -111,6 +113,7 @@ export type ComponentPropsByType = {
 		LunaticExtraProps & { componentType?: 'Subsequence' };
 	Question: Pick<
 		LunaticBaseProps<unknown>,
+		| 'propsTransformer'
 		| 'label'
 		| 'id'
 		| 'description'


### PR DESCRIPTION
Introduction d'une manière de transférer la transformation des props pour que le composant Question puisse transférer les props pour les boucles paginées et non paginées.

Fix #1153