### PR TITLE
fix: suggester do not filter stopwords on query

### DIFF
--- a/src/utils/search/tokenizer.spec.ts
+++ b/src/utils/search/tokenizer.spec.ts
@@ -121,21 +121,6 @@ describe('tokenizeQuery', () => {
 		expect(result).toEqual(['eleve', 'etudiant']);
 	});
 
-	it('should filter out stopWords', () => {
-		const queryParser = {
-			type: 'tokenized',
-			params: { pattern: '\\w+', min: 1 },
-		} as SearchInfo['queryParser'];
-		const stopWords = ['is', 'the', 'of', 'this', 'a'];
-
-		const result = tokenizeQuery(
-			'This is a test of stopWords !',
-			queryParser,
-			stopWords
-		);
-		expect(result).toEqual(['test', 'stopwords']);
-	});
-
 	it('should return an empty array for unmatched patterns', () => {
 		const queryParser = {
 			type: 'tokenized',
@@ -209,17 +194,6 @@ describe('tokenizer', () => {
 
 		const result = tokenize('Élève Étudiant!');
 		expect(result).toEqual(['eleve', 'etudiant']);
-	});
-
-	it('should filter out stopWords', () => {
-		const info = {
-			...mockSearchInfo,
-			stopWords: ['is', 'the', 'of', 'this', 'a'],
-		};
-		const tokenize = tokenizer(info);
-
-		const result = tokenize('This is a test of stopWords !');
-		expect(result).toEqual(['test', 'stopwords']);
 	});
 
 	it('should handle empty strings', () => {

--- a/src/utils/search/tokenizer.ts
+++ b/src/utils/search/tokenizer.ts
@@ -11,19 +11,15 @@ export const tokenizer =
 
 		return field
 			? tokenizeIndex(str, field, stopWords)
-			: tokenizeQuery(str, info.queryParser, stopWords);
+			: tokenizeQuery(str, info.queryParser);
 	};
 
 /**
  * Tokenizer used for the query entered by the user (based on "queryParser" info)
  */
-export const tokenizeQuery = (
-	str: string,
-	info: SearchInfo['queryParser'],
-	stopWords?: string[]
-) => {
+export const tokenizeQuery = (str: string, info: SearchInfo['queryParser']) => {
 	if (info.type === 'soft') {
-		return filterStopWords(normalizeStr(str), stopWords)
+		return normalizeStr(str)
 			.split(/[^a-z0-9]+/)
 			.filter((w) => w.length > 0);
 	}
@@ -35,7 +31,7 @@ export const tokenizeQuery = (
 	const minLength = info.params.min ?? 1;
 
 	return (
-		filterStopWords(normalizeStr(str), stopWords)
+		normalizeStr(str)
 			.match(wordRegex)
 			?.filter((w) => w.length >= minLength) ?? []
 	);

--- a/src/utils/search/tokenizer.ts
+++ b/src/utils/search/tokenizer.ts
@@ -2,7 +2,8 @@ import type { SearchInfo } from './SearchInterface';
 import type { ItemOf } from '../../type.utils';
 
 /**
- * Generates a tokenize method
+ * Generates a tokenize method.
+ * When used for tokenizing a search query instead of the indexing, the fieldName is undefined.
  */
 export const tokenizer =
 	(info: SearchInfo) => (str: string, fieldName?: string) => {
@@ -59,6 +60,7 @@ export const tokenizeIndex = (
 		}
 	}
 
+	// We remove the stopWords from the string
 	return (
 		filterStopWords(normalizeStr(str), stopWords)
 			.match(wordRegex)


### PR DESCRIPTION
- https://github.com/InseeFr/Lunatic/issues/1161#issuecomment-2501562248
- was introduced in https://github.com/InseeFr/Lunatic/pull/1175 . We added a filter on stopwords for suggester searching.
But it had to be done only when indexing, and not on the query. If you searched typing a stopword, it was completely removed from the query so you did not have any match