### PR TITLE
fix: crash on modality filter when cannot evaluate expression

### DIFF
--- a/src/use-lunatic/commons/fill-components/fill-components.ts
+++ b/src/use-lunatic/commons/fill-components/fill-components.ts
@@ -12,6 +12,7 @@ import { getMissingResponseProp } from '../../props/propMissingResponse';
 import { getValueProp } from '../../props/propValue';
 import { getIterationsProp } from '../../props/propIterations';
 import { getOptionsProp } from '../../props/propOptions';
+import { LunaticLogger } from '../../logger/type';
 
 type FillComponentArgs = {
 	disableFilters?: boolean;
@@ -25,6 +26,7 @@ type FillComponentArgs = {
 	preferences: LunaticOptions['preferences'];
 	pager: LunaticReducerState['pager'];
 	variables: LunaticReducerState['variables'];
+	logger: LunaticLogger;
 };
 
 /**
@@ -56,7 +58,8 @@ export const fillComponent = (
 			state.variables,
 			state.handleChanges,
 			state.pager.iteration,
-			value
+			value,
+			state.logger
 		),
 		...getComponentTypeProps(interpretedProps, state),
 		// This is too dynamic to be typed correctly, so we allow any here

--- a/src/use-lunatic/props/propOptions.spec.ts
+++ b/src/use-lunatic/props/propOptions.spec.ts
@@ -26,6 +26,7 @@ describe('getOptionsProp()', () => {
 		],
 	} satisfies DeepTranslateExpression<LunaticComponentDefinition>;
 	let mockChange: LunaticChangesHandler;
+	const mockLogger = vi.fn();
 
 	beforeEach(() => {
 		mockChange = vi.fn();
@@ -40,7 +41,8 @@ describe('getOptionsProp()', () => {
 				variables,
 				mockChange,
 				undefined,
-				undefined
+				undefined,
+				mockLogger
 			);
 			expect(options[1].checked).toBe(false);
 			variables.set('O2', true);
@@ -49,7 +51,8 @@ describe('getOptionsProp()', () => {
 				variables,
 				mockChange,
 				undefined,
-				undefined
+				undefined,
+				mockLogger
 			);
 			expect(options[1].checked).toBe(true);
 		});
@@ -61,7 +64,8 @@ describe('getOptionsProp()', () => {
 				variables,
 				mockChange,
 				0,
-				undefined
+				undefined,
+				mockLogger
 			);
 			expect(
 				options.filter((o) => o.checked),
@@ -74,7 +78,8 @@ describe('getOptionsProp()', () => {
 				variables,
 				mockChange,
 				0,
-				undefined
+				undefined,
+				mockLogger
 			);
 			expect(options[0].checked).toBe(true);
 			expect(options[1].checked).toBe(false);
@@ -87,12 +92,73 @@ describe('getOptionsProp()', () => {
 				variables,
 				mockChange,
 				1,
-				undefined
+				undefined,
+				mockLogger
 			);
 			options[1].onCheck(false);
 			expect(mockChange).toHaveBeenLastCalledWith([
 				{ name: 'O2', value: false },
 			]);
+		});
+		it('should not filter response (checkboxGroup) when its conditionFilter evaluation fails', () => {
+			const definition = {
+				...checkboxGroupDefinition,
+				responses: [
+					{
+						label: 'Option 1',
+						response: { name: 'O1' },
+						id: 'id1',
+						conditionFilter: { type: 'VTL', value: 'invalid expression' },
+					},
+				],
+			} satisfies DeepTranslateExpression<LunaticComponentDefinition>;
+
+			// mock variables.run for having an error interpreting a variable
+			vi.spyOn(variables, 'run').mockImplementation(() => {
+				throw new Error('Test error');
+			});
+
+			const options = getOptionsProp(
+				definition,
+				variables,
+				mockChange,
+				undefined,
+				undefined,
+				mockLogger
+			);
+
+			// Ensure the option is not filtered
+			expect(options).toHaveLength(1);
+		});
+		it('should not filter option (radio) when its conditionFilter evaluation fails', () => {
+			const definition = {
+				id: 'RadioGroup',
+				componentType: 'Radio',
+				options: [
+					{
+						label: 'Option 1',
+						value: 'id1',
+						conditionFilter: { type: 'VTL', value: 'invalid expression' },
+					},
+				],
+			} as any as DeepTranslateExpression<LunaticComponentDefinition>;
+
+			// Mock `variables.run` to throw an error
+			vi.spyOn(variables, 'run').mockImplementation(() => {
+				throw new Error('Test error');
+			});
+
+			const options = getOptionsProp(
+				definition,
+				variables,
+				mockChange,
+				undefined,
+				undefined,
+				mockLogger
+			);
+
+			// Ensure the option is not filtered
+			expect(options).toHaveLength(1);
 		});
 	});
 });

--- a/src/use-lunatic/props/propOptions.ts
+++ b/src/use-lunatic/props/propOptions.ts
@@ -7,6 +7,7 @@ import type { ReactNode } from 'react';
 import type { DeepTranslateExpression } from '../commons/fill-components/fill-component-expressions';
 import { isNumber } from '../../utils/number';
 import type { LunaticVariablesStore } from '../commons/variables/lunatic-variables-store';
+import { LunaticLogger } from '../logger/type';
 
 /* Used for radio option and checkbox one option */
 export type InterpretedOption = {
@@ -29,7 +30,8 @@ export function getOptionsProp(
 	variables: LunaticVariablesStore,
 	handleChanges: LunaticChangesHandler,
 	pagerIteration: LunaticState['pager']['iteration'],
-	value: unknown
+	value: unknown,
+	logger: LunaticLogger
 ) {
 	const iteration = isNumber(pagerIteration) ? [pagerIteration] : undefined;
 	//const iteration = pagerIteration ? [pagerIteration] : undefined;
@@ -40,7 +42,16 @@ export function getOptionsProp(
 				if (!response.conditionFilter) {
 					return true;
 				}
-				return variables.run(response.conditionFilter.value, { iteration });
+				try {
+					return variables.run(response.conditionFilter.value, { iteration });
+				} catch (e) {
+					// If there is an error interpreting a variable, we do not filter
+					logger({
+						type: 'ERROR',
+						error: e as Error,
+					});
+					return true;
+				}
 			})
 			.map((response) => ({
 				label: response.label,
@@ -74,7 +85,16 @@ export function getOptionsProp(
 			if (!('conditionFilter' in option) || !option.conditionFilter) {
 				return true;
 			}
-			return variables.run(option.conditionFilter.value, { iteration });
+			try {
+				return variables.run(option.conditionFilter.value, { iteration });
+			} catch (e) {
+				// If there is an error interpreting a variable, we do not filter
+				logger({
+					type: 'ERROR',
+					error: e as Error,
+				});
+				return true;
+			}
 		})
 		.map((option) => ({
 			label: option.label,

--- a/src/use-lunatic/use-lunatic.ts
+++ b/src/use-lunatic/use-lunatic.ts
@@ -205,6 +205,7 @@ export function useLunatic(
 		goNextPage,
 		goPreviousPage,
 		management,
+		logger,
 		...state,
 	});
 


### PR DESCRIPTION
when trying to filter a radio option or checkboxgroup response, if the conditionFilter expression could not be interpreted, it crashes.
Like for classic filters, we decide not to apply filter if it cannot be interpreted (so we keep the modality)