### PR TITLE
chore: change datepicker example

### DIFF
--- a/src/components/Datepicker/Datepicker.tsx
+++ b/src/components/Datepicker/Datepicker.tsx
@@ -118,7 +118,7 @@ export const CustomDatepicker = slottableComponent<CustomProps>(
 						<DatepickerField
 							id={id + 'month'}
 							label="Mois"
-							description="Exemple: 07"
+							description="Exemple: 7"
 							max={12}
 							value={numbers[1]}
 							onChange={setNumber(1)}

--- a/src/components/Datepicker/__snapshots__/Datepicker.spec.tsx.snap
+++ b/src/components/Datepicker/__snapshots__/Datepicker.spec.tsx.snap
@@ -52,7 +52,7 @@ exports[`Datepicker > should render properly with format YYYY-MM 1`] = `
           <span
             class="lunaticDatepickerHint"
           >
-            Exemple: 07
+            Exemple: 7
           </span>
         </label>
         <input
@@ -128,7 +128,7 @@ exports[`Datepicker > should render properly with format YYYY-MM-DD 1`] = `
           <span
             class="lunaticDatepickerHint"
           >
-            Exemple: 07
+            Exemple: 7
           </span>
         </label>
         <input


### PR DESCRIPTION
since currently in Datepicker we cannot enter a value starting with a 0, change the displayed example (current example for month : "07"). We don't change the component behaviour for the moment