### PR TITLE
Modification roundabout d'une seule itération

### DIFF
--- a/src/use-lunatic/commons/page-navigation.ts
+++ b/src/use-lunatic/commons/page-navigation.ts
@@ -30,8 +30,7 @@ export function getNextPager(
 	// We reached the end of the sequence
 	const isEndSequence =
 		subPage && pager.nbSubPages ? subPage >= pager.nbSubPages : false;
-	const moveUpOnEnd =
-		parent === 'Roundabout' && pager.nbIterations;
+	const moveUpOnEnd = parent === 'Roundabout' && pager.nbIterations;
 	// Move up at the end of a sequence (instead of going to the next Iteration)
 	if (isEndSequence && moveUpOnEnd) {
 		return {

--- a/src/use-lunatic/commons/page-navigation.ts
+++ b/src/use-lunatic/commons/page-navigation.ts
@@ -31,7 +31,7 @@ export function getNextPager(
 	const isEndSequence =
 		subPage && pager.nbSubPages ? subPage >= pager.nbSubPages : false;
 	const moveUpOnEnd =
-		parent === 'Roundabout' && pager.nbIterations && pager.nbIterations > 1;
+		parent === 'Roundabout' && pager.nbIterations;
 	// Move up at the end of a sequence (instead of going to the next Iteration)
 	if (isEndSequence && moveUpOnEnd) {
 		return {

--- a/src/use-lunatic/reducer/commons/auto-explore-loop.ts
+++ b/src/use-lunatic/reducer/commons/auto-explore-loop.ts
@@ -37,18 +37,6 @@ export function autoExploreLoop(
 		);
 	}
 
-	// The page contains a roundabout, go to the first iteration if it only has one iteration
-	if (
-		page.components[0].componentType === 'Roundabout' &&
-		page.subPages &&
-		page.subPages.length > 0
-	) {
-		const nbIterations = state.executeExpression<number>(page.iterations);
-		if (nbIterations === 1) {
-			goInsideSubpage(page.subPages, 1);
-		}
-	}
-
 	// No loop were explored, don't mutate the state
 	if (!hasExploredLoop) {
 		return state;


### PR DESCRIPTION
On enlève l'option qui permet d'aller directement dans les questions du roundabout si on a une seule itération.  
On a une erreur lorsque notre seul répondant ne respecte pas les conditions pour remplir les questions du roundabout. On veut avoir la page d'accueil du roundabout pour indiquer l'état de ce seul répondant.  
Et on préfère l'avoir aussi dans le cas ou le répondant doit répondre pour avoir des informations complémentaires avant la validation (questionnaire incomplet par exemple)