### PR TITLE
fix: dynamic table row deletion

### DIFF
--- a/src/use-lunatic/props/propValue.spec.ts
+++ b/src/use-lunatic/props/propValue.spec.ts
@@ -115,4 +115,56 @@ describe('fillComponentValue', () => {
 			});
 		});
 	});
+
+	describe('RosterForLoop', () => {
+		const rosterForLoopComponent = {
+			id: 'loop-prenom',
+			componentType: 'RosterForLoop',
+			bindingDependencies: ['PRENOM'],
+			lines: {
+				min: {
+					value: '1',
+					type: 'VTL',
+				},
+				max: {
+					value: '10',
+					type: 'VTL',
+				},
+			},
+			page: '1',
+			components: [
+				{
+					componentType: 'Input',
+					label: {
+						value: '"Prénom"',
+						type: 'VTL|MD',
+					},
+					conditionFilter: {
+						value: 'true',
+						type: 'VTL',
+					},
+					maxLength: 30,
+					bindingDependencies: ['PRENOM'],
+					id: 'prenom',
+					response: {
+						name: 'PRENOM',
+					},
+				},
+			],
+		} as any as LunaticComponentDefinition<'RosterForLoop'>;
+
+		it('should correctly extract values from nested responses as arrays', () => {
+			const values = {
+				PRENOM: ['Alice', 'Bob', 'Charlie'],
+			};
+
+			expectFilledComponent(rosterForLoopComponent, values).toEqual(values);
+		});
+
+		it('should return null for missing responses', () => {
+			expectFilledComponent(rosterForLoopComponent).toEqual({
+				PRENOM: null,
+			});
+		});
+	});
 });

--- a/src/use-lunatic/props/propValue.ts
+++ b/src/use-lunatic/props/propValue.ts
@@ -27,8 +27,11 @@ export function getValueProp(
 	if (hasResponse(component)) {
 		return args.variables.get(component.response.name, iteration);
 	}
-	// For loop, value will be a map of child component values
-	if (component.componentType === 'Loop') {
+	// For Loop and RosterForLoop, value will be a map of child component values
+	if (
+		component.componentType === 'Loop' ||
+		component.componentType === 'RosterForLoop'
+	) {
 		return getChildResponseValues(component.components, args.variables);
 	}
 	return null;


### PR DESCRIPTION
Fix row deletion in dynamic table (RosterForLoop).
Due to https://github.com/InseeFr/Lunatic/pull/1207/files#diff-5c71ab16af13f2e03886e13f45604639d0552a1fc3a649b48ef9e467eae7b7c6 , the RosterForLoop did not fill with children components values anymore, that was necessary for deleting row (since we remove values)