### PR TITLE
fix: pairwise resizing when editing an iteration

### DIFF
--- a/src/use-lunatic/commons/variables/behaviours/resizing-behaviour.ts
+++ b/src/use-lunatic/commons/variables/behaviours/resizing-behaviour.ts
@@ -29,7 +29,7 @@ export function resizingBehaviour(
 
 		// Pairwise resizing
 		if ('sizeForLinksVariables' in resizingInfo) {
-			resizePairwise(store, resizingInfo, e.detail);
+			resizePairwise(store, resizingInfo);
 			if (!('size' in resizingInfo)) {
 				return;
 			}
@@ -58,10 +58,6 @@ function resizePairwise(
 			| [string, string]
 			| { xAxisSize: string; yAxisSize: string };
 		linksVariables: string[];
-	},
-	// @ts-expect-error This will be used later (removing at a specific index)
-	args: {
-		iteration?: number[];
 	}
 ) {
 	// Handle expression being sent as an array or an object (ensure backward compatibility)

--- a/src/use-lunatic/commons/variables/behaviours/resizing-behaviour.ts
+++ b/src/use-lunatic/commons/variables/behaviours/resizing-behaviour.ts
@@ -59,6 +59,7 @@ function resizePairwise(
 			| { xAxisSize: string; yAxisSize: string };
 		linksVariables: string[];
 	},
+	// @ts-expect-error This will be used later (removing at a specific index)
 	args: {
 		iteration?: number[];
 	}
@@ -77,7 +78,7 @@ function resizePairwise(
 		return forceInt(store.run(getExpressionAsString(expression)));
 	});
 	resizingInfo.linksVariables.forEach((variable) => {
-		const value = store.get(variable, args.iteration);
+		const value = store.get(variable);
 		const resizedValue = resizeArray(
 			// The value is not an array, force an array
 			Array.isArray(value) ? value.map((i) => resizeArray(i, ySize, null)) : [],

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
@@ -298,7 +298,10 @@ describe('lunatic-variables-store', () => {
 			variables.set('LINKS', [[]]);
 			resizingBehaviour(variables, {
 				PRENOM: {
-					sizeForLinksVariables: ['count(PRENOM)', 'count(PRENOM)'],
+					sizeForLinksVariables: {
+						xAxisSize: 'count(PRENOM)',
+						yAxisSize: 'count(PRENOM)',
+					},
 					linksVariables: ['LINKS'],
 				},
 			});
@@ -307,6 +310,19 @@ describe('lunatic-variables-store', () => {
 				[null, null, null],
 				[null, null, null],
 				[null, null, null],
+			]);
+			// Adding a person should not reset links
+			variables.set('LINKS', [
+				[null, '1', '3'],
+				['1', null, '3'],
+				['2', '2', null],
+			]);
+			variables.set('PRENOM', 'Marie', { iteration: [3] });
+			expect(variables.get('LINKS') as string[][]).toEqual([
+				[null, '1', '3', null],
+				['1', null, '3', null],
+				['2', '2', null, null],
+				[null, null, null, null],
 			]);
 		});
 		it('should resize pairwise with the object syntax', () => {


### PR DESCRIPTION
## Issue 

When a pairwise was resized the value was reset to null instead of being truncated 

## Cause

The resizing was trying to retrieve the value of the pairwise at a specific iteration instead of working on the entire array. When adding an item the value resolve was "undefined" and it created a new null array.

Fix #1209