### PR TITLE
refactor: make datepicker fields slottable

### DIFF
--- a/src/components/Datepicker/Datepicker.tsx
+++ b/src/components/Datepicker/Datepicker.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-import { DatepickerField } from './DatepickerField';
 import { slottableComponent } from '../shared/HOC/slottableComponent';
 import type { LunaticComponentProps } from '../type';
 import { Label } from '../shared/Label/Label';
@@ -9,6 +7,7 @@ import {
 } from '../shared/ComponentErrors/ComponentErrors';
 import { Declarations } from '../shared/Declarations/Declarations';
 import type { LunaticError } from '../../use-lunatic/type';
+import { CustomDatepickerFields } from './DatepickerFields';
 
 export function Datepicker({
 	dateFormat = 'YYYY-MM-DD',
@@ -38,59 +37,9 @@ type CustomProps = Omit<
 export const CustomDatepicker = slottableComponent<CustomProps>(
 	'Datepicker',
 	(props) => {
-		const {
-			disabled,
-			readOnly,
-			value = '',
-			dateFormat = 'YYYY-MM-DD',
-			id,
-			label,
-			errors,
-			description,
-			declarations,
-			onChange,
-		} = props;
+		const { id, label, errors, description, declarations } = props;
+
 		const labelId = `lunatic-datepicker-${id}`;
-		const showDay = dateFormat.includes('DD');
-		const showMonth = dateFormat.includes('MM');
-
-		// Raw state, we allow invalid dates to be typed
-		const [numbers, setNumbers] = useState(() =>
-			numbersFromDateString(value ?? undefined)
-		);
-		const setNumber = (index: number) => (value: number) => {
-			const newNumbers = [...numbers] as typeof numbers;
-			newNumbers[index] = value;
-			setNumbers(newNumbers);
-			onNumbersChange(newNumbers);
-		};
-
-		const onNumbersChange = (numbers: [number, number, number]) => {
-			const formatParts = dateFormat.split('-');
-			const hasNaNIndex = numbers.findIndex((v) => Number.isNaN(v));
-
-			// Date has a missing part
-			if (hasNaNIndex > -1 && hasNaNIndex <= formatParts.length - 1) {
-				onChange(null);
-				return;
-			}
-
-			// Date is not valid
-			if (dateFormat === 'YYYY-MM-DD' && !isDateValid(numbers)) {
-				onChange(null);
-				return;
-			}
-
-			const result = formatParts
-				.map((v, k) => numbers[k].toString().padStart(v.length, '0'))
-				.join('-');
-			onChange(result);
-		};
-
-		const extraProps = {
-			readOnly,
-			disabled,
-		};
 
 		return (
 			<div className="lunatic-input">
@@ -102,71 +51,9 @@ export const CustomDatepicker = slottableComponent<CustomProps>(
 					declarations={declarations}
 					id={id}
 				/>
-				<div className="lunaticDatepickerFields">
-					{showDay && (
-						<DatepickerField
-							id={id + 'day'}
-							label="Jour"
-							description="Exemple: 14"
-							max={31}
-							value={numbers[2]}
-							onChange={setNumber(2)}
-							{...extraProps}
-						/>
-					)}
-					{showMonth && (
-						<DatepickerField
-							id={id + 'month'}
-							label="Mois"
-							description="Exemple: 7"
-							max={12}
-							value={numbers[1]}
-							onChange={setNumber(1)}
-							{...extraProps}
-						/>
-					)}
-					<DatepickerField
-						id={id + 'year'}
-						label="Année"
-						description="Exemple: 2023"
-						value={numbers[0]}
-						max={9999}
-						onChange={setNumber(0)}
-						{...extraProps}
-					/>
-				</div>
+				<CustomDatepickerFields {...props} />
 				<ComponentErrors errors={errors} />
 			</div>
 		);
 	}
 );
-
-function numbersFromDateString(s?: string): [number, number, number] {
-	if (!s) {
-		return [NaN, NaN, NaN];
-	}
-	const parts = s.split('-');
-	return [
-		parseInt(parts[0], 10),
-		parseInt(parts[1], 10),
-		parseInt(parts[2], 10),
-	];
-}
-
-/**
- * Check if the date provided by the user is valid (e.g. not 2001/02/29)
- */
-function isDateValid(dateArray: [number, number, number]) {
-	const [year, month, day] = dateArray;
-
-	// do not set the date directly on new Date(), to avoid transformation on year between 0 and 99.
-	//See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date#year
-	const date = new Date();
-	date.setFullYear(year, month - 1, day);
-
-	return (
-		date.getFullYear() === year &&
-		date.getMonth() === month - 1 &&
-		date.getDate() === day
-	);
-}

--- a/src/components/Datepicker/DatepickerFields.tsx
+++ b/src/components/Datepicker/DatepickerFields.tsx
@@ -42,14 +42,11 @@ export const CustomDatepickerFields = slottableComponent<CustomProps>(
 			const formatParts = dateFormat.split('-');
 			const hasNaNIndex = numbers.findIndex((v) => Number.isNaN(v));
 
-			// Date has a missing part
-			if (hasNaNIndex > -1 && hasNaNIndex <= formatParts.length - 1) {
-				onChange(null);
-				return;
-			}
-
-			// Date is not valid
-			if (dateFormat === 'YYYY-MM-DD' && !isDateValid(numbers)) {
+			// Date is not valid, or date has a missing part
+			if (
+				(dateFormat === 'YYYY-MM-DD' && !isDateValid(numbers)) ||
+				(hasNaNIndex > -1 && hasNaNIndex <= formatParts.length - 1)
+			) {
 				onChange(null);
 				return;
 			}
@@ -107,12 +104,8 @@ function numbersFromDateString(s?: string): [number, number, number] {
 	if (!s) {
 		return [NaN, NaN, NaN];
 	}
-	const parts = s.split('-');
-	return [
-		parseInt(parts[0], 10),
-		parseInt(parts[1], 10),
-		parseInt(parts[2], 10),
-	];
+	const [year, month, day] = s.split('-').map((part) => parseInt(part, 10));
+	return [year, month, day];
 }
 
 /**

--- a/src/components/Datepicker/DatepickerFields.tsx
+++ b/src/components/Datepicker/DatepickerFields.tsx
@@ -2,12 +2,14 @@ import { useState } from 'react';
 import { slottableComponent } from '../shared/HOC/slottableComponent';
 import type { LunaticComponentProps } from '../type';
 import { DatepickerField } from './DatepickerField';
+import { LunaticError } from '../../use-lunatic/type';
 
 type CustomProps = Omit<
 	LunaticComponentProps<'Datepicker'>,
 	'response' | 'handleChanges' | 'errors'
 > & {
 	onChange: (s: string | null) => void;
+	errors?: LunaticError[];
 };
 
 export const CustomDatepickerFields = slottableComponent<CustomProps>(

--- a/src/components/Datepicker/DatepickerFields.tsx
+++ b/src/components/Datepicker/DatepickerFields.tsx
@@ -1,0 +1,132 @@
+import { useState } from 'react';
+import { slottableComponent } from '../shared/HOC/slottableComponent';
+import type { LunaticComponentProps } from '../type';
+import { DatepickerField } from './DatepickerField';
+
+type CustomProps = Omit<
+	LunaticComponentProps<'Datepicker'>,
+	'response' | 'handleChanges' | 'errors'
+> & {
+	onChange: (s: string | null) => void;
+};
+
+export const CustomDatepickerFields = slottableComponent<CustomProps>(
+	'DatepickerFields',
+	(props) => {
+		const {
+			disabled,
+			readOnly,
+			value = '',
+			dateFormat = 'YYYY-MM-DD',
+			id,
+			onChange,
+		} = props;
+
+		const showDay = dateFormat.includes('DD');
+		const showMonth = dateFormat.includes('MM');
+
+		// Raw state, we allow invalid dates to be typed
+		const [numbers, setNumbers] = useState(() =>
+			numbersFromDateString(value ?? undefined)
+		);
+		const setNumber = (index: number) => (value: number) => {
+			const newNumbers = [...numbers] as typeof numbers;
+			newNumbers[index] = value;
+			setNumbers(newNumbers);
+			onNumbersChange(newNumbers);
+		};
+
+		const onNumbersChange = (numbers: [number, number, number]) => {
+			const formatParts = dateFormat.split('-');
+			const hasNaNIndex = numbers.findIndex((v) => Number.isNaN(v));
+
+			// Date has a missing part
+			if (hasNaNIndex > -1 && hasNaNIndex <= formatParts.length - 1) {
+				onChange(null);
+				return;
+			}
+
+			// Date is not valid
+			if (dateFormat === 'YYYY-MM-DD' && !isDateValid(numbers)) {
+				onChange(null);
+				return;
+			}
+
+			const result = formatParts
+				.map((v, k) => numbers[k].toString().padStart(v.length, '0'))
+				.join('-');
+			onChange(result);
+		};
+
+		const extraProps = {
+			readOnly,
+			disabled,
+		};
+
+		return (
+			<div className="lunaticDatepickerFields">
+				{showDay && (
+					<DatepickerField
+						id={id + 'day'}
+						label="Jour"
+						description="Exemple: 14"
+						max={31}
+						value={numbers[2]}
+						onChange={setNumber(2)}
+						{...extraProps}
+					/>
+				)}
+				{showMonth && (
+					<DatepickerField
+						id={id + 'month'}
+						label="Mois"
+						description="Exemple: 7"
+						max={12}
+						value={numbers[1]}
+						onChange={setNumber(1)}
+						{...extraProps}
+					/>
+				)}
+				<DatepickerField
+					id={id + 'year'}
+					label="Année"
+					description="Exemple: 2023"
+					value={numbers[0]}
+					max={9999}
+					onChange={setNumber(0)}
+					{...extraProps}
+				/>
+			</div>
+		);
+	}
+);
+
+function numbersFromDateString(s?: string): [number, number, number] {
+	if (!s) {
+		return [NaN, NaN, NaN];
+	}
+	const parts = s.split('-');
+	return [
+		parseInt(parts[0], 10),
+		parseInt(parts[1], 10),
+		parseInt(parts[2], 10),
+	];
+}
+
+/**
+ * Check if the date provided by the user is valid (e.g. not 2001/02/29)
+ */
+function isDateValid(dateArray: [number, number, number]) {
+	const [year, month, day] = dateArray;
+
+	// do not set the date directly on new Date(), to avoid transformation on year between 0 and 99.
+	//See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date#year
+	const date = new Date();
+	date.setFullYear(year, month - 1, day);
+
+	return (
+		date.getFullYear() === year &&
+		date.getMonth() === month - 1 &&
+		date.getDate() === day
+	);
+}

--- a/src/components/shared/HOC/slottableComponent.tsx
+++ b/src/components/shared/HOC/slottableComponent.tsx
@@ -43,6 +43,7 @@ import type { SummaryResponses, SummaryTitle } from '../../Summary/Summary';
 import type { LunaticComponentProps } from '../../type';
 import type { MarkdownLink } from '../MDLabel/MarkdownLink';
 import type { Accordion } from '../../Accordion/Accordion';
+import type { CustomDatepickerFields } from '../../Datepicker/DatepickerFields';
 
 /**
  * Contain the type of every customizable components.
@@ -79,6 +80,9 @@ export type LunaticSlotComponents = {
 	ComboboxInput: typeof ComboboxInput; // option (inside the li)
 	ComboboxClearButton: typeof ComboboxClearButton;
 	ComboboxLabelSelection: typeof ComboboxLabelSelection;
+
+	// Datepicker
+	DatepickerFields: typeof CustomDatepickerFields;
 
 	// Roundabout
 	Roundabout: typeof CustomRoundabout;


### PR DESCRIPTION
add intermediate slottable component in Datepicker (`DatepickerFields`) for override only the logic of the field (for example replacing it by a real datepicker in parent app, without carrying about handling the label/description/declaration/errors).

Would replace https://github.com/InseeFr/Lunatic/pull/1215 since we want to avoid importing mui in Lunatic