### PR TITLE
fix: hasPageResponse in non paginated loop

### DIFF
--- a/src/use-lunatic/hooks/use-page-has-response.ts
+++ b/src/use-lunatic/hooks/use-page-has-response.ts
@@ -77,6 +77,7 @@ function hasOneResponse(
 
 		// For rosterForLoop we need to inspect child components
 		if (
+			component.componentType === 'RosterForLoop' &&
 			'components' in component &&
 			Array.isArray(component.components) &&
 			!isSubComponentsEmpty(component.components, executeExpression)

--- a/src/use-lunatic/props/propValue.ts
+++ b/src/use-lunatic/props/propValue.ts
@@ -28,7 +28,7 @@ export function getValueProp(
 		return args.variables.get(component.response.name, iteration);
 	}
 	// For loop, value will be a map of child component values
-	if ('components' in component) {
+	if (component.componentType === 'Loop') {
 		return getChildResponseValues(component.components, args.variables);
 	}
 	return null;


### PR DESCRIPTION
In a Question component in a paginated loop, the hasPageResponse returned by useLunatic was always true if another iteration had answered to this same question.

Due to conflict between some components in the conditions of the hook and valueProp.
I explicitely made the conditions depending on the component type (it was implicit but matched with only specific components, and Question component matches wrongly with some conditions), 