### PR TITLE
fix: provider wrongly recalculated

### DIFF
--- a/src/stories/utils/orchestrator.jsx
+++ b/src/stories/utils/orchestrator.jsx
@@ -125,10 +125,7 @@ function OrchestratorForStories({
 }) {
 	const { maxPage } = source;
 
-	const componentsOptions = useMemo(
-		() => ({ detailAlwaysDisplayed }),
-		[detailAlwaysDisplayed]
-	);
+	const componentsOptions = { detailAlwaysDisplayed };
 
 	const {
 		getComponents,

--- a/src/use-lunatic/use-lunatic.test.ts
+++ b/src/use-lunatic/use-lunatic.test.ts
@@ -11,6 +11,7 @@ import sourceCleaningLoop from '../stories/behaviour/cleaning/source-loop.json';
 import sourceCleaningResizing from '../stories/behaviour/resizing/source-resizing-cleaning.json';
 import type { LunaticData, PageTag } from './type';
 import { useLunatic } from './use-lunatic';
+import { useCallback } from 'react';
 
 const dataFromObject = (o: Record<string, unknown>): LunaticData => {
 	return {
@@ -79,8 +80,22 @@ describe('use-lunatic()', () => {
 
 	describe('Provider', () => {
 		it('should not generate a new Provider every render', () => {
-			const { result } = renderHook(() => useLunatic(...defaultParams));
+			const { result } = renderHook(() => {
+				const missingStrategy = useCallback(() => {}, []);
+				return useLunatic(sourceSimpsons as any, undefined, {
+					management: false,
+					missing: false,
+					missingStrategy,
+					shortcut: false,
+					missingShortcut: { dontKnow: '1', refused: '2' },
+					dontKnowButton: 'DK',
+					refusedButton: 'RF',
+					componentsOptions: { detailAlwaysDisplayed: false },
+				});
+			});
+
 			const oldProvider = result.current.Provider;
+
 			act(() => {
 				result.current.goNextPage();
 			});

--- a/src/use-lunatic/use-lunatic.ts
+++ b/src/use-lunatic/use-lunatic.ts
@@ -119,7 +119,7 @@ export function useLunatic(
 				refusedButton,
 				componentsOptions,
 			}),
-		// for objects and arrays dependencies, not being handled by useMemo, we need to compare every value
+		/* eslint-disable-next-line react-hooks/exhaustive-deps -- object deps are not being handled very well by useMemo so we need to compare single values */
 		[
 			management,
 			missing,

--- a/src/use-lunatic/use-lunatic.ts
+++ b/src/use-lunatic/use-lunatic.ts
@@ -119,15 +119,17 @@ export function useLunatic(
 				refusedButton,
 				componentsOptions,
 			}),
+		// for objects and arrays dependencies, not being handled by useMemo, we need to compare every value
 		[
 			management,
 			missing,
 			missingStrategy,
 			shortcut,
-			missingShortcut,
+			missingShortcut.dontKnow,
+			missingShortcut.refused,
 			dontKnowButton,
 			refusedButton,
-			componentsOptions,
+			componentsOptions.detailAlwaysDisplayed,
 		]
 	);
 


### PR DESCRIPTION
In the useLunatic, the Provider was wrongly recalculated even if props were not updated

We are using a useMemo to calculate it, but some dependencies were objects, and useMemo does not handle objects/arrays