### PR TITLE
fix: display Label with description and no label

### DIFF
--- a/src/components/Input/__snapshots__/Input.spec.tsx.snap
+++ b/src/components/Input/__snapshots__/Input.spec.tsx.snap
@@ -5,6 +5,18 @@ exports[`Input > renders without crashing 1`] = `
   <div
     class="lunatic-input"
   >
+    <label
+      class="lunatic-label"
+      data-testid="label"
+      for="input"
+      id="label-input"
+    >
+      <span
+        class="label-description"
+      >
+        description
+      </span>
+    </label>
     <input
       aria-invalid="false"
       aria-labelledby="label-input"

--- a/src/components/Input/__snapshots__/Input.spec.tsx.snap
+++ b/src/components/Input/__snapshots__/Input.spec.tsx.snap
@@ -7,7 +7,6 @@ exports[`Input > renders without crashing 1`] = `
   >
     <label
       class="lunatic-label"
-      data-testid="label"
       for="input"
       id="label-input"
     >

--- a/src/components/RosterForLoop/__snapshots__/RosterForLoop.spec.tsx.snap
+++ b/src/components/RosterForLoop/__snapshots__/RosterForLoop.spec.tsx.snap
@@ -4,6 +4,7 @@ exports[`RosterForLoop > renders the right number of columns 1`] = `
 <div>
   <label
     class="lunatic-label"
+    data-testid="label"
     for="table"
     id="label-table"
   >

--- a/src/components/RosterForLoop/__snapshots__/RosterForLoop.spec.tsx.snap
+++ b/src/components/RosterForLoop/__snapshots__/RosterForLoop.spec.tsx.snap
@@ -4,7 +4,6 @@ exports[`RosterForLoop > renders the right number of columns 1`] = `
 <div>
   <label
     class="lunatic-label"
-    data-testid="label"
     for="table"
     id="label-table"
   >

--- a/src/components/shared/Label/Label.spec.tsx
+++ b/src/components/shared/Label/Label.spec.tsx
@@ -3,9 +3,9 @@ import { Label } from './Label';
 import { describe, it, expect } from 'vitest';
 
 describe('Label', () => {
-	it('renders null when children is falsy', () => {
+	it('renders null when children and description are falsy', () => {
 		const { container } = render(
-			<Label htmlFor="input" id="label" description="This is a label">
+			<Label htmlFor="input" id="label">
 				{null}
 			</Label>
 		);
@@ -34,8 +34,20 @@ describe('Label', () => {
 
 		const label = getByText('Name');
 		expect(label).toBeInTheDocument();
-		expect(label.parentNode).toHaveAttribute('for', 'kze792d8');
+		expect(label.closest('label')).toHaveAttribute('for', 'kze792d8');
 		const description = queryByText('This is a label');
 		expect(description).not.toBeInTheDocument();
+	});
+
+	it('renders a label with description and no label', () => {
+		const { getByTestId, queryByText } = render(
+			<Label htmlFor="kze792d8" id="label" description="This is a label" />
+		);
+
+		const label = getByTestId('label');
+		expect(label).toBeInTheDocument();
+		expect(label).toHaveAttribute('for', 'kze792d8');
+		const description = queryByText('This is a label');
+		expect(description).toBeInTheDocument();
 	});
 });

--- a/src/components/shared/Label/Label.spec.tsx
+++ b/src/components/shared/Label/Label.spec.tsx
@@ -40,11 +40,11 @@ describe('Label', () => {
 	});
 
 	it('renders a label with description and no label', () => {
-		const { getByTestId, queryByText } = render(
+		const { container, queryByText } = render(
 			<Label htmlFor="kze792d8" id="label" description="This is a label" />
 		);
 
-		const label = getByTestId('label');
+		const label = container.querySelector('label');
 		expect(label).toBeInTheDocument();
 		expect(label).toHaveAttribute('for', 'kze792d8');
 		const description = queryByText('This is a label');

--- a/src/components/shared/Label/Label.tsx
+++ b/src/components/shared/Label/Label.tsx
@@ -27,7 +27,7 @@ function LunaticLabel({
 	style,
 	description,
 }: Props) {
-	if (!children) {
+	if (!children && !description) {
 		return null;
 	}
 	return (
@@ -36,6 +36,7 @@ function LunaticLabel({
 			id={id}
 			className={classnames('lunatic-label', className)}
 			style={style}
+			data-testid="label"
 		>
 			{children}
 			<LabelDescription value={description} />

--- a/src/components/shared/Label/Label.tsx
+++ b/src/components/shared/Label/Label.tsx
@@ -36,7 +36,6 @@ function LunaticLabel({
 			id={id}
 			className={classnames('lunatic-label', className)}
 			style={style}
-			data-testid="label"
 		>
 			{children}
 			<LabelDescription value={description} />


### PR DESCRIPTION
Fix the missing description in many components : Datepicker, Input, InputNumber, Textarea, CheckboxGroup (only for options), Radio (only for options), Suggester, Dropdown

All those components used the `Label` component for displaying label and description.
But since in the model using Question component, the label is on the Question and not the children component, then the `Label` did not render anything because label is undefined

=> fix the `Label` to display the description even if there is no label