### PR TITLE
Delay resizing on page change

### DIFF
--- a/src/hooks/use-track-changes.ts
+++ b/src/hooks/use-track-changes.ts
@@ -43,13 +43,14 @@ export function useTrackChanges(
 					'getChangedData() cannot be used without enabling tracking mode, add "trackChanges: true" to useLunatic options'
 				);
 			}
+			store.commit();
 			const data = getDataRef.current(Array.from(changedVariables.current));
 			if (reset) {
 				resetChangedData();
 			}
 			return data;
 		},
-		[enabledRef, getDataRef, resetChangedData]
+		[enabledRef, getDataRef, resetChangedData, store]
 	);
 
 	return {

--- a/src/stories/behaviour/cleaning/source-loop.json
+++ b/src/stories/behaviour/cleaning/source-loop.json
@@ -115,7 +115,7 @@
 			}
 		}
 	],
-	"pagination": "question",
+	"pagination": "sequence",
 	"lunaticModelVersion": "2.3.2-rc4",
 	"modele": "TESTSURSUM",
 	"enoCoreVersion": "2.4.1-pairwise",

--- a/src/stories/behaviour/resizing/source-resizing-cleaning.json
+++ b/src/stories/behaviour/resizing/source-resizing-cleaning.json
@@ -6,7 +6,7 @@
 	"lunaticModelVersion": "2.3.1",
 	"generatingDate": "28-03-2023 12:57:35",
 	"missing": false,
-	"pagination": "question",
+	"pagination": "sequence",
 	"maxPage": "2",
 	"label": {
 		"value": "\"Resizing with cleaning\"",

--- a/src/use-lunatic/commons/variables/behaviours/resizing-behaviour.ts
+++ b/src/use-lunatic/commons/variables/behaviours/resizing-behaviour.ts
@@ -43,9 +43,13 @@ export function resizingBehaviour(
 		for (const variableName of resizingInfo.variables) {
 			const value = store.get(variableName);
 			if (!Array.isArray(value) || value.length !== newSize) {
-				store.set(variableName, resizeArrayVariable(value, newSize, null), {
-					cause: 'resizing',
-				});
+				store.enqueueSet(
+					variableName,
+					resizeArrayVariable(value, newSize, null),
+					{
+						cause: 'resizing',
+					}
+				);
 			}
 		}
 	});
@@ -81,6 +85,6 @@ function resizePairwise(
 			xSize,
 			new Array(ySize).fill(null)
 		);
-		store.set(variable, resizedValue);
+		store.enqueueSet(variable, resizedValue);
 	});
 }

--- a/src/use-lunatic/commons/variables/behaviours/resizing-behaviour.ts
+++ b/src/use-lunatic/commons/variables/behaviours/resizing-behaviour.ts
@@ -41,16 +41,19 @@ export function resizingBehaviour(
 
 		const newSize = forceInt(store.run(resizingInfo.size));
 		for (const variableName of resizingInfo.variables) {
-			const value = store.get(variableName);
-			if (!Array.isArray(value) || value.length !== newSize) {
-				store.enqueueSet(
-					variableName,
-					resizeArrayVariable(value, newSize, null),
-					{
-						cause: 'resizing',
+			// Since data can change after the resize, we need to pass a callback that will use the last value of the variable for the resize
+			store.enqueueSet(
+				variableName,
+				() => {
+					const value = store.get(variableName);
+					if (!Array.isArray(value) || value.length !== newSize) {
+						return resizeArrayVariable(value, newSize, null);
 					}
-				);
-			}
+				},
+				{
+					cause: 'resizing',
+				}
+			);
 		}
 	});
 }

--- a/src/use-lunatic/commons/variables/behaviours/resizing-behaviour.ts
+++ b/src/use-lunatic/commons/variables/behaviours/resizing-behaviour.ts
@@ -49,6 +49,7 @@ export function resizingBehaviour(
 					if (!Array.isArray(value) || value.length !== newSize) {
 						return resizeArrayVariable(value, newSize, null);
 					}
+					return value;
 				},
 				{
 					cause: 'resizing',

--- a/src/use-lunatic/commons/variables/get-questionnaire-data.ts
+++ b/src/use-lunatic/commons/variables/get-questionnaire-data.ts
@@ -7,6 +7,7 @@ export function getQuestionnaireData(
 	withCalculated: boolean = false,
 	variableNames?: string[]
 ): LunaticData {
+	store.commit();
 	const result = {
 		EXTERNAL: {} as Record<string, unknown>,
 		CALCULATED: {} as Record<string, unknown>,

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
@@ -124,7 +124,6 @@ describe('lunatic-variables-store', () => {
 		expect(variables.get('FIRSTNAME')).toEqual('Jane');
 	});
 
-
 	describe('event listener', () => {
 		it('should trigger onChange', () => {
 			variables.set('FIRSTNAME', 'John');

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
@@ -586,6 +586,25 @@ describe('lunatic-variables-store', () => {
 		});
 	});
 
+	describe('commit', () => {
+		it('should handle data change before commit', () => {
+			variables.set('PRENOM', []);
+			variables.set('NOM', []);
+			resizingBehaviour(variables, {
+				PRENOM: {
+					size: 'count(PRENOM)',
+					variables: ['NOM'],
+				},
+			});
+			variables.set('PRENOM', ['John', 'Jane', 'Marc']);
+			variables.set('NOM', ['Doe', 'Doe2', 'Doe3']);
+			variables.set('PRENOM', ['John', 'Jane']); // Should trigger a delayed resize
+			variables.set('NOM', 'New', { iteration: [1] }); // But we change a value inside the resized variable
+			variables.commit();
+			expect(variables.get('NOM') as string[][]).toEqual(['Doe', 'New']);
+		});
+	});
+
 	describe('makeFromSource', () => {
 		it('should handle initial data correctly', () => {
 			const store = LunaticVariablesStore.makeFromSource(

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
@@ -115,6 +115,16 @@ describe('lunatic-variables-store', () => {
 		expect(variables.get('AGES_PLUS_NBHAB')).toEqual([4, 5, 6]);
 	});
 
+	it('should handle transaction mode correctly', () => {
+		variables.set('FIRSTNAME', 'John');
+		expect(variables.get('FIRSTNAME')).toEqual('John');
+		variables.enqueueSet('FIRSTNAME', 'Jane');
+		expect(variables.get('FIRSTNAME')).toEqual('John');
+		variables.commit();
+		expect(variables.get('FIRSTNAME')).toEqual('Jane');
+	});
+
+
 	describe('event listener', () => {
 		it('should trigger onChange', () => {
 			variables.set('FIRSTNAME', 'John');
@@ -273,6 +283,10 @@ describe('lunatic-variables-store', () => {
 	});
 
 	describe('resizing', () => {
+		beforeEach(() => {
+			variables.autoCommit = true;
+		});
+
 		it('should resize variables', () => {
 			variables.set('PRENOM', ['John', 'Jane']);
 			variables.set('NOM', ['Doe']);
@@ -367,6 +381,10 @@ describe('lunatic-variables-store', () => {
 	});
 
 	describe('cleaning', () => {
+		beforeEach(() => {
+			variables.autoCommit = true;
+		});
+
 		it('should clean variables', () => {
 			variables.set('PRENOM', 'John');
 			variables.set('NOM', 'Doe');
@@ -606,6 +624,7 @@ describe('lunatic-variables-store', () => {
 			);
 			expect(store.get('PRENOM')).toEqual('Jane');
 			store.set('NOM', 'Doe');
+			store.commit();
 			expect(store.get('PRENOM')).toEqual('John');
 		});
 		it('should enable cleaning when disableCleaning = false', () => {

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.ts
@@ -46,6 +46,8 @@ export type LunaticVariablesStoreEvent<T extends keyof EventArgs> = {
 export class LunaticVariablesStore {
 	private dictionary = new Map<string, LunaticVariable>();
 	private eventTarget = new EventTarget();
+	private queue = new Map<string, () => void>();
+	public autoCommit = false; // Commit change instantly (used in tests)
 
 	constructor() {
 		interpretCount = 0;
@@ -55,11 +57,15 @@ export class LunaticVariablesStore {
 		source: LunaticSource,
 		data: LunaticData,
 		changeHandler: RefObject<LunaticOptions['onVariableChange']>,
-		disableCleaning?: boolean
+		disableCleaning?: boolean,
+		autoCommit?: boolean
 	) {
 		const store = new LunaticVariablesStore();
 		if (!source.variables) {
 			return store;
+		}
+		if (autoCommit) {
+			store.autoCommit = autoCommit;
 		}
 		// Source data (picked from "variables" in the source.json)s
 		const sourceValues: Record<string, unknown> = {};
@@ -118,6 +124,34 @@ export class LunaticVariablesStore {
 			return null;
 		}
 		return this.dictionary.get(name)!.getValue(iteration) as T;
+	}
+
+	/**
+	 * Transactional setter that will change data only when `commit()` is called
+	 */
+	public enqueueSet(
+		name: string,
+		value: unknown,
+		args: Pick<EventArgs['change'], 'iteration' | 'cause'> = {}
+	) {
+		if (this.autoCommit) {
+			this.set(name, value, args);
+			return;
+		}
+		this.queue.set(name, () => {
+			this.set(name, value, args);
+		});
+	}
+
+	/**
+	 * Commit all changes in the queue
+	 */
+	public commit() {
+		// Since we can have nested operation, we prevent delayed set while commiting
+		this.autoCommit = true;
+		Array.from(this.queue.values()).forEach((cb) => cb());
+		this.autoCommit = false;
+		this.queue.clear();
 	}
 
 	/**

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.ts
@@ -135,10 +135,15 @@ export class LunaticVariablesStore {
 		args: Pick<EventArgs['change'], 'iteration' | 'cause'> = {}
 	) {
 		if (this.autoCommit) {
-			this.set(name, value, args);
+			this.set(name, typeof value === 'function' ? value() : value, args);
 			return;
 		}
 		this.queue.set(name, () => {
+			// A function can be enqueued, we need to evaluate it to retrieve the value to set
+			// This is used for the resizing, where we want to resize the last version of the variable
+			if (typeof value === 'function') {
+				value = value();
+			}
 			this.set(name, value, args);
 		});
 	}
@@ -147,10 +152,11 @@ export class LunaticVariablesStore {
 	 * Commit all changes in the queue
 	 */
 	public commit() {
+		const autoCommitValue = this.autoCommit;
 		// Since we can have nested operation, we prevent delayed set while commiting
 		this.autoCommit = true;
 		Array.from(this.queue.values()).forEach((cb) => cb());
-		this.autoCommit = false;
+		this.autoCommit = autoCommitValue;
 		this.queue.clear();
 	}
 

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.ts
@@ -57,7 +57,9 @@ export class LunaticVariablesStore {
 		source: LunaticSource,
 		data: LunaticData,
 		changeHandler: RefObject<LunaticOptions['onVariableChange']>,
+		// Disable cleaning
 		disableCleaning?: boolean,
+		// Do not delay resizing / cleaning
 		autoCommit?: boolean
 	) {
 		const store = new LunaticVariablesStore();

--- a/src/use-lunatic/reducer/reducer.ts
+++ b/src/use-lunatic/reducer/reducer.ts
@@ -5,10 +5,22 @@ import { reduceHandleChanges } from './reduce-handle-changes';
 import { reduceGoPreviousPage } from './reduce-go-previous-page';
 import { reduceGoToPage } from './reduce-go-to-page';
 
+// Action that trigger a change in the store
+const commitActions: ActionKind[] = [
+	ActionKind.GO_PREVIOUS_PAGE,
+	ActionKind.GO_NEXT_PAGE,
+	ActionKind.GO_TO_PAGE
+]
+
 export function reducer(
 	state: LunaticReducerState,
 	action: Action
 ): LunaticReducerState {
+
+	if (commitActions.includes(action.type)) {
+		state.variables.commit()
+	}
+
 	switch (action.type) {
 		case ActionKind.GO_PREVIOUS_PAGE:
 			return reduceGoPreviousPage(state);

--- a/src/use-lunatic/reducer/reducer.ts
+++ b/src/use-lunatic/reducer/reducer.ts
@@ -9,16 +9,15 @@ import { reduceGoToPage } from './reduce-go-to-page';
 const commitActions: ActionKind[] = [
 	ActionKind.GO_PREVIOUS_PAGE,
 	ActionKind.GO_NEXT_PAGE,
-	ActionKind.GO_TO_PAGE
-]
+	ActionKind.GO_TO_PAGE,
+];
 
 export function reducer(
 	state: LunaticReducerState,
 	action: Action
 ): LunaticReducerState {
-
 	if (commitActions.includes(action.type)) {
-		state.variables.commit()
+		state.variables.commit();
 	}
 
 	switch (action.type) {

--- a/src/use-lunatic/reducer/reducerInitializer.tsx
+++ b/src/use-lunatic/reducer/reducerInitializer.tsx
@@ -50,7 +50,6 @@ export function reducerInitializer({
 	getReferentiel,
 	onVariableChange,
 	logger,
-	autoCommit = false,
 }: {
 	source: LunaticSource;
 	data: LunaticData;
@@ -63,14 +62,13 @@ export function reducerInitializer({
 	getReferentiel?: LunaticOptions['getReferentiel'];
 	onVariableChange: RefObject<LunaticOptions['onVariableChange']>;
 	logger: LunaticLogger;
-	autoCommit?: boolean;
 }): LunaticReducerState {
 	const variables = LunaticVariablesStore.makeFromSource(
 		source,
 		data,
 		onVariableChange,
 		disableFilters,
-		autoCommit
+		source.pagination !== 'question'
 	);
 	const pages = checkLoops(createMapPages(source));
 

--- a/src/use-lunatic/reducer/reducerInitializer.tsx
+++ b/src/use-lunatic/reducer/reducerInitializer.tsx
@@ -63,7 +63,7 @@ export function reducerInitializer({
 	getReferentiel?: LunaticOptions['getReferentiel'];
 	onVariableChange: RefObject<LunaticOptions['onVariableChange']>;
 	logger: LunaticLogger;
-	autoCommit: boolean;
+	autoCommit?: boolean;
 }): LunaticReducerState {
 	const variables = LunaticVariablesStore.makeFromSource(
 		source,

--- a/src/use-lunatic/reducer/reducerInitializer.tsx
+++ b/src/use-lunatic/reducer/reducerInitializer.tsx
@@ -50,6 +50,7 @@ export function reducerInitializer({
 	getReferentiel,
 	onVariableChange,
 	logger,
+	autoCommit = false,
 }: {
 	source: LunaticSource;
 	data: LunaticData;
@@ -62,12 +63,14 @@ export function reducerInitializer({
 	getReferentiel?: LunaticOptions['getReferentiel'];
 	onVariableChange: RefObject<LunaticOptions['onVariableChange']>;
 	logger: LunaticLogger;
+	autoCommit: boolean;
 }): LunaticReducerState {
 	const variables = LunaticVariablesStore.makeFromSource(
 		source,
 		data,
 		onVariableChange,
-		disableFilters
+		disableFilters,
+		autoCommit
 	);
 	const pages = checkLoops(createMapPages(source));
 

--- a/src/use-lunatic/type.ts
+++ b/src/use-lunatic/type.ts
@@ -235,6 +235,8 @@ export type LunaticOptions = {
 	trackChanges?: boolean;
 	logger?: LunaticLogger;
 	componentsOptions?: { detailAlwaysDisplayed?: boolean };
+	/** Commit variable change automatically for resizing / cleaning (used for testing) **/
+	autoCommit?: boolean;
 };
 
 /**

--- a/src/use-lunatic/use-lunatic.test.ts
+++ b/src/use-lunatic/use-lunatic.test.ts
@@ -230,7 +230,7 @@ describe('use-lunatic()', () => {
 	describe('cleaning', () => {
 		it('should handle cleaning in a loop', () => {
 			const { result } = renderHook(() =>
-				useLunatic(sourceCleaningLoop as any, undefined, { autoCommit: true })
+				useLunatic(sourceCleaningLoop as any, undefined)
 			);
 			act(() => {
 				result.current.handleChanges([
@@ -269,7 +269,6 @@ describe('use-lunatic()', () => {
 			const { result } = renderHook(() =>
 				useLunatic(sourceCleaningResizing as any, undefined, {
 					onChange: spy,
-					autoCommit: true,
 				})
 			);
 			act(() => result.current.handleChanges([{ name: 'NB', value: 3 }]));

--- a/src/use-lunatic/use-lunatic.test.ts
+++ b/src/use-lunatic/use-lunatic.test.ts
@@ -230,7 +230,7 @@ describe('use-lunatic()', () => {
 	describe('cleaning', () => {
 		it('should handle cleaning in a loop', () => {
 			const { result } = renderHook(() =>
-				useLunatic(sourceCleaningLoop as any, undefined, {})
+				useLunatic(sourceCleaningLoop as any, undefined, { autoCommit: true })
 			);
 			act(() => {
 				result.current.handleChanges([
@@ -269,6 +269,7 @@ describe('use-lunatic()', () => {
 			const { result } = renderHook(() =>
 				useLunatic(sourceCleaningResizing as any, undefined, {
 					onChange: spy,
+					autoCommit: true,
 				})
 			);
 			act(() => result.current.handleChanges([{ name: 'NB', value: 3 }]));


### PR DESCRIPTION
When using a number input changes are triggered too soon and the user  end up loosing data. The goal of this MR is to move resizing on page change.

## Issue

The user has "2" in the input, but want to set the new value to "13"

- He removes the "2" and type "1". The resizing is triggered and remove items
- He then type the "3"

## Solution

Instead of applying resize on every change, we store the changes to apply and we only apply it on page change.

## Side effect

I wonder if we should do the same behaviour for the cleaning since we could encounter a similar problem (data being cleaned too soon)

Fix #1210