### PR TITLE
fix: rename mandatory to isMandatory & improve accessibility for required

### DIFF
--- a/lunatic-schema.json
+++ b/lunatic-schema.json
@@ -439,7 +439,7 @@
 				"id": {
 					"type": "string"
 				},
-				"mandatory": {
+				"isMandatory": {
 					"type": "boolean"
 				},
 				"missingResponse": {

--- a/src/components/Input/Input.spec.tsx
+++ b/src/components/Input/Input.spec.tsx
@@ -93,6 +93,15 @@ describe('Input', () => {
 		expect(input).toHaveValue('toto');
 	});
 
+	it('should handle required', () => {
+		const { container } = render(<Input {...baseProps} required />);
+
+		const input = container.querySelector('input[type="text"]');
+
+		expect(input).toHaveAttribute('required');
+		expect(input).toHaveAttribute('aria-required', 'true');
+	});
+
 	it('should display input value from the start when user leave input', () => {
 		const setSelectionRangeMock = vi.fn();
 		const { container } = render(<Input {...baseProps} />);

--- a/src/components/InputNumber/InputNumber.spec.tsx
+++ b/src/components/InputNumber/InputNumber.spec.tsx
@@ -106,6 +106,15 @@ describe('InputNumber', () => {
 		expect(input).toHaveValue('123');
 	});
 
+	it('should handle required', () => {
+		const { container } = render(<InputNumber {...baseProps} required />);
+
+		const input = container.querySelector('input[type="text"]');
+
+		expect(input).toHaveAttribute('required');
+		expect(input).toHaveAttribute('aria-required', 'true');
+	});
+
 	it('renders with unit', () => {
 		const { container } = render(<InputNumber {...baseProps} unit="kg" />);
 

--- a/src/components/InputNumber/InputNumberThousand.tsx
+++ b/src/components/InputNumber/InputNumberThousand.tsx
@@ -77,6 +77,7 @@ export const InputNumberThousand = ({
 			disabled={disabled}
 			readOnly={readOnly}
 			required={required}
+			aria-required={required}
 			lang="en"
 			isAllowed={isAllowed}
 			allowNegative={min < 0}

--- a/src/components/InputNumber/__snapshots__/InputNumber.spec.tsx.snap
+++ b/src/components/InputNumber/__snapshots__/InputNumber.spec.tsx.snap
@@ -8,6 +8,7 @@ exports[`InputNumber > renders without crashing 1`] = `
     <input
       aria-invalid="false"
       aria-labelledby="label-number"
+      aria-required="false"
       class=""
       id="number"
       inputmode="numeric"
@@ -28,6 +29,7 @@ exports[`InputNumber > should handle readOnly 1`] = `
     <input
       aria-invalid="false"
       aria-labelledby="label-number"
+      aria-required="false"
       class=""
       id="number"
       inputmode="numeric"

--- a/src/components/Textarea/Textarea.spec.tsx
+++ b/src/components/Textarea/Textarea.spec.tsx
@@ -61,4 +61,14 @@ describe('Textarea', () => {
 			'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
 		);
 	});
+
+	it('should handle required', () => {
+		const { container } = render(<Textarea {...baseProps} required />);
+
+		const textarea = container.querySelector('textarea');
+
+		expect(textarea).toBeInTheDocument();
+		expect(textarea).toHaveAttribute('required');
+		expect(textarea).toHaveAttribute('aria-required', 'true');
+	});
 });

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -68,6 +68,7 @@ export const CustomTextarea = slottableComponent<CustomProps>(
 				<div className="field-with-count">
 					<textarea
 						required={required}
+						aria-required={required}
 						disabled={disabled}
 						id={id}
 						aria-labelledby={labelId}

--- a/src/stories/behaviour/cleaning/loop.json
+++ b/src/stories/behaviour/cleaning/loop.json
@@ -24,7 +24,7 @@
 				{
 					"id": "m8ilsr46",
 					"componentType": "RosterForLoop",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "2",
 					"lines": {
 						"min": { "value": "1", "type": "VTL" },
@@ -78,7 +78,7 @@
 						{
 							"id": "m8ilvkbt",
 							"componentType": "Input",
-							"mandatory": false,
+							"isMandatory": false,
 							"page": "3.2",
 							"maxLength": 249,
 							"response": { "name": "CETTEQUEST" }
@@ -101,7 +101,7 @@
 						{
 							"id": "m8iljjiu",
 							"componentType": "Input",
-							"mandatory": false,
+							"isMandatory": false,
 							"page": "3.3",
 							"maxLength": 249,
 							"response": { "name": "ONLY_LAURENT" }
@@ -124,7 +124,7 @@
 						{
 							"id": "m8ili0k6",
 							"componentType": "Input",
-							"mandatory": false,
+							"isMandatory": false,
 							"page": "3.4",
 							"maxLength": 249,
 							"response": { "name": "ONLY_TROIS_LAURENT" }

--- a/src/stories/behaviour/cleaning/source.json
+++ b/src/stories/behaviour/cleaning/source.json
@@ -83,7 +83,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 1. \" || \"Origine\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"bindingDependencies": ["ORIGIN"],
 			"response": {
 				"name": "ORIGIN"
@@ -112,7 +112,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 2. \" || \"Ville de france\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"bindingDependencies": ["CITY"],
 			"response": {
 				"name": "CITY"

--- a/src/stories/behaviour/controls/boucles-n.json
+++ b/src/stories/behaviour/controls/boucles-n.json
@@ -110,7 +110,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 1. \" || \"\"question 1 : Q1\" \""
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"maxLength": 5,
 					"declarations": [
 						{
@@ -177,7 +177,7 @@
 				"type": "VTL|MD",
 				"value": "\"Avez-vous des remarques concernant l'enquête ou des commentaires ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 2000
 		}
 	],

--- a/src/stories/behaviour/controls/simple-numeric.json
+++ b/src/stories/behaviour/controls/simple-numeric.json
@@ -64,7 +64,7 @@
 		{
 			"id": "k0dzbfek",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "2",
 			"min": 0,
 			"max": 100,
@@ -132,7 +132,7 @@
 		{
 			"id": "kd0a6rn3",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "3",
 			"min": 0,
 			"max": 100,
@@ -178,7 +178,7 @@
 		{
 			"id": "kd0a8h62",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "4",
 			"min": 0,
 			"max": 100,
@@ -238,7 +238,7 @@
 		{
 			"id": "kd0a4t4f",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"min": 0,
 			"max": 100,
@@ -298,7 +298,7 @@
 		{
 			"id": "kd0ac92p",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"min": 0,
 			"max": 100,
@@ -358,7 +358,7 @@
 		{
 			"id": "k1cahy88",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "7",
 			"min": 0,
 			"max": 9,
@@ -407,7 +407,7 @@
 		{
 			"id": "kd0ch7pf",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"min": 0,
 			"max": 9,
@@ -469,7 +469,7 @@
 		{
 			"id": "kd0aamy0",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "9",
 			"min": -100,
 			"max": 100,
@@ -631,7 +631,7 @@
 		{
 			"id": "kd0aa5ah",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "10",
 			"min": -100,
 			"max": 100,
@@ -708,7 +708,7 @@
 		{
 			"id": "l5qvuk9e",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "11",
 			"min": -100,
 			"max": 100,
@@ -765,7 +765,7 @@
 		{
 			"id": "l5qvtc2l",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "12",
 			"min": -100,
 			"max": 100,
@@ -822,7 +822,7 @@
 		{
 			"id": "kd0c3h3b",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "13",
 			"min": 0,
 			"max": 1000000000,
@@ -929,7 +929,7 @@
 		{
 			"id": "kd0achk0",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "15",
 			"min": -100,
 			"max": 100,
@@ -974,7 +974,7 @@
 		{
 			"id": "kd0bl558",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "16",
 			"min": -100,
 			"max": 100,
@@ -1092,7 +1092,7 @@
 		{
 			"id": "l5qt3xu9",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "17",
 			"min": 0,
 			"max": 100,
@@ -1149,7 +1149,7 @@
 		{
 			"id": "kd0bu8xz",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "18",
 			"min": -400,
 			"max": 400,
@@ -1237,7 +1237,7 @@
 		{
 			"id": "k0gj7g4v",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "19",
 			"min": -200,
 			"max": 200,
@@ -1345,7 +1345,7 @@
 		{
 			"id": "kd0bx24r",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "20",
 			"min": -400,
 			"max": 400,
@@ -1439,7 +1439,7 @@
 		{
 			"id": "kd0c2j4a",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "21",
 			"min": -400,
 			"max": 400,

--- a/src/stories/behaviour/controls/simple.json
+++ b/src/stories/behaviour/controls/simple.json
@@ -183,7 +183,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 1. \" || \"Controle sur booleen\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Input",
@@ -239,7 +239,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 2. \" || \"Controle sur du texte < 255\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 15,
 			"declarations": [
 				{
@@ -344,7 +344,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 3. \" || \"Controle sur code\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "INSTRUCTION",
@@ -408,7 +408,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 4. \" || \"Controle sur date AAAA-MM-JJ (saisie entre 31/12/1990 et 31/12/2040)\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "INSTRUCTION",
@@ -486,7 +486,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 5. \" || \"Controle sur date AAAA-MM (manque lunatic)\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "INSTRUCTION",
@@ -555,7 +555,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 6. \" || \"Controle sur date AAAA (si supérieur à 2020) manque lunatic\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "INSTRUCTION",
@@ -620,7 +620,7 @@
 				"type": "VTL|MD",
 				"value": "\"Avez-vous des remarques concernant l'enquête ou des commentaires ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 2000
 		}
 	],

--- a/src/stories/behaviour/filter/source.json
+++ b/src/stories/behaviour/filter/source.json
@@ -93,7 +93,7 @@
 					"response": {
 						"name": "NAME"
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"maxLength": 249,
 					"componentType": "Input"
 				}
@@ -151,7 +151,7 @@
 					"response": {
 						"name": "AGE"
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"description": {
 						"type": "TXT",
 						"value": "Format attendu : un nombre entre 1 et 200"
@@ -206,7 +206,7 @@
 					"response": {
 						"name": "APPLE"
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"orientation": "vertical",
 					"componentType": "Radio"
 				}

--- a/src/stories/behaviour/filter/sourceLoop.json
+++ b/src/stories/behaviour/filter/sourceLoop.json
@@ -152,7 +152,7 @@
 					"response": {
 						"name": "NBHAB"
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"description": {
 						"type": "TXT",
 						"value": "Format attendu : un nombre entre 1 et 10"
@@ -209,7 +209,7 @@
 							"response": {
 								"name": "NAME"
 							},
-							"mandatory": false,
+							"isMandatory": false,
 							"maxLength": 249,
 							"componentType": "Input"
 						}
@@ -311,7 +311,7 @@
 							"response": {
 								"name": "AGE"
 							},
-							"mandatory": false,
+							"isMandatory": false,
 							"description": {
 								"type": "TXT",
 								"value": "Format attendu : un nombre entre 1 et 200"

--- a/src/stories/behaviour/missing/source.json
+++ b/src/stories/behaviour/missing/source.json
@@ -39,7 +39,7 @@
 		{
 			"id": "kze792d8",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "2",
 			"min": 0,
 			"max": 10,
@@ -165,7 +165,7 @@
 				{
 					"id": "ksyjvi40",
 					"componentType": "Input",
-					"mandatory": false,
+					"isMandatory": false,
 					"maxLength": 249,
 					"label": {
 						"value": "\"prénom\"",
@@ -197,7 +197,7 @@
 				{
 					"id": "nomksyjvi40",
 					"componentType": "Input",
-					"mandatory": false,
+					"isMandatory": false,
 					"maxLength": 249,
 					"label": {
 						"value": "\"Nom\"",
@@ -310,7 +310,7 @@
 				{
 					"id": "ksyke448",
 					"componentType": "InputNumber",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "5.1",
 					"min": 0,
 					"max": 100,
@@ -467,7 +467,7 @@
 		{
 			"id": "ku2pxugf",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "7",
 			"maxLength": 249,
 			"label": {
@@ -584,7 +584,7 @@
 		{
 			"id": "COMMENT-QUESTION",
 			"componentType": "Textarea",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "10",
 			"maxLength": 2000,
 			"label": {

--- a/src/stories/behaviour/others/V2_DeclarationsSimples.json
+++ b/src/stories/behaviour/others/V2_DeclarationsSimples.json
@@ -87,7 +87,7 @@
 		{
 			"id": "kanyduey",
 			"componentType": "Textarea",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "3",
 			"maxLength": 255,
 			"label": {
@@ -120,7 +120,7 @@
 		{
 			"id": "kzfdehqy",
 			"componentType": "Textarea",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "4",
 			"maxLength": 255,
 			"label": {
@@ -145,7 +145,7 @@
 		{
 			"id": "kzfdsuhw",
 			"componentType": "Textarea",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"maxLength": 255,
 			"label": {
@@ -170,7 +170,7 @@
 		{
 			"id": "kanye45b",
 			"componentType": "Textarea",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"maxLength": 255,
 			"label": {
@@ -203,7 +203,7 @@
 		{
 			"id": "kzfds450",
 			"componentType": "Textarea",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "7",
 			"maxLength": 255,
 			"label": {
@@ -228,7 +228,7 @@
 		{
 			"id": "kzfdnpeb",
 			"componentType": "Textarea",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"maxLength": 255,
 			"label": {
@@ -253,7 +253,7 @@
 		{
 			"id": "kzwo41pm",
 			"componentType": "Textarea",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "9",
 			"maxLength": 255,
 			"label": {
@@ -278,7 +278,7 @@
 		{
 			"id": "kanywetv",
 			"componentType": "Textarea",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "10",
 			"maxLength": 255,
 			"label": {
@@ -360,7 +360,7 @@
 		{
 			"id": "kanyscwo",
 			"componentType": "Textarea",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "12",
 			"maxLength": 255,
 			"label": {
@@ -411,7 +411,7 @@
 		{
 			"id": "kanz8hgh",
 			"componentType": "Textarea",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "13",
 			"maxLength": 255,
 			"label": {
@@ -497,7 +497,7 @@
 		{
 			"id": "kao1aya7",
 			"componentType": "Textarea",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "15",
 			"maxLength": 255,
 			"label": {
@@ -551,7 +551,7 @@
 		{
 			"id": "kanyicbv",
 			"componentType": "Textarea",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "16",
 			"maxLength": 255,
 			"label": {
@@ -584,7 +584,7 @@
 		{
 			"id": "kanyu00b",
 			"componentType": "Textarea",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "17",
 			"maxLength": 255,
 			"label": {
@@ -638,7 +638,7 @@
 		{
 			"id": "kanz18h6",
 			"componentType": "CheckboxOne",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "18",
 			"label": {
 				"value": "\"➡ 14. \" || \"Q11 saut de lignes dans les modalités de réponses (ne marche pas je crois)\"",

--- a/src/stories/behaviour/others/V2_MinMaxSum_Boucles.json
+++ b/src/stories/behaviour/others/V2_MinMaxSum_Boucles.json
@@ -30,7 +30,7 @@
 		{
 			"id": "kze792d8",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "2",
 			"min": 0,
 			"max": 10,
@@ -94,7 +94,7 @@
 				{
 					"id": "ksyjvi40",
 					"componentType": "Input",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "3",
 					"maxLength": 249,
 					"label": { "value": "\"➡ 2. \" || \"prénom\"", "type": "VTL|MD" },
@@ -174,7 +174,7 @@
 				{
 					"id": "ksyke448",
 					"componentType": "InputNumber",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "5.1",
 					"min": 0,
 					"max": 100,
@@ -260,7 +260,7 @@
 		{
 			"id": "ku2pxugf",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "7",
 			"maxLength": 249,
 			"label": { "value": "\"➡ 2. \" || \"divers\"", "type": "VTL|MD" },
@@ -323,7 +323,7 @@
 		{
 			"id": "ktwvc5zc",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "9",
 			"maxLength": 249,
 			"label": { "value": "\"➡ 3. \" || \"Texte\"", "type": "VTL|MD" },

--- a/src/stories/behaviour/others/V2_QuestSimple_Boucles.json
+++ b/src/stories/behaviour/others/V2_QuestSimple_Boucles.json
@@ -105,7 +105,7 @@
 		{
 			"id": "jfazk91m",
 			"componentType": "CheckboxBoolean",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "3",
 			"label": {
 				"value": "\"➡ 1. \" || \"Je suis un booleen qui filtre le reste\"",
@@ -181,7 +181,7 @@
 		{
 			"id": "jfazww20",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "4",
 			"maxLength": 10,
 			"label": {
@@ -218,7 +218,7 @@
 		{
 			"id": "jfazwjyv",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"maxLength": 249,
 			"label": {
@@ -255,7 +255,7 @@
 		{
 			"id": "kzwqst6c",
 			"componentType": "Textarea",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"maxLength": 250,
 			"label": {
@@ -292,7 +292,7 @@
 		{
 			"id": "kk2fu72i",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "7",
 			"maxLength": 9,
 			"label": {
@@ -379,7 +379,7 @@
 		{
 			"id": "jfjh1ndk",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"min": 10,
 			"max": 100,
@@ -438,7 +438,7 @@
 		{
 			"id": "jfjhb2pz",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "9",
 			"min": 10,
 			"max": 100,
@@ -474,7 +474,7 @@
 		{
 			"id": "l1ujlrg4",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "10",
 			"min": -1000,
 			"max": 1000,
@@ -510,7 +510,7 @@
 		{
 			"id": "jfjtbqh1",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "11",
 			"min": 0,
 			"max": 10,
@@ -547,7 +547,7 @@
 		{
 			"id": "kyiseu7q",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "12",
 			"min": 0,
 			"max": 10,
@@ -634,7 +634,7 @@
 		{
 			"id": "jfjfckyw",
 			"componentType": "Datepicker",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "13",
 			"min": "1980-01-01",
 			"max": "2022-01-01",
@@ -670,7 +670,7 @@
 		{
 			"id": "kvl6bpxb",
 			"componentType": "Datepicker",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "14",
 			"min": "1900",
 			"max": "2022",
@@ -706,7 +706,7 @@
 		{
 			"id": "jfjeud07",
 			"componentType": "CheckboxBoolean",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "15",
 			"label": { "value": "\"➡ 13. \" || \"Booléen\"", "type": "VTL|MD" },
 			"conditionFilter": {
@@ -797,7 +797,7 @@
 		{
 			"id": "jfjepz6i",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "18",
 			"label": {
 				"value": "\"➡ 1. \" || \"Question à choix unique - présentation bouton radio\"",
@@ -847,7 +847,7 @@
 		{
 			"id": "jfjero7b",
 			"componentType": "CheckboxOne",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "19",
 			"label": {
 				"value": "\"➡ 2. \" || \"Question à choix unique - présentation case à cocher\"",
@@ -897,7 +897,7 @@
 		{
 			"id": "jfjfae9f",
 			"componentType": "Dropdown",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "20",
 			"label": {
 				"value": "\"➡ 3. \" || \"Question à choix unique - présentation liste déroulante\"",
@@ -1061,7 +1061,7 @@
 		{
 			"id": "jfkxybfe",
 			"componentType": "Table",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "23",
 			"label": {
 				"value": "\"➡ 5. \" || \"Question à choix multiple - réponse oui/non case à cocher\"",
@@ -1203,7 +1203,7 @@
 		{
 			"id": "jfkyw9o1",
 			"componentType": "Table",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "24",
 			"label": {
 				"value": "\"➡ 6. \" || \"Question à choix multiple - réponse oui/non radio\"",
@@ -1370,7 +1370,7 @@
 		{
 			"id": "jfkzltkm",
 			"componentType": "Table",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "26",
 			"label": {
 				"value": "\"➡ 1. \" || \"Tableau un axe simple, une mesure\"",
@@ -1500,7 +1500,7 @@
 		{
 			"id": "jfkzpexn",
 			"componentType": "Table",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "27",
 			"label": {
 				"value": "\"➡ 2. \" || \"Tableau un axe simple, plusieurs mesures\"",
@@ -1766,7 +1766,7 @@
 		{
 			"id": "jfkzttm3",
 			"componentType": "Table",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "28",
 			"label": {
 				"value": "\"➡ 3. \" || \"Tableau 2 axes\"",
@@ -2173,7 +2173,7 @@
 		{
 			"id": "jfkzrwce",
 			"componentType": "Table",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "29",
 			"label": {
 				"value": "\"➡ 4. \" || \"Tableau 1 axe avec hiérarchie , 1 mesure\"",
@@ -2236,7 +2236,7 @@
 		{
 			"id": "kk47qwrd",
 			"componentType": "Table",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "30",
 			"label": {
 				"value": "\"➡ 5. \" || \"Tableau dynamique\"",
@@ -2412,7 +2412,7 @@
 		{
 			"id": "kmg10a27",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "32",
 			"min": 1,
 			"max": 20,
@@ -2513,7 +2513,7 @@
 				{
 					"id": "kmg0zlec",
 					"componentType": "Input",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "33",
 					"maxLength": 30,
 					"label": {
@@ -2546,7 +2546,7 @@
 				{
 					"id": "k3opea2m",
 					"componentType": "InputNumber",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "33",
 					"min": 0,
 					"max": 120,
@@ -2647,7 +2647,7 @@
 				{
 					"id": "l204183l",
 					"componentType": "Input",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "34",
 					"maxLength": 30,
 					"label": {
@@ -2680,7 +2680,7 @@
 				{
 					"id": "l20407qf",
 					"componentType": "InputNumber",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "34",
 					"min": 0,
 					"max": 120,

--- a/src/stories/behaviour/others/V2_TCMRallyeGames.json
+++ b/src/stories/behaviour/others/V2_TCMRallyeGames.json
@@ -41,7 +41,7 @@
 		{
 			"id": "l0v2t2lc",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "2",
 			"min": 1,
 			"max": 20,
@@ -128,7 +128,7 @@
 				{
 					"id": "l0v3g11i",
 					"componentType": "Input",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "3",
 					"maxLength": 40,
 					"label": {
@@ -276,7 +276,7 @@
 				{
 					"id": "l0v4b34m",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "4.2",
 					"label": {
 						"value": "\"➡ 3. \" || \"Quel est \" || if (PRENOM = PRENOMREF) then \"votre sexe ?\" else \"le sexe de \" || PRENOM || \" ?\"",
@@ -313,7 +313,7 @@
 				{
 					"id": "l0v4oi1v",
 					"componentType": "Datepicker",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "4.3",
 					"min": "1900-01-01",
 					"max": "2022-03-17",
@@ -353,7 +353,7 @@
 				{
 					"id": "l11z2too",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "4.4",
 					"label": {
 						"value": "\"➡ 5. \" || \"Vous n’avez pas indiqué de date de naissance, pouvez-vous indiquer \" || if (PRENOM = PRENOMREF) then \" votre âge ?\" else \"l’âge de \" || PRENOM || \" ?\"",
@@ -449,7 +449,7 @@
 				{
 					"id": "l11zznh4",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "4.5",
 					"label": {
 						"value": "\"➡ 6. \" || if (PRENOM = PRENOMREF) then \"Où êtes-vous né\"|| LIB_E || \" ?\" else \"Où est né\" || LIB_E || \" \" || PRENOM || \" ?\"",
@@ -512,7 +512,7 @@
 				{
 					"id": "l120kmks",
 					"componentType": "Dropdown",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "4.6",
 					"label": {
 						"value": "\"➡ 7. \" || \"Dans quel département \" || if (PRENOM = PRENOMREF) then \"êtes-vous né\" || LIB_E || \" ?\" else \"est né\" || LIB_E || \" \" || PRENOM || \" ?\"",
@@ -574,7 +574,7 @@
 				{
 					"id": "l120lqns",
 					"componentType": "Dropdown",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "4.7",
 					"label": {
 						"value": "\"➡ 8. \" || \"Dans quel pays \" || if(PRENOM = PRENOMREF) then \"êtes-vous né\" || LIB_E || \" ?\" else \"est né\"|| LIB_E || \" \" || PRENOM || \" ?\"",
@@ -719,7 +719,7 @@
 				{
 					"id": "l121ftlg",
 					"componentType": "Dropdown",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "4.9",
 					"label": {
 						"value": "\"➡ 10. \" || \"Quelle est \" || if (PRENOM = PRENOMREF) then \"votre nationalité étrangère ?\" else \"la nationalité étrangère de \" || PRENOM || \" ?\"",
@@ -822,7 +822,7 @@
 				{
 					"id": "l1265ml0",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "4.11",
 					"label": {
 						"value": "\"➡ 11. \" || (if (PRENOM = PRENOMREF) then \"Depuis votre naissance, avez-vous\" else \"Depuis sa naissance, \" || PRENOM || \" a-t-\" || LIB_PR ) || \" vécu au moins un an sans interruption à l’étranger ?\"",
@@ -869,7 +869,7 @@
 				{
 					"id": "l12b8hbj",
 					"componentType": "Datepicker",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "4.12",
 					"min": "1900-01",
 					"max": "2022-03",
@@ -934,7 +934,7 @@
 				{
 					"id": "l126og4z",
 					"componentType": "Datepicker",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "4.13",
 					"min": "1900-01",
 					"max": "2022-03",
@@ -999,7 +999,7 @@
 				{
 					"id": "l1uxyne3",
 					"componentType": "InputNumber",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "4.14",
 					"min": 0,
 					"max": 120,
@@ -1045,7 +1045,7 @@
 				{
 					"id": "l127ghn9",
 					"componentType": "Datepicker",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "4.15",
 					"min": "1900",
 					"max": "2022",
@@ -1117,7 +1117,7 @@
 				{
 					"id": "l1283pqp",
 					"componentType": "InputNumber",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "4.16",
 					"min": 0,
 					"max": 120,
@@ -1245,7 +1245,7 @@
 				{
 					"id": "l13nj6s2",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "5.2",
 					"label": {
 						"value": "\"➡ 17. \" || (if (PRENOM = PRENOMREF) then \"Vivez-vous\" else PRENOM || \" vit-\" || LIB_PR ) || \" aussi dans un autre logement ?\"",
@@ -1306,7 +1306,7 @@
 				{
 					"id": "l13nyqwe",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "5.3",
 					"label": {
 						"value": "\"➡ 18. \" || \"Combien de temps \" || if (PRENOM = PRENOMREF) then \"vivez vous dans le logement situé à l’adresse \" || ADR || \" ?\" else PRENOM || \" vit-\" || LIB_PR || \" dans le logement situé à l’adresse \" || ADR || \" ?\"",
@@ -1456,7 +1456,7 @@
 				{
 					"id": "l13on6tn",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "5.5",
 					"label": {
 						"value": "\"➡ 20. \" || if (PRENOM = PRENOMREF) then \"L’autre logement dans lequel vous vivez est-il ... ?\" else \"Pour \" || PRENOM || \", l’autre logement dans lequel \" || LIB_PR || \" vit, est-il ... ?\"",
@@ -1563,7 +1563,7 @@
 				{
 					"id": "l13oux5e",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "5.6",
 					"label": {
 						"value": "\"➡ 21. \" || (if (PRENOM = PRENOMREF) then \"Etes-vous\" else PRENOM || \" est-\" ||LIB_PR ) || \" en résidence alternée entre ses deux parents ?\"",
@@ -1607,7 +1607,7 @@
 				{
 					"id": "l13pabqu",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "5.7",
 					"label": {
 						"value": "\"➡ 22. \" || (if (PRENOM = PRENOMREF) then \"Où avez-vous\" else \"Où \" || PRENOM || \" a-t-\" || LIB_PR ) || \" dormi la nuit derière ?\"",
@@ -1676,7 +1676,7 @@
 				{
 					"id": "l13pbxr1",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "5.8",
 					"label": {
 						"value": "\"➡ 23. \" || (if (PRENOM = PRENOMREF) then \"Pour vous\" else \"Pour \" || PRENOM ) || \", le logement situé à l’adresse \" || ADR || \" est-il ... ?\"",
@@ -1773,7 +1773,7 @@
 				{
 					"id": "l13pyw1k",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "5.9",
 					"label": {
 						"value": "\"➡ 24. \" || if (PRENOM = PRENOMREF) then \"L’autre logement dans lequel vous vivez est-il ... ?\" else \"Pour \" || PRENOM || \", l’autre logement dans lequel \" || LIB_PR || \" vit, est-il ... ?\"",
@@ -1881,7 +1881,7 @@
 				{
 					"id": "l13q9a24",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "5.10",
 					"label": {
 						"value": "\"➡ 25. \" || \"L’autre logement \" || (if (PRENOM = PRENOMREF) then \"dans lequel vous vivez\" else \"où vit \" || PRENOM ) || \" est-il une chambre dans une structure collective (internat, résidence étudiante, foyer de l’enfance, foyer de jeunes travailleurs) ?\"",
@@ -1919,7 +1919,7 @@
 				{
 					"id": "l13qc9n8",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "5.11",
 					"label": {
 						"value": "\"➡ 26. \" || \"De quelle structure s’agit-il ?\"",

--- a/src/stories/behaviour/others/test-dylan.json
+++ b/src/stories/behaviour/others/test-dylan.json
@@ -155,7 +155,7 @@
 			},
 			"conditionFilter": { "type": "VTL", "value": "true" },
 			"label": { "type": "VTL|MD", "value": "\"➡ 1. \" || \"NB\"" },
-			"mandatory": false,
+			"isMandatory": false,
 			"bindingDependencies": ["NB"],
 			"min": 0,
 			"response": { "name": "NB" },
@@ -233,7 +233,7 @@
 					"id": "ksyjvi40",
 					"page": "3",
 					"label": { "type": "VTL|MD", "value": "\"➡ 2. \" || \"prénom\"" },
-					"mandatory": false,
+					"isMandatory": false,
 					"maxLength": 249,
 					"declarations": [
 						{
@@ -360,7 +360,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 3. \" || \"Age de l’individu : \" || PRENOM"
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"declarations": [
 						{
 							"declarationType": "HELP",
@@ -483,7 +483,7 @@
 			"id": "ku2pxugf",
 			"page": "7",
 			"label": { "type": "VTL|MD", "value": "\"➡ 4. \" || \"divers\"" },
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 249
 		},
 		{
@@ -518,7 +518,7 @@
 				"type": "VTL|MD",
 				"value": "\"Avez-vous des remarques concernant l'enquête ou des commentaires ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 2000
 		}
 	],

--- a/src/stories/behaviour/resizing/source-resizing-cleaning.json
+++ b/src/stories/behaviour/resizing/source-resizing-cleaning.json
@@ -17,7 +17,7 @@
 			"page": "1",
 			"id": "lfwih8tj-habitants",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"min": 0,
 			"max": 25,
 			"label": {

--- a/src/stories/behaviour/resizing/source.json
+++ b/src/stories/behaviour/resizing/source.json
@@ -201,7 +201,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 1. \" || \"NB\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"bindingDependencies": ["NB"],
 			"min": 0,
 			"response": {
@@ -313,7 +313,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 2. \" || \"prénom\""
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"maxLength": 249,
 					"declarations": [
 						{
@@ -488,7 +488,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 3. \" || \"Age de l’individu : \" || PRENOM"
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"declarations": [
 						{
 							"declarationType": "HELP",
@@ -639,7 +639,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 4. \" || \"divers\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 249
 		},
 		{
@@ -744,7 +744,7 @@
 				"type": "VTL|MD",
 				"value": "\"Avez-vous des remarques concernant l'enquête ou des commentaires ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 2000
 		}
 	],

--- a/src/stories/checkbox-boolean/source.json
+++ b/src/stories/checkbox-boolean/source.json
@@ -3,7 +3,7 @@
 		{
 			"id": "checkboxboolean",
 			"componentType": "CheckboxBoolean",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "1",
 			"label": {
 				"value": "\"checkboxBoolean component (checked: true, unchecked: false)\"",

--- a/src/stories/checkbox-one/source.json
+++ b/src/stories/checkbox-one/source.json
@@ -5,7 +5,7 @@
 		{
 			"id": "checkboxone",
 			"componentType": "CheckboxOne",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "1",
 			"label": {
 				"value": "\"checkboxone ONE component\"",

--- a/src/stories/checkbox-one/sourceDetail.json
+++ b/src/stories/checkbox-one/sourceDetail.json
@@ -4,7 +4,7 @@
 		{
 			"id": "checkboxone",
 			"componentType": "CheckboxOne",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "3",
 			"label": {
 				"value": "\"checkboxone ONE component\"",

--- a/src/stories/date-picker/source.json
+++ b/src/stories/date-picker/source.json
@@ -6,7 +6,7 @@
 			"dateFormat": "YYYY-MM-DD",
 			"conditionFilter": { "type": "VTL", "value": "true" },
 			"label": { "type": "VTL|MD", "value": "\"➡ 1. \" || \"Birth day\"" },
-			"mandatory": false,
+			"isMandatory": false,
 			"min": "1900-01-01",
 			"response": { "name": "Q1" },
 			"id": "l7ovm2rv",

--- a/src/stories/disabled/source.json
+++ b/src/stories/disabled/source.json
@@ -40,7 +40,7 @@
 		{
 			"id": "radio",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "1",
 			"label": {
 				"value": "\"Disabled or enabled!\"",
@@ -74,7 +74,7 @@
 		{
 			"id": "radio1",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "2",
 			"readOnly": { "value": "DISABLED_SEXE", "type": "VTL" },
 			"label": {
@@ -109,7 +109,7 @@
 		{
 			"id": "radio3",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "2",
 			"label": {
 				"value": "\"Disabled or enabled!\"",
@@ -193,7 +193,7 @@
 		{
 			"id": "radio",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "3",
 			"label": {
 				"value": "\"Disabled or enabled!\"",
@@ -262,7 +262,7 @@
 		{
 			"id": "radio",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "4",
 			"label": {
 				"value": "\"Disabled or enabled!\"",

--- a/src/stories/dropdown/source.json
+++ b/src/stories/dropdown/source.json
@@ -4,7 +4,7 @@
 		{
 			"id": "j4nw5cqz",
 			"componentType": "Dropdown",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "1",
 			"label": {
 				"value": "\"In which state do The Simpsons reside?\"",
@@ -59,7 +59,7 @@
 		{
 			"id": "j4nw5cqz-bis",
 			"componentType": "Dropdown",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "1",
 			"label": {
 				"value": "\"In which state do The Simpsons reside?\"",

--- a/src/stories/duration/mois.json
+++ b/src/stories/duration/mois.json
@@ -3,7 +3,7 @@
 		{
 			"id": "kxi788",
 			"componentType": "Duration",
-			"mandatory": false,
+			"isMandatory": false,
 			"format": "PnYnM",
 			"page": "1",
 			"maxPage": "1",

--- a/src/stories/duration/time.json
+++ b/src/stories/duration/time.json
@@ -3,7 +3,7 @@
 		{
 			"id": "kxi788",
 			"componentType": "Duration",
-			"mandatory": false,
+			"isMandatory": false,
 			"format": "PTnHnM",
 			"page": "1",
 			"maxPage": "1",

--- a/src/stories/input-number/source-big-number.json
+++ b/src/stories/input-number/source-big-number.json
@@ -4,7 +4,7 @@
 		{
 			"id": "kze792d8",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "1",
 			"min": 0,
 			"decimals": 0,

--- a/src/stories/input-number/source-euro.json
+++ b/src/stories/input-number/source-euro.json
@@ -4,7 +4,7 @@
 		{
 			"id": "kze792d8",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "1",
 			"min": 0,
 			"max": 10,
@@ -18,7 +18,7 @@
 		{
 			"id": "kze792d8",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "1",
 			"min": 0,
 			"max": 10,

--- a/src/stories/overview/sourceLoop.json
+++ b/src/stories/overview/sourceLoop.json
@@ -331,7 +331,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 1. \" || \"Vous allez bien ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Subsequence",
@@ -428,7 +428,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 2. \" || \"Êtes-vous satisfait de votre logement ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Sequence",
@@ -484,7 +484,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 3. \" || \"Combien d'habitants dans votre logement ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"paginatedLoop": false,
@@ -559,7 +559,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 4. \" || \" \" || if (T_NBHAB = 1) then \"Votre prénom : \" else (if ( not(isnull(T_PRENOM)) and T_PRENOM=PRENOMREF ) then \"Votre prénom : \" else ( if (isnull(PRENOMREFB) and isnull(T_PRENOM)) then \"Prénom (commencez par votre prénom) : \" else \"Prénom : \")) "
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"maxLength": 40
 				}
 			],
@@ -658,7 +658,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 5. \" || \"Un petit commentaire sur cette composition de logement ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 249
 		},
 		{
@@ -772,7 +772,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 6. \" || \"Quel est \" || if (PRENOM = PRENOMREF) then \"votre sexe ?\" else \"le sexe de \" || PRENOM || \" ?\" "
 					},
-					"mandatory": false
+					"isMandatory": false
 				}
 			],
 			"depth": 1,
@@ -873,7 +873,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 7. \" || \"Quelle est la date de naissance de \" || PRENOM || \" ?\" "
 					},
-					"mandatory": false
+					"isMandatory": false
 				},
 				{
 					"componentType": "Subsequence",
@@ -942,7 +942,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 8. \" || \"Des remarques pour \" || PRENOM "
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"maxLength": 249
 				}
 			],
@@ -1064,7 +1064,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 9. \" || \"Super question pour \" || PRENOM "
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"maxLength": 249
 				},
 				{
@@ -1134,7 +1134,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 10. \" || \"Encore une question pour \" || PRENOM "
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"maxLength": 249
 				},
 				{
@@ -1188,7 +1188,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 11. \" || \"Autre super question pour \" || PRENOM "
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"maxLength": 249
 				}
 			],
@@ -1266,7 +1266,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 12. \" || \"Avez-vous des remarques concernant l'enquête ou des commentaires ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 2000
 		}
 	],

--- a/src/stories/overview/sourceWithHierarchy.json
+++ b/src/stories/overview/sourceWithHierarchy.json
@@ -39,7 +39,7 @@
 		{
 			"id": "j6p3dkx6",
 			"componentType": "Textarea",
-			"mandatory": true,
+			"isMandatory": true,
 			"page": "2",
 			"maxLength": 500,
 			"label": {
@@ -62,7 +62,7 @@
 		{
 			"id": "j6p0np9q",
 			"componentType": "CheckboxBoolean",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "3",
 			"label": {
 				"value": "\"➡ \" || \"If you agree to answer this questionnaire, please check the box\"",
@@ -144,7 +144,7 @@
 		{
 			"id": "j3343qhx",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "4",
 			"maxLength": 30,
 			"label": {
@@ -179,7 +179,7 @@
 		{
 			"id": "j6q9h8tj",
 			"componentType": "InputNumber",
-			"mandatory": true,
+			"isMandatory": true,
 			"page": "5",
 			"min": 0,
 			"max": 99,
@@ -216,7 +216,7 @@
 		{
 			"id": "kiq71eoi",
 			"componentType": "Datepicker",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"min": "1900-01-01",
 			"max": "format-date(current-date(),'[Y0001]-[M01]-[D01]')",
@@ -264,7 +264,7 @@
 		{
 			"id": "k5nvty2o",
 			"componentType": "Datepicker",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "7",
 			"min": "1980-05",
 			"label": {
@@ -311,7 +311,7 @@
 		{
 			"id": "k5nw1fir",
 			"componentType": "Datepicker",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"min": "1900",
 			"max": "year-from-date(current-date())",
@@ -359,7 +359,7 @@
 		{
 			"id": "k5nw0w05",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "9",
 			"min": 0,
 			"max": 70,
@@ -397,7 +397,7 @@
 		{
 			"id": "k5nvu98z",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "10",
 			"min": 0,
 			"max": 366,
@@ -435,7 +435,7 @@
 		{
 			"id": "k5nw8ei1",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "11",
 			"min": 0,
 			"max": 12,
@@ -473,7 +473,7 @@
 		{
 			"id": "k5nw9dk4",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "12",
 			"min": 0,
 			"max": 100,
@@ -511,7 +511,7 @@
 		{
 			"id": "j6z06z1e",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "13",
 			"min": 0,
 			"max": 99,
@@ -582,7 +582,7 @@
 		{
 			"id": "j3343clt",
 			"componentType": "Radio",
-			"mandatory": true,
+			"isMandatory": true,
 			"page": "15",
 			"label": {
 				"value": "\"➡ \" || \"In which city do the Simpsons reside?\"",
@@ -635,7 +635,7 @@
 		{
 			"id": "j6qdfhvw",
 			"componentType": "CheckboxOne",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "16",
 			"label": {
 				"value": "\"➡ \" || \"Who is the Simpsons city mayor?\"",
@@ -693,7 +693,7 @@
 		{
 			"id": "j4nw5cqz",
 			"componentType": "Dropdown",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "17",
 			"label": {
 				"value": "\"➡ \" || \"In which state do The Simpsons reside?\"",
@@ -852,7 +852,7 @@
 		{
 			"id": "j6p29i81",
 			"componentType": "Table",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "20",
 			"label": {
 				"value": "\"➡ \" || \"Does Jay like the following ice cream flavours?\"",
@@ -980,7 +980,7 @@
 		{
 			"id": "j6qefnga",
 			"componentType": "Table",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "21",
 			"label": {
 				"value": "\"➡ \" || \"Which character works in the nuclear power plant?\"",
@@ -1103,7 +1103,7 @@
 		{
 			"id": "j6yzoc6g",
 			"componentType": "Table",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "22",
 			"label": {
 				"value": "\"➡ \" || \"In which city each character was born?\"",
@@ -1388,7 +1388,7 @@
 		{
 			"id": "j4nwc63q",
 			"componentType": "Table",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "24",
 			"label": {
 				"value": "\"➡ \" || \"Please, specify the percentage of Jay’s expenses in the Kwik-E-Mart for each product?\"",
@@ -1590,7 +1590,7 @@
 		{
 			"id": "k9cg2q5t",
 			"componentType": "Table",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "25",
 			"label": {
 				"value": "\"➡ \" || \"Please specify if Jay has bought each product in his last food shopping\"",
@@ -1930,7 +1930,7 @@
 		{
 			"id": "kbkjvgel",
 			"componentType": "Table",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "26",
 			"label": {
 				"value": "\"➡ \" || \"Who did these clownings and tell us what you remember?\"",
@@ -2189,7 +2189,7 @@
 		{
 			"id": "j6p2lwuj",
 			"componentType": "Table",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "27",
 			"label": {
 				"value": "\"➡ \" || \"Which of the following means of transport were used by the hero and in which country?\"",
@@ -2487,7 +2487,7 @@
 		{
 			"id": "j6qg8rc6",
 			"componentType": "Table",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "29",
 			"label": {
 				"value": "\"➡ \" || \"Please, complete the following grid with your favourite characters\"",
@@ -2977,7 +2977,7 @@
 		{
 			"id": "jvxux0mi",
 			"componentType": "Table",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "30",
 			"label": {
 				"value": "\"➡ \" || \"How has your feeling about the following characters evolved over time?\"",
@@ -3123,7 +3123,7 @@
 		{
 			"id": "jvxwy68n",
 			"componentType": "Table",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "31",
 			"label": {
 				"value": "\"➡ \" || \"Can you tell how long Bart Simpson has been on leave for each type and whether there has been another type?\"",
@@ -3374,7 +3374,7 @@
 		{
 			"id": "kiq612ky",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "33",
 			"min": 0,
 			"max": 20,
@@ -3475,7 +3475,7 @@
 				{
 					"id": "kiq66gtw",
 					"componentType": "Input",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "34",
 					"maxLength": 30,
 					"label": {
@@ -3512,7 +3512,7 @@
 				{
 					"id": "kiq5r8wu",
 					"componentType": "InputNumber",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "34",
 					"min": 0,
 					"max": 120,
@@ -3600,7 +3600,7 @@
 				{
 					"id": "kiq65x3c",
 					"componentType": "CheckboxOne",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "35.2",
 					"label": {
 						"value": "\"➡ \" || \"Is character named \" || NAME_CHAR || \" your favourite one ? \"",
@@ -3639,7 +3639,7 @@
 				{
 					"id": "kiq651zv",
 					"componentType": "Textarea",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "35.3",
 					"maxLength": 255,
 					"label": {
@@ -3692,7 +3692,7 @@
 		{
 			"id": "j6z0z3us",
 			"componentType": "Textarea",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "37",
 			"maxLength": 255,
 			"label": {
@@ -3730,7 +3730,7 @@
 		{
 			"id": "COMMENT-QUESTION",
 			"componentType": "Textarea",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "39",
 			"maxLength": 2000,
 			"label": { "value": "\"VIII - \" || \"Comment\"", "type": "VTL|MD" },

--- a/src/stories/question/source.json
+++ b/src/stories/question/source.json
@@ -114,7 +114,7 @@
 						"type": "VTL|MD",
 						"value": "\"Le label du champ input\""
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"maxLength": 15,
 					"declarations": [
 						{
@@ -146,7 +146,7 @@
 				{
 					"id": "k0dzbfek",
 					"componentType": "InputNumber",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "2",
 					"min": 0,
 					"max": 100,

--- a/src/stories/questionnaires/logement/source-sequence.json
+++ b/src/stories/questionnaires/logement/source-sequence.json
@@ -49,7 +49,7 @@
 		{
 			"id": "kb9hlpdc",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "1",
 			"label": {
 				"value": "\"➡ \" || \"Confirmez-vous que vous habitez toujours à l’adresse suivante : \" || ADRESSE || \" ?\"",
@@ -116,7 +116,7 @@
 		{
 			"id": "kbakywwy",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "1",
 			"maxLength": 10,
 			"label": { "value": "\"➡ \" || \"Numéro de voie :\"", "type": "VTL|MD" },
@@ -171,7 +171,7 @@
 		{
 			"id": "kbal4bzb",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "1",
 			"maxLength": 50,
 			"label": {
@@ -224,7 +224,7 @@
 		{
 			"id": "kbalhn4i",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "1",
 			"maxLength": 50,
 			"label": {
@@ -262,7 +262,7 @@
 		{
 			"id": "kbal8crw",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "1",
 			"maxLength": 5,
 			"label": { "value": "\"➡ \" || \"Code postal :\"", "type": "VTL|MD" },
@@ -312,7 +312,7 @@
 		{
 			"id": "kbal9dwk",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "1",
 			"maxLength": 100,
 			"label": { "value": "\"➡ \" || \"Commune :\"", "type": "VTL|MD" },
@@ -375,7 +375,7 @@
 		{
 			"id": "kqweh61i",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "1",
 			"label": {
 				"value": "\"➡ \" || \"Connaissez-vous le nom de la ou des personnes qui vous ont succédé dans le logement situé à l’adresse suivante : \" || ADRESSE || \" ?\"",
@@ -411,7 +411,7 @@
 		{
 			"id": "kqwga16w",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "1",
 			"maxLength": 40,
 			"label": { "value": "\"➡ \" || \"Nom :\"", "type": "VTL|MD" },
@@ -451,7 +451,7 @@
 		{
 			"id": "kqwfswjj",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "1",
 			"maxLength": 20,
 			"label": { "value": "\"➡ \" || \"Prénom :\"", "type": "VTL|MD" },
@@ -480,7 +480,7 @@
 		{
 			"id": "kqwfedoy",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "1",
 			"maxLength": 40,
 			"label": {
@@ -512,7 +512,7 @@
 		{
 			"id": "kqwg9azb",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "1",
 			"maxLength": 20,
 			"label": {
@@ -544,7 +544,7 @@
 		{
 			"id": "kr0e0pav",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "1",
 			"maxLength": 10,
 			"label": {
@@ -592,7 +592,7 @@
 		{
 			"id": "kr0ee3u2",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "1",
 			"maxLength": 249,
 			"label": {
@@ -675,7 +675,7 @@
 		{
 			"id": "kbc1b4k2",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "2",
 			"min": 1,
 			"max": 15,
@@ -873,7 +873,7 @@
 				{
 					"id": "kmno1n7m",
 					"componentType": "Input",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "3",
 					"maxLength": 20,
 					"label": {
@@ -1022,7 +1022,7 @@
 				{
 					"id": "kmoo2fiy",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "3",
 					"label": {
 						"value": "\"➡ \" || \"Quel est \" || if (PRENOM=PRENOMREF) then \"votre sexe ?\" else \"le sexe de \" || PRENOM || \" ?\"",
@@ -1073,7 +1073,7 @@
 				{
 					"id": "kmoouamz",
 					"componentType": "Datepicker",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "3",
 					"min": "1900-01-01",
 					"max": "2022-12-31",
@@ -1148,7 +1148,7 @@
 				{
 					"id": "kmx6w6n5",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "3",
 					"label": {
 						"value": "\"➡ \" || \"Vous n’avez pas indiqué de date de naissance, pouvez-vous indiquer la tranche d’âge dans laquelle \" || if (PRENOM=PRENOMREF) then \"vous vous situez ?\" else \"se situe\" || \" \" || PRENOM || \" ?\"",
@@ -1207,7 +1207,7 @@
 				{
 					"id": "kmookacu",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "3",
 					"label": {
 						"value": "\"➡ \" || \"Où \"|| if (PRENOM=PRENOMREF) then \"êtes-vous né\" || LIB_FEM || \" ?\" else \"est né\" || LIB_FEM || \" \" || PRENOM || \" ?\"",
@@ -1265,7 +1265,7 @@
 				{
 					"id": "kmor2z1x",
 					"componentType": "Dropdown",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "3",
 					"label": {
 						"value": "\"➡ \" || \"Dans quel département \"|| if (PRENOM=PRENOMREF) then \"êtes-vous né\" || LIB_FEM || \" ?\" else \"est né\" || LIB_FEM || \" \" || PRENOM || \" ?\"",
@@ -1337,7 +1337,7 @@
 				{
 					"id": "kmorege9",
 					"componentType": "Dropdown",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "3",
 					"label": {
 						"value": "\"➡ \" || \"Dans quel pays \"|| if (PRENOM=PRENOMREF) then \"êtes-vous né\" || LIB_FEM || \" ?\" else \"est né\" || LIB_FEM || \" \" || PRENOM || \" ?\"",
@@ -1520,7 +1520,7 @@
 				{
 					"id": "kmos2yo6",
 					"componentType": "Dropdown",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "3",
 					"label": {
 						"value": "\"➡ \" || \"Quelle est \"|| if (PRENOM=PRENOMREF) then \"votre nationalité étrangère ?\" else \"la nationalité étrangère de \" || PRENOM || \" ?\"",
@@ -1665,7 +1665,7 @@
 				{
 					"id": "kmw4revw",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "3",
 					"label": {
 						"value": "\"➡ \" || \"Qui est \"|| PRENOM || \" pour vous ?\"",
@@ -1763,7 +1763,7 @@
 				{
 					"id": "kod271pp",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "3",
 					"label": {
 						"value": "\"➡ \" || if (PRENOM=PRENOMREF) then \"Vivez-vous en couple ?\" else PRENOM || \" vit-\" || LIB_SUJET || \" en couple ?\"",
@@ -1977,7 +1977,7 @@
 		{
 			"id": "kwp9ynon",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "3",
 			"label": {
 				"value": "\"➡ \" || (if (INDENF=\"1\") then \"En dehors des enfants décrits précédemment, accueillez-vous \" else \"Accueillez-vous \") || \"un ou plusieurs enfants au titre du droit de visite et d’hébergement ?\"",
@@ -2019,7 +2019,7 @@
 		{
 			"id": "kwpbyciz",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "3",
 			"min": 0,
 			"max": 15,
@@ -2227,7 +2227,7 @@
 				{
 					"id": "kmx8sgeu",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "3",
 					"label": {
 						"value": "\"➡ \" || if (PRENOM=PRENOMREF) then \"Vivez-vous uniquement dans ce logement ou aussi dans un autre logement ?\" else PRENOM || \" vit-\" || LIB_SUJET || \" uniquement dans ce logement ou aussi dans un autre logement ?\"",
@@ -2300,7 +2300,7 @@
 				{
 					"id": "kmx97ttc",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "3",
 					"label": {
 						"value": "\"➡ \" || if (PRENOM=PRENOMREF) then \"Vous vivez dans le logement situé à l’adresse : \" || ADRCOLLC || \" ... ?\" else PRENOM || \" vit dans ce logement situé à l’adresse : \" || ADRCOLLC || \" ... ?\"",
@@ -2366,7 +2366,7 @@
 				{
 					"id": "kmx97tz1",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "3",
 					"label": {
 						"value": "\"➡ \" || if (PRENOM=PRENOMREF) then \"Pour vous, ce logement est... ?\" else \"Pour \" || PRENOM || \", ce logement est... ?\"",
@@ -2470,7 +2470,7 @@
 				{
 					"id": "kmx93med",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "3",
 					"label": {
 						"value": "\"➡ \" || if (PRENOM=PRENOMREF) then \"Pour vous, l’autre logement où vous vivez est... ?\" else \"Pour \" || PRENOM || \", l’autre logement où \" || LIB_SUJET || \" vit est... ?\"",
@@ -2585,7 +2585,7 @@
 				{
 					"id": "kmx9punx",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "3",
 					"label": {
 						"value": "\"➡ \" || if (PRENOM=PRENOMREF) then \"Êtes-vous en garde alternée entre vos deux parents ?\" else PRENOM || \" est-\" || LIB_SUJET || \" en garde alternée entre ses deux parents ?\"",
@@ -2640,7 +2640,7 @@
 				{
 					"id": "kmx9im0b",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "3",
 					"label": {
 						"value": "\"➡ \" || if (PRENOM=PRENOMREF) then \"Où avez-vous dormi la nuit dernière ?\" else \"Où \" || PRENOM || \" a-t-\" || LIB_SUJET || \" dormi la nuit dernière ?\"",
@@ -2720,7 +2720,7 @@
 				{
 					"id": "kqi4zdkk",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "3",
 					"label": {
 						"value": "\"➡ \" || if (PRENOM=PRENOMREF) then \"À propos de cet autre logement dans lequel vous vivez, s’agit-il d’une chambre dans une structure collective ?\" else \"À propos de cet autre logement dans lequel vit \" || PRENOM || \", s’agit-il d’une chambre dans une structure collective ?\"",
@@ -2780,7 +2780,7 @@
 				{
 					"id": "kmx9pvyn",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "3",
 					"label": {
 						"value": "\"➡ \" || \"De quelle structure s’agit-il ?\"",
@@ -2986,7 +2986,7 @@
 				{
 					"id": "kmxfqrb1",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "3",
 					"label": {
 						"value": "\"➡ \" || if (PRENOM=PRENOMREF) then \"Actuellement, quelle est votre situation principale ?\" else \"Actuellement, quelle est la situation principale de \" || PRENOM || \" ?\"",
@@ -3114,7 +3114,7 @@
 				{
 					"id": "kmxg8ci7",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "3",
 					"label": {
 						"value": "\"➡ \" || if (PRENOM=PRENOMREF) then \"Avez-vous cependant un emploi ?\" else PRENOM || \" a-t-\" || LIB_SUJET || \" cependant un emploi ?\"",
@@ -3192,7 +3192,7 @@
 				{
 					"id": "kmxgftfs",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "3",
 					"label": {
 						"value": "\"➡ \" || if (PRENOM=PRENOMREF) then \"À ce jour, quel est le plus haut diplôme ou titre que vous possédez ?\" else \"À ce jour, quel est le plus haut diplôme ou titre que \" || PRENOM || \" possède ?\"",
@@ -3327,7 +3327,7 @@
 				{
 					"id": "kqi8s71l",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "3",
 					"label": {
 						"value": "\"➡ \" || if (PRENOM=PRENOMREF) then \"Plus précisément, quel est votre niveau d’études ?\" else \"Plus précisément, quel est le niveau d’études de \" || PRENOM ||\" ?\"",
@@ -3405,7 +3405,7 @@
 				{
 					"id": "kqi8mfos",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "3",
 					"label": {
 						"value": "\"➡ \" || if (PRENOM=PRENOMREF) then \"Plus précisément, quel diplôme de niveau supérieur à bac+2 avez-vous obtenu ?\" else \"Plus précisément, quel diplôme de niveau supérieur à bac+2 \"|| PRENOM || \" a-t-\" || LIB_SUJET || \" obtenu ?\"",
@@ -3484,7 +3484,7 @@
 				{
 					"id": "kp4dw3br",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "3",
 					"label": {
 						"value": "\"➡ \" || if (PRENOM=PRENOMREF) then \"Pratiquez-vous le télétravail ?\" else PRENOM || \" pratique-t-\" || LIB_SUJET || \" le télétravail ?\"",
@@ -3545,7 +3545,7 @@
 				{
 					"id": "kvjb8q33",
 					"componentType": "InputNumber",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "3",
 					"min": 0,
 					"max": 7,
@@ -3636,7 +3636,7 @@
 		{
 			"id": "kd8qd4ou",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "3",
 			"label": {
 				"value": "\"➡ \" || \"À quoi correspond votre logement ?\"",
@@ -3727,7 +3727,7 @@
 		{
 			"id": "kp4b8f63",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "3",
 			"label": {
 				"value": "\"➡ \" || \"Est-ce que votre logement se trouve en foyer (ou résidence) pour personnes âgées ?\"",
@@ -3766,7 +3766,7 @@
 		{
 			"id": "kp4bwrb9",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "3",
 			"label": {
 				"value": "\"➡ \" || \"Plus précisément, quel est le type de cette résidence ?\"",
@@ -3817,7 +3817,7 @@
 		{
 			"id": "kbgi5n3g",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "3",
 			"label": {
 				"value": "\"➡ \" || \"Le logement fait-il partie d’un immeuble collectif ?\"",
@@ -3871,7 +3871,7 @@
 		{
 			"id": "kbgigljc",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "3",
 			"label": {
 				"value": "\"➡ \" || \"Quel est le type de construction de la maison individuelle ?\"",
@@ -3916,7 +3916,7 @@
 		{
 			"id": "kbgim4v3",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "3",
 			"label": {
 				"value": "\"➡ \" || \"La maison fait-elle partie d’une résidence ou d’un ’village’ en copropriété ?\"",
@@ -3967,7 +3967,7 @@
 		{
 			"id": "kbgidvnm",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "3",
 			"label": {
 				"value": "\"➡ \" || \"Y a-t-il au moins un ascenseur dans l’immeuble collectif ?\"",
@@ -4006,7 +4006,7 @@
 		{
 			"id": "kbgigafp",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "3",
 			"min": 0,
 			"max": 99,
@@ -4058,7 +4058,7 @@
 		{
 			"id": "kbghszh6",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "3",
 			"label": {
 				"value": "\"➡ \" || \"À quelle période a été achevée la construction \"|| libIAATC || \" ?\"",
@@ -4120,7 +4120,7 @@
 		{
 			"id": "kbghz7mp",
 			"componentType": "Dropdown",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "3",
 			"label": {
 				"value": "\"➡ \" || \"En quelle année exactement la construction \" || libIAATC || \" a-t-elle été achevée ?\"",
@@ -4266,7 +4266,7 @@
 		{
 			"id": "jn0cttir",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "4",
 			"label": {
 				"value": "\"➡ \" || \"Comment votre ménage occupe-t-il ce logement ?\"",
@@ -4367,7 +4367,7 @@
 		{
 			"id": "klusnxnh",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "4",
 			"label": {
 				"value": "\"➡ \" || \"Un des occupants actuels du logement est-il propriétaire de ce logement ?\"",
@@ -4431,7 +4431,7 @@
 		{
 			"id": "jn0e3nhg",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "4",
 			"label": {
 				"value": "\"➡ \" || \"Votre ménage occupe-t-il ce logement en pleine propriété ou en propriété partielle ?&#xd;​\"",
@@ -4579,7 +4579,7 @@
 				{
 					"id": "ko9tiu0f",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "4",
 					"label": {
 						"value": "\"➡ \" || \"À titre personnel, \" || if (PRENOM=PRENOMREF) then \"votre nom figure-t-il sur l’acte de propriété ?\" else \"le nom de \" || PRENOM || \" figure-t-il sur l’acte de propriété ?\"",
@@ -4664,7 +4664,7 @@
 				{
 					"id": "ko9r0alc",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "4",
 					"label": {
 						"value": "\"➡ \" || \"À titre personnel, \" || (if (PRENOM=PRENOMREF) then \"êtes-vous\" else (PRENOM || \" est-\" || LIB_SUJET)) || \" usufruiti\" || LIB_FEM2 || \" de ce logement ?\"",
@@ -4743,7 +4743,7 @@
 				{
 					"id": "ko9t45t9",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "4",
 					"label": {
 						"value": "\"➡ \" || \"À titre personnel, \" || if (PRENOM=PRENOMREF) then \"votre nom figure-t-il sur le bail de location ?\" else \"le nom de \" || PRENOM || \" figure-t-il sur le bail de location ?\"",
@@ -4820,7 +4820,7 @@
 				{
 					"id": "knoqewds",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "4",
 					"label": {
 						"value": "\"➡ \" || (if (PRENOM=PRENOMREF) then \"Êtes-vous\" else (PRENOM || \" est-\" || LIB_SUJET)) || \" \" || if (isnull(STOC)) then \"locataire, sous-locataire ou colocataire\" else (if (STOC=\"1\" or STOC=\"2\" or STOC=\"3\") then \"locataire ou colocataire\" else \"sous-locataire\") || \" d’une partie du logement ?\"",
@@ -5025,7 +5025,7 @@
 				{
 					"id": "joh8lowu",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "4",
 					"label": {
 						"value": "\"➡ \" || PRENOM || \" a-t-\" || LIB_SUJET || \" déjà quitté le logement familial pour vivre dans un logement indépendant pendant plus de trois mois ?\"",
@@ -5122,7 +5122,7 @@
 				{
 					"id": "kppmespv",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "4",
 					"label": {
 						"value": "\"➡ \" || PRENOM || \" vit-\" || LIB_SUJET || \" chez vous uniquement pour les vacances, les week-ends ?\"",
@@ -5195,7 +5195,7 @@
 				{
 					"id": "joh8ixt2",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "4",
 					"label": {
 						"value": "\"➡ \" || \"Au total, pendant combien de temps \" || PRENOM || \" a-t-\" || LIB_SUJET || \" vécu dans un logement indépendant ?\"",
@@ -5307,7 +5307,7 @@
 				{
 					"id": "kcnccgjg",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "4",
 					"label": {
 						"value": "\"➡ \" || \"Depuis quand \" || PRENOM || \" est-\" || LIB_SUJET || \" venu\" || LIB_FEM || \" ou revenu\" || LIB_FEM || \" vivre chez vous ?\"",
@@ -5542,7 +5542,7 @@
 				{
 					"id": "kp5vtjh4",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "4",
 					"label": {
 						"value": "\"➡ \" || \"Le fait que \" || PRENOM || \" vit chez vous est-il lié à la crise sanitaire due à l’épidémie de Covid19 ?\"",
@@ -5615,7 +5615,7 @@
 				{
 					"id": "joirni0x",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "4",
 					"label": {
 						"value": "\"➡ \" || PRENOM || \" envisage-t-\" || LIB_SUJET || \" d’aller habiter dans un logement indépendant dans les six mois qui viennent ?\"",
@@ -5693,7 +5693,7 @@
 				{
 					"id": "joirve2f",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "4",
 					"label": {
 						"value": "\"➡ \" || PRENOM || \" a-t-\" || LIB_SUJET || \" actuellement les moyens financiers lui permettant d’avoir un logement indépendant ?\"",
@@ -5786,7 +5786,7 @@
 				{
 					"id": "joirtz3j",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "4",
 					"label": {
 						"value": "\"➡ \" || PRENOM || \" aurait-\" || LIB_SUJET || \" les moyens financiers d’obtenir un logement indépendant ?\"",
@@ -5879,7 +5879,7 @@
 				{
 					"id": "joisp3u9",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "4",
 					"label": {
 						"value": "\"➡ \" || \"Si \" || PRENOM || \" en avait les moyens financiers, quitterait-\" || LIB_SUJET || \" le logement familial ?\"",
@@ -6098,7 +6098,7 @@
 				{
 					"id": "joisq6l3",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "4",
 					"label": {
 						"value": "\"➡ \" || \"Depuis quand \" || PRENOM || \" vit-\" || LIB_SUJET ||\" chez vous ?\"",
@@ -6331,7 +6331,7 @@
 				{
 					"id": "kppptqlu",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "4",
 					"label": {
 						"value": "\"➡ \" || \"Le fait que \" || PRENOM || \" vive chez vous est-il lié à la crise sanitaire due l’épidémie de Covid 19 ?\"",
@@ -6405,7 +6405,7 @@
 				{
 					"id": "joismxwd",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "4",
 					"label": {
 						"value": "\"➡ \" || \"Selon vous, \" || PRENOM || \" a-t-\" || LIB_SUJET || \" actuellement les moyens financiers lui permettant d’avoir un logement indépendant ?\"",
@@ -6485,7 +6485,7 @@
 				{
 					"id": "kqv3atis",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "4",
 					"label": {
 						"value": "\"➡ \" || \"Est-ce compliqué pour vous d’héberger \" || PRENOM || \" ?\"",
@@ -6567,7 +6567,7 @@
 				{
 					"id": "kqv44b8j",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "4",
 					"label": {
 						"value": "\"➡ \" || \"Est-ce que \" || PRENOM || \" a une chambre indépendante dans votre logement ?\"",
@@ -6677,7 +6677,7 @@
 		{
 			"id": "jojtbo85",
 			"componentType": "Dropdown",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "4",
 			"label": {
 				"value": "\"➡ \" || \"En quelle année êtes-vous arrivé\" || (if (isnull(SEXEREF)) then \"\" else (if (cast(SEXEREF,string) = \"2\") then \"e\" else \"\")) || \" dans ce logement ?\"",
@@ -6973,7 +6973,7 @@
 		{
 			"id": "kp6iwd90",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "4",
 			"label": {
 				"value": "\"➡ \" || \"Depuis environ combien d’années êtes-vous arrivé\" || (if (isnull(SEXEREF)) then \"\" else (if (cast(SEXEREF,string) = \"2\") then \"e\" else \"\")) || \" dans ce logement ?\"",
@@ -7036,7 +7036,7 @@
 		{
 			"id": "jojt16mt",
 			"componentType": "Dropdown",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "4",
 			"label": {
 				"value": "\"➡ \" || \"Quel est le mois de votre arrivée en \" || MAA2A || \" ?\"",
@@ -7131,7 +7131,7 @@
 		{
 			"id": "jojt3qxp",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "4",
 			"label": {
 				"value": "\"➡ \" || \"Votre conjoint\" || SEXECJ_E || \" est-\" || SEXECJ_IEL || \" arrivé\" || SEXECJ_E || \" dans ce logement en même temps que vous ?\"",
@@ -7178,7 +7178,7 @@
 		{
 			"id": "jojtnq9z",
 			"componentType": "Dropdown",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "4",
 			"label": {
 				"value": "\"➡ \" || \"En quelle année votre conjoint\" || SEXECJ_E || \" est-\" || SEXECJ_IEL || \" arrivé\" || SEXECJ_E || \" dans ce logement ?\"",
@@ -7473,7 +7473,7 @@
 		{
 			"id": "kp6ja40b",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "4",
 			"label": {
 				"value": "\"➡ \" || \"Depuis environ combien d’années votre conjoint\" || SEXECJ_E || \" est-\" || SEXECJ_IEL || \" arrivé\" || SEXECJ_E || \" dans ce logement ?\"",
@@ -7548,7 +7548,7 @@
 		{
 			"id": "jor73af6",
 			"componentType": "Dropdown",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "4",
 			"label": {
 				"value": "\"➡ \" || \"Quel est le mois de son arrivée dans le logement en \" || MAA2AC || \" ?\"",
@@ -7640,7 +7640,7 @@
 		{
 			"id": "jojtsgsr",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "4",
 			"label": {
 				"value": "\"➡ \" || \"Parmi les membres de votre ménage actuel, une personne habitait-elle déjà dans ce logement, au moment de \" || libMAA3 || \" ?\"",
@@ -7690,7 +7690,7 @@
 		{
 			"id": "jojtutyy",
 			"componentType": "Dropdown",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "4",
 			"label": {
 				"value": "\"➡ \" || \"En quelle année cette personne est-elle arrivée dans ce logement ?\"",
@@ -8006,7 +8006,7 @@
 		{
 			"id": "jojtizrx",
 			"componentType": "Dropdown",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "4",
 			"label": {
 				"value": "\"➡ \" || \"Quel est le mois de son arrivée dans le logement en \" || MAA3A || \" ?\"",
@@ -8171,7 +8171,7 @@
 		{
 			"id": "jojuueml",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"label": {
 				"value": "\"➡ \" || \"Votre logement dispose-t-il d’une cuisine ?\"",
@@ -8235,7 +8235,7 @@
 		{
 			"id": "jojuno0d",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"label": {
 				"value": "\"➡ \" || \"Quelle est la surface de la cuisine ?\"",
@@ -8320,7 +8320,7 @@
 		{
 			"id": "klv34du0",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"label": {
 				"value": "\"➡ \" || \"Avez-vous une pièce dédiée spécifiquement au télétravail dans votre logement ?\"",
@@ -8389,7 +8389,7 @@
 		{
 			"id": "jojuwst2",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"label": {
 				"value": "\"➡ \" || \"Y a-t-il, dans le logement, des [pièces réservées exclusivement à une activité professionnelle](. 'Ne rentrent pas dans cette catégorie les pièces à usage mixte, utilisées également par les membres de la famille.'), comme un cabinet de dentiste ou d’avocat par exemple ?\"",
@@ -8446,7 +8446,7 @@
 		{
 			"id": "jojv1e5e",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"min": 1,
 			"max": 9,
@@ -8506,7 +8506,7 @@
 		{
 			"id": "jojuz9k3",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"min": 1,
 			"max": 997,
@@ -8574,7 +8574,7 @@
 		{
 			"id": "jojv79ut",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"label": {
 				"value": "\"➡ \" || \"Y a-t-il des pièces annexes à usage d’habitation rattachées au logement avec une entrée indépendante, telles que des chambres de bonne ou d’anciens garages réaménagés en studios par exemple ?\"",
@@ -8624,7 +8624,7 @@
 		{
 			"id": "jojv3ha7",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"min": 1,
 			"max": 9,
@@ -8676,7 +8676,7 @@
 		{
 			"id": "kmd6o006",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"label": {
 				"value": "\"➡ \" || \"Quel usage faites-vous de la pièce annexe ?\"",
@@ -8808,7 +8808,7 @@
 		{
 			"id": "jojuzbus",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"min": 1,
 			"max": 9,
@@ -8867,7 +8867,7 @@
 		{
 			"id": "klv4iusu",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"min": 1,
 			"max": 9,
@@ -8926,7 +8926,7 @@
 		{
 			"id": "jojv5bnw",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"min": 1,
 			"max": 999,
@@ -8964,7 +8964,7 @@
 		{
 			"id": "klw36l7v",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"min": 1,
 			"max": 999,
@@ -9032,7 +9032,7 @@
 		{
 			"id": "jojvgfei",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"min": 1,
 			"max": 100,
@@ -9134,7 +9134,7 @@
 		{
 			"id": "jojv4yqe",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"min": 0,
 			"max": 100,
@@ -9225,7 +9225,7 @@
 		{
 			"id": "jojvc0vt",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"min": 1,
 			"max": 1000,
@@ -9337,7 +9337,7 @@
 		{
 			"id": "jojv1ux1",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"label": {
 				"value": "\"➡ \" || \"Compte tenu du nombre de personnes de votre ménage, comment estimez-vous le nombre de pièces dont vous disposez ?\"",
@@ -9391,7 +9391,7 @@
 		{
 			"id": "kv29cjdq",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"label": {
 				"value": "\"➡ \" || \"Quelle est la [hauteur sous plafond](. 'Lorsque la pièce principale est située sous des combles, la hauteur sous plafond varie. Choisir la réponse correspondant à la partie la plus haute de la pièce.') de votre pièce principale ?\"",
@@ -9468,7 +9468,7 @@
 		{
 			"id": "jrupq1i5",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"label": {
 				"value": "\"➡ \" || \"Avez-vous une véranda ?\"",
@@ -9515,7 +9515,7 @@
 		{
 			"id": "jrupsr80",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"min": 1,
 			"max": 999,
@@ -9550,7 +9550,7 @@
 		{
 			"id": "jrupy93h",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"label": {
 				"value": "\"➡ \" || \"La surface de la véranda (\" || cast(KSV,string) || \" m²) a t-elle été prise en compte dans la surface totale du logement (\" || cast(HST,string) || \" m²) que vous avez indiquée précédemment ?\"",
@@ -9586,7 +9586,7 @@
 		{
 			"id": "jrupzl7m",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"label": {
 				"value": "\"➡ \" || \"Avez-vous un balcon\" || libKBA1 || \" ou une loggia ?\"",
@@ -9622,7 +9622,7 @@
 		{
 			"id": "jrupx7iz",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"min": 1,
 			"max": 999,
@@ -9657,7 +9657,7 @@
 		{
 			"id": "jruq98v2",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"label": {
 				"value": "\"➡ \" || libKJA || \" un jardin, un terrain ou une cour réservés à votre usage personnel ?\"",
@@ -9693,7 +9693,7 @@
 		{
 			"id": "jruq8x6e",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"min": 1,
 			"max": 100000,
@@ -9761,7 +9761,7 @@
 		{
 			"id": "jruq85av",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"label": {
 				"value": "\"➡ \" || \"Pouvez-vous néanmoins indiquer dans quelle tranche se situe la surface du terrain ?\"",
@@ -9825,7 +9825,7 @@
 		{
 			"id": "jruq4was",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"min": 1,
 			"max": 99999,
@@ -9896,7 +9896,7 @@
 		{
 			"id": "jruq6fv0",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"min": 1,
 			"max": 99999,
@@ -9931,7 +9931,7 @@
 		{
 			"id": "jruqlf39",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"label": {
 				"value": "\"➡ \" || \"Disposez-vous d’espaces extérieurs (jardin, terrain, cour...) en tant que parties communes de la résidence ou de la copropriété ?\"",
@@ -9978,7 +9978,7 @@
 		{
 			"id": "jrusmgfq",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"label": {
 				"value": "\"➡ \" || \"Quelle est la surface de ces espaces partagés ?\"",
@@ -10238,7 +10238,7 @@
 		{
 			"id": "jrut0i0j",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"label": {
 				"value": "\"➡ \" || \"Disposez-vous d’une cave ou d’un sous-sol (même si vous ne l’utilisez pas) ?\"",
@@ -10285,7 +10285,7 @@
 		{
 			"id": "jrusu349",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"label": {
 				"value": "\"➡ \" || \"Disposez-vous, dans les parties communes de \" || libKVELO || \", d’un local fermé où vous pouvez déposer un vélo ou une poussette ?\"",
@@ -10334,7 +10334,7 @@
 		{
 			"id": "jrutj5co",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"label": {
 				"value": "\"➡ \" || \"Disposez-vous d’un grenier ou de combles aménageables, mais non aménagés en pièces d’habitation ?\"",
@@ -10370,7 +10370,7 @@
 		{
 			"id": "jruu4ry3",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"label": {
 				"value": "\"➡ \" || \"Disposez-vous d’un sous-sol non aménagé en pièces d’habitation ?\"",
@@ -10406,7 +10406,7 @@
 		{
 			"id": "jruubukg",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"label": {
 				"value": "\"➡ \" || \"Disposez-vous d’une grange non aménagée en pièces d’habitation ?\"",
@@ -10442,7 +10442,7 @@
 		{
 			"id": "jruue197",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"label": {
 				"value": "\"➡ \" || \"Avez-vous une piscine fixe d’une profondeur de plus de 1 mètre ?\"",
@@ -10513,7 +10513,7 @@
 		{
 			"id": "jruuncm0",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"label": {
 				"value": "\"➡ \" || \"Comment votre logement est-il alimenté en eau ?\"",
@@ -10560,7 +10560,7 @@
 		{
 			"id": "jruv1cla",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"label": {
 				"value": "\"➡ \" || \"Disposez-vous de W-C à l’intérieur du logement ?\"",
@@ -10607,7 +10607,7 @@
 		{
 			"id": "kmeu61l4",
 			"componentType": "Table",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"label": {
 				"value": "\"➡ \" || \"Combien avez-vous de W-C ?\"",
@@ -10729,7 +10729,7 @@
 		{
 			"id": "jruva8uu",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"label": {
 				"value": "\"➡ \" || \"Possédez-vous une salle d’eau ou une salle de bain (pièce contenant une douche ou une baignoire) ?\"",
@@ -10765,7 +10765,7 @@
 		{
 			"id": "kksgd6fv",
 			"componentType": "Table",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"label": {
 				"value": "\"➡ \" || \"Combien avez-vous de salle d’eau ou salle de bain ?\"",
@@ -10884,7 +10884,7 @@
 		{
 			"id": "kmf0xcox",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"label": {
 				"value": "\"➡ \" || \"Avez-vous une douche ou une baignoire installée dans une pièce destinée à un autre usage ?\"",
@@ -10920,7 +10920,7 @@
 		{
 			"id": "jruv164k",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"label": {
 				"value": "\"➡ \" || \"Disposez-vous d’un ou plusieurs lavabos ?\"",
@@ -11051,7 +11051,7 @@
 		{
 			"id": "joicolgp",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"label": {
 				"value": "\"➡ \" || \"Comment estimez-vous vos conditions actuelles de logement ?\"",
@@ -11111,7 +11111,7 @@
 		{
 			"id": "joiccm1l",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"min": 1,
 			"max": 10,
@@ -11177,7 +11177,7 @@
 		{
 			"id": "knio1w9d",
 			"componentType": "Table",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"label": {
 				"value": "\"➡ \" || \"Votre logement présente-t-il les défauts suivants ?\"",
@@ -11325,7 +11325,7 @@
 		{
 			"id": "kninrf3p",
 			"componentType": "Table",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"label": {
 				"value": "\"➡ \" || \"Votre logement présente-t-il les autres défauts suivants ?\"",
@@ -11464,7 +11464,7 @@
 		{
 			"id": "knioggcs",
 			"componentType": "Table",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"label": {
 				"value": "\"➡ \" || \"L’environnement de votre logement présente-t-il les défauts suivants ?\"",
@@ -11592,7 +11592,7 @@
 		{
 			"id": "kniwyjy0",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"label": {
 				"value": "\"➡ \" || \"Vous plaisez-vous dans votre quartier (ou village) ?\"",
@@ -11639,7 +11639,7 @@
 		{
 			"id": "joidpl4s",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"min": 1,
 			"max": 10,
@@ -11738,7 +11738,7 @@
 		{
 			"id": "kcvx4gaz",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"label": {
 				"value": "\"➡ \" || \"Au cours des 12 derniers mois, l’un des membres du ménage, y compris vous-même, a-t-il déposé ou renouvelé une demande de HLM ?\"",
@@ -11851,7 +11851,7 @@
 		{
 			"id": "joieoqtu",
 			"componentType": "Table",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"label": {
 				"value": "\"➡ \" || \"Auprès de qui \" || libOIH || \" déposé cette demande de HLM ?\"",
@@ -12016,7 +12016,7 @@
 		{
 			"id": "joieparb",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"label": {
 				"value": "\"➡ \" || \"Depuis combien de temps \" || libOIH || \" déposé cette demande de HLM ?\"",
@@ -12109,7 +12109,7 @@
 		{
 			"id": "joiegq0p",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"label": {
 				"value": "\"➡ \" || \"Depuis le dépôt de cette demande de HLM, \" || libOIH || \" refusé une ou plusieurs propositions de logements ?\"",
@@ -12285,7 +12285,7 @@
 		{
 			"id": "joifgmrr",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"label": {
 				"value": "\"➡ \" || \"Souhaitez-vous changer de logement ?\"",
@@ -12327,7 +12327,7 @@
 		{
 			"id": "joifoap2",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"label": {
 				"value": "\"➡ \" || \"Pensez-vous être contraint de quitter votre logement dans les trois ans à venir ?\"",
@@ -12374,7 +12374,7 @@
 		{
 			"id": "joifcbgf",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"label": {
 				"value": "\"➡ \" || \"Pour quelle raison pensez-vous être contraint de quitter votre logement ?\"",
@@ -12452,7 +12452,7 @@
 		{
 			"id": "joifzvkd",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"label": {
 				"value": "\"➡ \" || \"Avez-vous fait une demande de logement dans le cadre de la loi Dalo ([Droit au logement opposable](. 'La loi sur le droit au logement opposable (Dalo) du 5 mars 2007 a instauré un recours pour les personnes mal-logées. La loi désigne l’État comme le garant du droit au logement. La mise en œuvre de cette garantie s’appuie sur un recours amiable ou un recours contentieux.')) ?\"",
@@ -12494,7 +12494,7 @@
 		{
 			"id": "joifs2y7",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"label": {
 				"value": "\"➡ \" || \"Suite à votre demande, avez-vous obtenu un logement dans le cadre de la loi Dalo ?\"",
@@ -12536,7 +12536,7 @@
 		{
 			"id": "joig627d",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"label": {
 				"value": "\"➡ \" || \"Envisagez-vous de quitter votre commune ?\"",
@@ -12583,7 +12583,7 @@
 		{
 			"id": "joig7qe3",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"label": {
 				"value": "\"➡ \" || \"Où envisagez-vous d’aller vous installer ?\"",
@@ -12649,7 +12649,7 @@
 		{
 			"id": "joigb7rg",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"label": {
 				"value": "\"➡ \" || \"Plus précisément, où comptez-vous vivre ?\"",
@@ -12710,7 +12710,7 @@
 		{
 			"id": "joig56ii",
 			"componentType": "Dropdown",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"label": {
 				"value": "\"➡ \" || \"Dans quel département envisagez-vous de vous installer ou de rester ?\"",
@@ -12756,7 +12756,7 @@
 		{
 			"id": "joigkrjq",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"label": {
 				"value": "\"➡ \" || \"Plus précisément, où comptez-vous vivre ?\"",
@@ -12806,7 +12806,7 @@
 		{
 			"id": "joigdh1o",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"label": {
 				"value": "\"➡ \" || \"Plus précisément, où comptez-vous vivre ?\"",
@@ -12876,7 +12876,7 @@
 		{
 			"id": "joigr611",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"label": {
 				"value": "\"➡ \" || \"Quel type de logement envisagez-vous d’occuper ?\"",
@@ -12939,7 +12939,7 @@
 		{
 			"id": "joigyk2a",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"label": {
 				"value": "\"➡ \" || \"Par rapport à votre logement actuel, quelle serait la taille du logement que vous envisagez d’occuper ?\"",
@@ -12991,7 +12991,7 @@
 		{
 			"id": "joigwqiq",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"label": {
 				"value": "\"➡ \" || \"Dans votre futur logement, quel statut d’occupation envisagez-vous ?\"",
@@ -13043,7 +13043,7 @@
 		{
 			"id": "joigrs80",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"min": 1,
 			"max": 1.0e7,
@@ -13121,7 +13121,7 @@
 		{
 			"id": "joigx4x8",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"min": 1,
 			"max": 1.0e7,
@@ -13188,7 +13188,7 @@
 		{
 			"id": "joih1sgy",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"label": {
 				"value": "\"➡ \" || \"Où en êtes-vous de vos démarches ?\"",
@@ -13255,7 +13255,7 @@
 		{
 			"id": "joigwfan",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"label": {
 				"value": "\"➡ \" || \"Quand envisagez-vous de quitter votre logement ?\"",
@@ -13318,7 +13318,7 @@
 		{
 			"id": "knk8j9xd",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"label": {
 				"value": "\"➡ \" || \"Pourquoi n’avez vous pas déposé de demande HLM ?\"",
@@ -13775,7 +13775,7 @@
 				{
 					"id": "kqr0kx1e",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "7",
 					"label": {
 						"value": "\"➡ \" || \"Comment la chambre d’hôtel était-elle payée ?\"",
@@ -13850,7 +13850,7 @@
 				{
 					"id": "kpb8b0vw",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "7",
 					"label": {
 						"value": "\"➡ \" || \"Était-ce un centre d’hébergement pour demandeurs d’asile ou réfugiés ?\"",
@@ -13902,7 +13902,7 @@
 				{
 					"id": "joio5w41",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "7",
 					"label": {
 						"value": "\"➡ \" || \"Combien de situations de ce type \" || (if (PRENOM=PRENOMREF) then \"avez-vous\" else PRENOM || \" a-t-\" || LIB_SUJET) || \" connues ?\"",
@@ -13970,7 +13970,7 @@
 				{
 					"id": "joioebt6",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "7",
 					"label": {
 						"value": "\"➡ \" || \"Combien de temps au total \" || (if (PRENOM=PRENOMREF) then \"avez-vous\" else PRENOM || \" a-t-\" || LIB_SUJET) || \" été dans \" || libSDT || \" ?\"",
@@ -14064,7 +14064,7 @@
 				{
 					"id": "kudultmi",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "7",
 					"label": {
 						"value": "\"➡ \" || if (PRENOM=PRENOMREF) then \"Quelle est la première situation de ce type que vous avez connue ?\" else \"Quelle est la première situation de ce type que \" || PRENOM || \" a connue ?\"",
@@ -14182,7 +14182,7 @@
 				{
 					"id": "joo0yx5k",
 					"componentType": "Dropdown",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "7",
 					"label": {
 						"value": "\"➡ \" || \"En quelle année \" || if (isnull(SDN1)) then ( if (PRENOM=PRENOMREF) then \"avez-vous été pour la première fois dans une de ces situations ?\" else PRENOM || \" a-t-\" || LIB_SUJET || \" été pour la première fois dans une de ces situations ?\" ) else (if (SDN1=\"1\") then \"cette situation a-t-elle débuté ?\" else ( if (PRENOM=PRENOMREF) then \"avez-vous été dans cette première situation ?\" else PRENOM || \" a-t-\" || LIB_SUJET || \" été dans cette première situation ?\" ))",
@@ -14860,7 +14860,7 @@
 				{
 					"id": "joo1m3x2",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "7",
 					"label": {
 						"value": "\"➡ \" || \"La première fois que \" || (if (PRENOM=PRENOMREF) then \"vous avez été\" else PRENOM || \" a été\") || \" dans cette situation, combien de temps cela a-t-il duré ?\"",
@@ -14952,7 +14952,7 @@
 				{
 					"id": "kudvobyc",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "7",
 					"label": {
 						"value": "\"➡ \" || if (PRENOM=PRENOMREF) then \"Quelle est la dernière situation de ce type que vous avez connue ?\" else \"Quelle est la dernière situation de ce type que \" || PRENOM || \" a connue ?\"",
@@ -15070,7 +15070,7 @@
 				{
 					"id": "kudvxpft",
 					"componentType": "Dropdown",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "7",
 					"label": {
 						"value": "\"➡ \" || \"En quelle année \" || ( if (PRENOM=PRENOMREF) then \"avez-vous été dans cette dernière situation ?\" else PRENOM || \" a-t-\" || LIB_SUJET || \" été dans cette dernière situation ?\" )",
@@ -15747,7 +15747,7 @@
 				{
 					"id": "kudwrcyp",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "7",
 					"label": {
 						"value": "\"➡ \" || \"La dernière fois que \" || (if (PRENOM=PRENOMREF) then \"vous avez été\" else PRENOM || \" a été\") || \" dans cette situation, combien de temps cela a-t-il duré ?\"",
@@ -16255,7 +16255,7 @@
 		{
 			"id": "jopgtrq1",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"label": {
 				"value": "\"➡ \" || \"Depuis le 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \", un des membres de votre ménage actuel, y compris vous-même, a-t-il vendu un ou plusieurs logements ?\"",
@@ -16321,7 +16321,7 @@
 		{
 			"id": "jopgvwb0",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"label": {
 				"value": "\"➡ \" || \"Comment aviez-vous fait l’acquisition de ce logement maintenant vendu ?\"",
@@ -16395,7 +16395,7 @@
 		{
 			"id": "jopgzovi",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"label": {
 				"value": "\"➡ \" || libVFLA || \" était-il votre résidence principale ?\"",
@@ -16454,7 +16454,7 @@
 		{
 			"id": "koeabibm",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"label": {
 				"value": "\"➡ \" || \"Depuis le 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \", un des membres de votre ménage actuel, y compris vous-même, a-t-il acheté un ou plusieurs logements, comme une résidence principale, secondaire, un logement destiné à être loué, etc. ?\"",
@@ -16509,7 +16509,7 @@
 		{
 			"id": "joph9za3",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"label": {
 				"value": "\"➡ \" || \"Par rapport au prix du \" || libVBILLOG1 || \", comment était le prix du \" || libVBILLOG2 || \" ?\"",
@@ -16588,7 +16588,7 @@
 		{
 			"id": "jopkquw3",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"label": {
 				"value": "\"➡ \" || \"Où habitiez-vous le 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \" ?\"",
@@ -16681,7 +16681,7 @@
 		{
 			"id": "jopl7p41",
 			"componentType": "Dropdown",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"label": {
 				"value": "\"➡ \" || \"Dans quelle commune habitiez-vous le 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \" ?\"",
@@ -16749,7 +16749,7 @@
 		{
 			"id": "joplihpv",
 			"componentType": "Dropdown",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"label": {
 				"value": "\"➡ \" || \"Dans quel département habitiez-vous le 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \" ?\"",
@@ -16818,7 +16818,7 @@
 		{
 			"id": "joplkxrd",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"maxLength": 30,
 			"label": {
@@ -16866,7 +16866,7 @@
 		{
 			"id": "jopldlvn",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"maxLength": 30,
 			"label": {
@@ -16929,7 +16929,7 @@
 		{
 			"id": "joplorns",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"label": {
 				"value": "\"➡ \" || \"Au 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \", quelle était votre situation ?\"",
@@ -17001,7 +17001,7 @@
 		{
 			"id": "joplzrmo",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"label": {
 				"value": "\"➡ \" || \"Au 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \", comment votre ménage occupait-il ce logement ?\"",
@@ -17091,7 +17091,7 @@
 		{
 			"id": "jopri4xh",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"label": {
 				"value": "\"➡ \" || \"Quel était le régime juridique du loyer ?\"",
@@ -17167,7 +17167,7 @@
 		{
 			"id": "joprsm9u",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"min": 0,
 			"max": 1.0e6,
@@ -17261,7 +17261,7 @@
 		{
 			"id": "joprlyql",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"label": {
 				"value": "\"➡ \" || \"Bénéficiez-vous au 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \" de l’allocation logement ou de l’aide personnalisée au logement (APL) ?\"",
@@ -17322,7 +17322,7 @@
 		{
 			"id": "joprp441",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"min": 1,
 			"max": 24,
@@ -17413,7 +17413,7 @@
 		{
 			"id": "jopruzlo",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"label": {
 				"value": "\"➡ \" || \"À quoi correspondait le logement occupé au 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \" ?\"",
@@ -17483,7 +17483,7 @@
 		{
 			"id": "jopsc29x",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"min": 1,
 			"max": 999,
@@ -17550,7 +17550,7 @@
 		{
 			"id": "jops4c0x",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"min": 1,
 			"max": 20,
@@ -17631,7 +17631,7 @@
 		{
 			"id": "jopsjl1n",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"min": 0,
 			"max": 100,
@@ -17711,7 +17711,7 @@
 		{
 			"id": "jopsiigq",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"label": {
 				"value": "\"➡ \" || \"Quelle était votre situation professionnelle au 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \" ?\"",
@@ -17834,7 +17834,7 @@
 		{
 			"id": "jopsrdb3",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"min": 0,
 			"max": 9,
@@ -17905,7 +17905,7 @@
 		{
 			"id": "joptkb9d",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"label": {
 				"value": "\"➡ \" || \"Juste avant d’habiter dans votre logement actuel, où résidiez-vous ?\"",
@@ -17973,7 +17973,7 @@
 		{
 			"id": "jopu7wfr",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"label": {
 				"value": "\"➡ \" || \"Avant d’occuper votre logement actuel, quelle était votre situation ?\"",
@@ -18056,7 +18056,7 @@
 		{
 			"id": "jopua1hn",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"label": {
 				"value": "\"➡ \" || \"Comment votre ménage occupait-il le précédent logement ?\"",
@@ -18145,7 +18145,7 @@
 		{
 			"id": "jopuofnr",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"label": {
 				"value": "\"➡ \" || \"Quel était le régime juridique du loyer ?\"",
@@ -18255,7 +18255,7 @@
 		{
 			"id": "jopuhzbr",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"label": {
 				"value": "\"➡ \" || \"À quoi correspondait votre précédent logement ?\"",
@@ -18320,7 +18320,7 @@
 		{
 			"id": "jopukm75",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"min": 1,
 			"max": 997,
@@ -18382,7 +18382,7 @@
 		{
 			"id": "joputbjc",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"min": 1,
 			"max": 20,
@@ -19000,7 +19000,7 @@
 		{
 			"id": "kp55gaf4",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "9",
 			"label": {
 				"value": "\"➡ \" || \"Comment est votre état de santé en général ?\"",
@@ -19037,7 +19037,7 @@
 		{
 			"id": "kp56b045",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "9",
 			"label": {
 				"value": "\"➡ \" || \"Avez-vous une maladie ou un problème de santé qui soit chronique ou de caractère durable ?\"",
@@ -19079,7 +19079,7 @@
 		{
 			"id": "kp56ml0f",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "9",
 			"label": {
 				"value": "\"➡ \" || \"Êtes-vous limité\" || (if (isnull(SEXEREF)) then \"\" else (if (cast(SEXEREF,string) = \"2\") then \"e\" else \"\")) || \", depuis au moins 6 mois, à cause d’un problème de santé, dans les activités que les gens font habituellement ?\"",
@@ -19186,7 +19186,7 @@
 				{
 					"id": "kp56qgdl",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "9",
 					"label": {
 						"value": "\"➡ \" || \"Comment est l’état de santé de \" || PRENOM || \" en général ?\"",
@@ -19242,7 +19242,7 @@
 				{
 					"id": "kp56xi4v",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "9",
 					"label": {
 						"value": "\"➡ \" || PRENOM || \" a-t-\" || LIB_SUJET || \" une maladie ou un problème de santé qui soit chronique ou de caractère durable ?\"",
@@ -19295,7 +19295,7 @@
 				{
 					"id": "kp5712k1",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "9",
 					"label": {
 						"value": "\"➡ \" || PRENOM || \" est-\" || LIB_SUJET || \" limité\" || LIB_FEM || \", depuis au moins 6 mois, à cause d’un problème de santé, dans les activités que les gens font habituellement ?\"",
@@ -19391,7 +19391,7 @@
 		{
 			"id": "kp59rky6",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "9",
 			"label": {
 				"value": "\"➡ \" || \"Où est né votre père ?\"",
@@ -19455,7 +19455,7 @@
 		{
 			"id": "kp59rmtt",
 			"componentType": "Dropdown",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "9",
 			"label": {
 				"value": "\"➡ \" || \"Dans quel pays est né votre père ?\"",
@@ -19604,7 +19604,7 @@
 		{
 			"id": "kp59tm8h",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "9",
 			"label": {
 				"value": "\"➡ \" || \"Où est née votre mère ?\"",
@@ -19657,7 +19657,7 @@
 		{
 			"id": "kp59nici",
 			"componentType": "Dropdown",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "9",
 			"label": {
 				"value": "\"➡ \" || \"Dans quel pays est née votre mère ?\"",
@@ -19852,7 +19852,7 @@
 		{
 			"id": "kp5apvf3",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "10",
 			"label": {
 				"value": "\"➡ \" || \"Vous ou une autre personne de votre ménage, décrochez-vous lorsque votre téléphone fixe sonne ?\"",
@@ -19928,7 +19928,7 @@
 		{
 			"id": "kp5au0iu",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "10",
 			"label": {
 				"value": "\"➡ \" || \"Décrochez-vous lorsque votre téléphone mobile sonne ?\"",
@@ -20004,7 +20004,7 @@
 		{
 			"id": "kp5bjbzg",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "10",
 			"label": {
 				"value": "\"➡ \" || \"Comment avez-vous utilisé Internet, au cours des trois derniers mois, en moyenne ?\"",
@@ -20109,7 +20109,7 @@
 		{
 			"id": "kbamkrlv",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "10",
 			"label": {
 				"value": "\"➡ \" || \"Les courriers que nous vous envoyons dans le cadre de cette enquête sont adressés à : \" || libCHGNC || \". Cela vous convient-il ?\"",
@@ -20148,7 +20148,7 @@
 		{
 			"id": "kbaxq9l0",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "10",
 			"label": {
 				"value": "\"➡ \" || \"Civilité du \" || if (not(isnull(NOMVOUS_D2)) and NOMVOUS_D2<>\"\") then \"premier destinataire :\" else \" destinataire :\"",
@@ -20198,7 +20198,7 @@
 		{
 			"id": "kr0fw3n6",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "10",
 			"maxLength": 20,
 			"label": {
@@ -20233,7 +20233,7 @@
 		{
 			"id": "kr0fn06f",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "10",
 			"maxLength": 40,
 			"label": {
@@ -20268,7 +20268,7 @@
 		{
 			"id": "kwjivaa1",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "10",
 			"label": {
 				"value": "\"➡ \" || \"Souhaitez-vous ajouter un deuxième destinataire au courrier que nous vous envoyons ?\"",
@@ -20307,7 +20307,7 @@
 		{
 			"id": "kr0fr82y",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "10",
 			"label": {
 				"value": "\"➡ \" || \"Civilité du deuxième destinataire :\"",
@@ -20363,7 +20363,7 @@
 		{
 			"id": "kbbzjgn8",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "10",
 			"maxLength": 20,
 			"label": {
@@ -20404,7 +20404,7 @@
 		{
 			"id": "kbbzhtx3",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "10",
 			"maxLength": 40,
 			"label": {
@@ -20472,7 +20472,7 @@
 		{
 			"id": "kbay0xfi",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "10",
 			"maxLength": 10,
 			"label": {

--- a/src/stories/questionnaires/logement/source-sum.json
+++ b/src/stories/questionnaires/logement/source-sum.json
@@ -7464,7 +7464,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 1. \" || \"Confirmez-vous que vous habitez toujours à l’adresse suivante : \" || ADRESSE || \" ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Input",
@@ -7493,7 +7493,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 2. \" || \"Numéro de voie :\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 10,
 			"declarations": [
 				{
@@ -7568,7 +7568,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 3. \" || \"Libellé de la voie :\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 50,
 			"declarations": [
 				{
@@ -7609,7 +7609,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 4. \" || \"Complément d’adresse :\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 50,
 			"declarations": [
 				{
@@ -7666,7 +7666,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 5. \" || \"Code postal :\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 5,
 			"declarations": [
 				{
@@ -7723,7 +7723,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 6. \" || \"Commune :\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 100
 		},
 		{
@@ -7809,7 +7809,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 7. \" || \"Connaissez-vous le nom de la ou des personnes qui vous ont succédé dans le logement situé à l’adresse suivante : \" || ADRESSE || \" ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Input",
@@ -7846,7 +7846,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 8. \" || \"Nom :\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 40,
 			"declarations": [
 				{
@@ -7895,7 +7895,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 9. \" || \"Prénom :\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 20
 		},
 		{
@@ -7933,7 +7933,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 10. \" || \"Nom d’un éventuel deuxième occupant :\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 40
 		},
 		{
@@ -7971,7 +7971,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 11. \" || \"Prénom d’un éventuel deuxième occupant :\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 20
 		},
 		{
@@ -8009,7 +8009,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 12. \" || \"Pouvez-vous indiquer un numéro de téléphone \" || if (isnull(NOMNVOCC2) and isnull(PRENOMNVOCC2)) then \"de l’occupant du logement ?\" else \"des occupants du logement ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 10,
 			"declarations": [
 				{
@@ -8058,7 +8058,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 13. \" || \"Pouvez-vous indiquer un mail \" || if (isnull(NOMNVOCC2) and isnull(PRENOMNVOCC2)) then \"de l’occupant du logement ?\" else \"des occupants du logement ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 249
 		},
 		{
@@ -8183,7 +8183,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 14. \" || \"Au total, en vous comptant, combien de personnes habitent dans ce logement ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "INSTRUCTION",
@@ -8371,7 +8371,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 15. \" || \" \" || if (isnull(NBHAB) or cast(NBHAB,integer)=1) then \"Votre prénom : \" else (if ( not(isnull(G_PRENOM)) and G_PRENOM=PRENOMREF ) then \"Votre prénom : \" else ( if (isnull(PRENOMREF) and isnull(G_PRENOM)) then \"Prénom (commencez par votre prénom) : \" else \"Prénom : \"))"
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"maxLength": 20
 				}
 			],
@@ -8494,7 +8494,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 16. \" || \"Quel est \" || if (PRENOM=PRENOMREF) then \"votre sexe ?\" else \"le sexe de \" || PRENOM || \" ?\""
 					},
-					"mandatory": false
+					"isMandatory": false
 				},
 				{
 					"componentType": "Datepicker",
@@ -8570,7 +8570,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 17. \" || \"Quelle est \" || if (PRENOM=PRENOMREF) then \"votre date de naissance ?\" else \"la date de naissance de \" || PRENOM ||\" ?\""
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"bindingDependencies": [
 						"PRENOM",
 						"PRENOMREF",
@@ -8642,7 +8642,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 18. \" || \"Vous n’avez pas indiqué de date de naissance, pouvez-vous indiquer la tranche d’âge dans laquelle \" || if (PRENOM=PRENOMREF) then \"vous vous situez ?\" else \"se situe\" || \" \" || PRENOM || \" ?\""
 					},
-					"mandatory": false
+					"isMandatory": false
 				},
 				{
 					"componentType": "Radio",
@@ -8706,7 +8706,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 19. \" || \"Où \"|| if (PRENOM=PRENOMREF) then \"êtes-vous né\" || LIB_FEM || \" ?\" else \"est né\" || LIB_FEM || \" \" || PRENOM || \" ?\""
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"declarations": [
 						{
 							"declarationType": "HELP",
@@ -8822,7 +8822,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 20. \" || \"Dans quel département \"|| if (PRENOM=PRENOMREF) then \"êtes-vous né\" || LIB_FEM || \" ?\" else \"est né\" || LIB_FEM || \" \" || PRENOM || \" ?\""
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"declarations": [
 						{
 							"declarationType": "INSTRUCTION",
@@ -8885,7 +8885,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 21. \" || \"Dans quel pays \"|| if (PRENOM=PRENOMREF) then \"êtes-vous né\" || LIB_FEM || \" ?\" else \"est né\" || LIB_FEM || \" \" || PRENOM || \" ?\""
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"declarations": [
 						{
 							"declarationType": "INSTRUCTION",
@@ -9066,7 +9066,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 23. \" || \"Quelle est \"|| if (PRENOM=PRENOMREF) then \"votre nationalité étrangère ?\" else \"la nationalité étrangère de \" || PRENOM || \" ?\""
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"declarations": [
 						{
 							"declarationType": "INSTRUCTION",
@@ -9263,7 +9263,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 24. \" || \"Qui est \"|| PRENOM || \" pour vous ?\""
 					},
-					"mandatory": false
+					"isMandatory": false
 				},
 				{
 					"componentType": "Radio",
@@ -9341,7 +9341,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 25. \" || if (PRENOM=PRENOMREF) then \"Vivez-vous en couple ?\" else PRENOM || \" vit-\" || LIB_SUJET || \" en couple ?\""
 					},
-					"mandatory": false
+					"isMandatory": false
 				},
 				{
 					"componentType": "CheckboxGroup",
@@ -9589,7 +9589,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 27. \" || (if (INDENF=\"1\") then \"En dehors des enfants décrits précédemment, accueillez-vous \" else \"Accueillez-vous \") || \"un ou plusieurs enfants au titre du droit de visite et d’hébergement ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "InputNumber",
@@ -9663,7 +9663,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 28. \" || \"Combien d’enfants accueillez-vous au titre du droit de visite et d’hébergement  ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "HELP",
@@ -9850,7 +9850,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 30. \" || if (PRENOM=PRENOMREF) then \"Vivez-vous uniquement dans ce logement ou aussi dans un autre logement ?\" else PRENOM || \" vit-\" || LIB_SUJET || \" uniquement dans ce logement ou aussi dans un autre logement ?\""
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"declarations": [
 						{
 							"declarationType": "HELP",
@@ -9927,7 +9927,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 31. \" || if (PRENOM=PRENOMREF) then \"Vous vivez dans le logement situé à l’adresse : \" || ADRCOLLC || \" ... ?\" else PRENOM || \" vit dans ce logement situé à l’adresse : \" || ADRCOLLC || \" ... ?\""
 					},
-					"mandatory": false
+					"isMandatory": false
 				},
 				{
 					"componentType": "Radio",
@@ -10014,7 +10014,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 32. \" || if (PRENOM=PRENOMREF) then \"Pour vous, ce logement est... ?\" else \"Pour \" || PRENOM || \", ce logement est... ?\""
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"declarations": [
 						{
 							"declarationType": "INSTRUCTION",
@@ -10113,7 +10113,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 33. \" || if (PRENOM=PRENOMREF) then \"Pour vous, l’autre logement où vous vivez est... ?\" else \"Pour \" || PRENOM || \", l’autre logement où \" || LIB_SUJET || \" vit est... ?\""
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"declarations": [
 						{
 							"declarationType": "INSTRUCTION",
@@ -10198,7 +10198,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 34. \" || if (PRENOM=PRENOMREF) then \"Êtes-vous en garde alternée entre vos deux parents ?\" else PRENOM || \" est-\" || LIB_SUJET || \" en garde alternée entre ses deux parents ?\""
 					},
-					"mandatory": false
+					"isMandatory": false
 				},
 				{
 					"componentType": "Radio",
@@ -10265,7 +10265,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 35. \" || if (PRENOM=PRENOMREF) then \"Où avez-vous dormi la nuit dernière ?\" else \"Où \" || PRENOM || \" a-t-\" || LIB_SUJET || \" dormi la nuit dernière ?\""
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"declarations": [
 						{
 							"declarationType": "INSTRUCTION",
@@ -10335,7 +10335,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 36. \" || if (PRENOM=PRENOMREF) then \"À propos de cet autre logement dans lequel vous vivez, s’agit-il d’une chambre dans une structure collective ?\" else \"À propos de cet autre logement dans lequel vit \" || PRENOM || \", s’agit-il d’une chambre dans une structure collective ?\""
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"declarations": [
 						{
 							"declarationType": "INSTRUCTION",
@@ -10434,7 +10434,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 37. \" || \"De quelle structure s’agit-il ?\""
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"declarations": [
 						{
 							"declarationType": "HELP",
@@ -10651,7 +10651,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 38. \" || if (PRENOM=PRENOMREF) then \"Actuellement, quelle est votre situation principale ?\" else \"Actuellement, quelle est la situation principale de \" || PRENOM || \" ?\""
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"declarations": [
 						{
 							"declarationType": "INSTRUCTION",
@@ -10732,7 +10732,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 39. \" || if (PRENOM=PRENOMREF) then \"Avez-vous cependant un emploi ?\" else PRENOM || \" a-t-\" || LIB_SUJET || \" cependant un emploi ?\""
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"declarations": [
 						{
 							"declarationType": "INSTRUCTION",
@@ -10856,7 +10856,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 40. \" || if (PRENOM=PRENOMREF) then \"À ce jour, quel est le plus haut diplôme ou titre que vous possédez ?\" else \"À ce jour, quel est le plus haut diplôme ou titre que \" || PRENOM || \" possède ?\""
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"declarations": [
 						{
 							"declarationType": "INSTRUCTION",
@@ -10946,7 +10946,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 41. \" || if (PRENOM=PRENOMREF) then \"Plus précisément, quel est votre niveau d’études ?\" else \"Plus précisément, quel est le niveau d’études de \" || PRENOM ||\" ?\""
 					},
-					"mandatory": false
+					"isMandatory": false
 				},
 				{
 					"componentType": "Radio",
@@ -11022,7 +11022,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 42. \" || if (PRENOM=PRENOMREF) then \"Plus précisément, quel diplôme de niveau supérieur à bac+2 avez-vous obtenu ?\" else \"Plus précisément, quel diplôme de niveau supérieur à bac+2 \"|| PRENOM || \" a-t-\" || LIB_SUJET || \" obtenu ?\""
 					},
-					"mandatory": false
+					"isMandatory": false
 				},
 				{
 					"componentType": "Radio",
@@ -11093,7 +11093,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 43. \" || if (PRENOM=PRENOMREF) then \"Pratiquez-vous le télétravail ?\" else PRENOM || \" pratique-t-\" || LIB_SUJET || \" le télétravail ?\""
 					},
-					"mandatory": false
+					"isMandatory": false
 				},
 				{
 					"componentType": "InputNumber",
@@ -11166,7 +11166,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 44. \" || if (PRENOM=PRENOMREF) then \"Combien de jours par semaine êtes-vous en télétravail, en moyenne ?\" else \"Combien de jours par semaine \" || PRENOM || \" est-\" || LIB_SUJET || \" en télétravail, en moyenne ? \""
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"unit": "jours",
 					"bindingDependencies": [
 						"PRENOM",
@@ -11355,7 +11355,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 45. \" || \"À quoi correspond votre logement ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "STATEMENT",
@@ -11419,7 +11419,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 46. \" || \"Est-ce que votre logement se trouve en foyer (ou résidence) pour personnes âgées ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -11472,7 +11472,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 47. \" || \"Plus précisément, quel est le type de cette résidence ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -11541,7 +11541,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 48. \" || \"Le logement fait-il partie d’un immeuble collectif ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -11594,7 +11594,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 49. \" || \"Quel est le type de construction de la maison individuelle ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -11663,7 +11663,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 50. \" || \"La maison fait-elle partie d’une résidence ou d’un ’village’ en copropriété ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -11716,7 +11716,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 51. \" || \"Y a-t-il au moins un ascenseur dans l’immeuble collectif ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "InputNumber",
@@ -11790,7 +11790,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 52. \" || \"À quel étage se trouve votre logement ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"bindingDependencies": ["IEL"],
 			"min": 0,
 			"response": {
@@ -11879,7 +11879,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 53. \" || \"À quelle période a été achevée la construction \"|| libIAATC || \" ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Dropdown",
@@ -12037,7 +12037,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 54. \" || \"En quelle année exactement la construction \" || libIAATC || \" a-t-elle été achevée ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "HELP",
@@ -12233,7 +12233,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 55. \" || \"Comment votre ménage occupe-t-il ce logement ?\" || cast(nbpersmaj,string)"
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "HELP",
@@ -12304,7 +12304,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 56. \" || \"Un des occupants actuels du logement est-il propriétaire de ce logement ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "HELP",
@@ -12368,7 +12368,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 57. \" || \"Votre ménage occupe-t-il ce logement en pleine propriété ou en propriété partielle ?&#xd;​\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"paginatedLoop": true,
@@ -12501,7 +12501,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 58. \" || \"À titre personnel, \" || if (PRENOM=PRENOMREF) then \"votre nom figure-t-il sur l’acte de propriété ?\" else \"le nom de \" || PRENOM || \" figure-t-il sur l’acte de propriété ?\""
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"declarations": [
 						{
 							"declarationType": "INSTRUCTION",
@@ -12602,7 +12602,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 59. \" || \"À titre personnel, \" || (if (PRENOM=PRENOMREF) then \"êtes-vous\" else (PRENOM || \" est-\" || LIB_SUJET)) || \" usufruitier\" || LIB_FEM2 || \" de ce logement ?\""
 					},
-					"mandatory": false
+					"isMandatory": false
 				},
 				{
 					"componentType": "Radio",
@@ -12685,7 +12685,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 60. \" || \"À titre personnel, \" || if (PRENOM=PRENOMREF) then \"votre nom figure-t-il sur le bail de location ?\" else \"le nom de \" || PRENOM || \" figure-t-il sur le bail de location ?\""
 					},
-					"mandatory": false
+					"isMandatory": false
 				},
 				{
 					"componentType": "Radio",
@@ -12764,7 +12764,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 61. \" || (if (PRENOM=PRENOMREF) then \"Êtes-vous\" else (PRENOM || \" est-\" || LIB_SUJET)) || \" \" || if (isnull(STOC)) then \"locataire, sous-locataire ou colocataire\" else (if (STOC=\"1\" or STOC=\"2\" or STOC=\"3\") then \"locataire ou colocataire\" else \"sous-locataire\") || \" d’une partie du logement ?\""
 					},
-					"mandatory": false
+					"isMandatory": false
 				}
 			],
 			"bindingDependencies": [
@@ -12956,7 +12956,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 62. \" || PRENOM || \" a-t-\" || LIB_SUJET || \" déjà quitté le logement familial pour vivre dans un logement indépendant pendant plus de trois mois ?\""
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"declarations": [
 						{
 							"declarationType": "INSTRUCTION",
@@ -13045,7 +13045,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 63. \" || PRENOM || \" vit-\" || LIB_SUJET || \" chez vous uniquement pour les vacances, les week-ends ?\""
 					},
-					"mandatory": false
+					"isMandatory": false
 				},
 				{
 					"componentType": "Radio",
@@ -13145,7 +13145,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 64. \" || \"Au total, pendant combien de temps \" || PRENOM || \" a-t-\" || LIB_SUJET || \" vécu dans un logement indépendant ?\""
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"declarations": [
 						{
 							"declarationType": "INSTRUCTION",
@@ -13262,7 +13262,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 65. \" || \"Depuis quand \" || PRENOM || \" est-\" || LIB_SUJET || \" venu\" || LIB_FEM || \" ou revenu\" || LIB_FEM || \" vivre chez vous ?\""
 					},
-					"mandatory": false
+					"isMandatory": false
 				},
 				{
 					"componentType": "CheckboxGroup",
@@ -13484,7 +13484,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 67. \" || \"Le fait que \" || PRENOM || \" vit chez vous est-il lié à la crise sanitaire due à l’épidémie de Covid19 ?\""
 					},
-					"mandatory": false
+					"isMandatory": false
 				},
 				{
 					"componentType": "Radio",
@@ -13569,7 +13569,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 68. \" || PRENOM || \" envisage-t-\" || LIB_SUJET || \" d’aller habiter dans un logement indépendant dans les six mois qui viennent ?\""
 					},
-					"mandatory": false
+					"isMandatory": false
 				},
 				{
 					"componentType": "Radio",
@@ -13662,7 +13662,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 69. \" || PRENOM || \" a-t-\" || LIB_SUJET || \" actuellement les moyens financiers lui permettant d’avoir un logement indépendant ?\""
 					},
-					"mandatory": false
+					"isMandatory": false
 				},
 				{
 					"componentType": "Radio",
@@ -13755,7 +13755,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 70. \" || PRENOM || \" aurait-\" || LIB_SUJET || \" les moyens financiers d’obtenir un logement indépendant ?\""
 					},
-					"mandatory": false
+					"isMandatory": false
 				},
 				{
 					"componentType": "Radio",
@@ -13849,7 +13849,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 71. \" || \"Si \" || PRENOM || \" en avait les moyens financiers, quitterait-\" || LIB_SUJET || \" le logement familial ?\""
 					},
-					"mandatory": false
+					"isMandatory": false
 				}
 			],
 			"bindingDependencies": [
@@ -14083,7 +14083,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 72. \" || \"Depuis quand \" || PRENOM || \" vit-\" || LIB_SUJET ||\" chez vous ?\""
 					},
-					"mandatory": false
+					"isMandatory": false
 				},
 				{
 					"componentType": "CheckboxGroup",
@@ -14322,7 +14322,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 74. \" || \"Le fait que \" || PRENOM || \" vive chez vous est-il lié à la crise sanitaire due l’épidémie de Covid 19 ?\""
 					},
-					"mandatory": false
+					"isMandatory": false
 				},
 				{
 					"componentType": "Radio",
@@ -14412,7 +14412,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 75. \" || \"Selon vous, \" || PRENOM || \" a-t-\" || LIB_SUJET || \" actuellement les moyens financiers lui permettant d’avoir un logement indépendant ?\""
 					},
-					"mandatory": false
+					"isMandatory": false
 				},
 				{
 					"componentType": "Radio",
@@ -14502,7 +14502,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 76. \" || \"Est-ce compliqué pour vous d’héberger \" || PRENOM || \" ?\""
 					},
-					"mandatory": false
+					"isMandatory": false
 				},
 				{
 					"componentType": "Radio",
@@ -14585,7 +14585,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 77. \" || \"Est-ce que \" || PRENOM || \" a une chambre indépendante dans votre logement ?\""
 					},
-					"mandatory": false
+					"isMandatory": false
 				}
 			],
 			"bindingDependencies": [
@@ -15595,7 +15595,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 78. \" || \"En quelle année êtes-vous arrivé\" || (if (isnull(SEXEREF)) then \"\" else (if (cast(SEXEREF,string) = \"2\") then \"e\" else \"\")) || \" dans ce logement ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -15669,7 +15669,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 79. \" || \"Depuis environ combien d’années êtes-vous arrivé\" || (if (isnull(SEXEREF)) then \"\" else (if (cast(SEXEREF,string) = \"2\") then \"e\" else \"\")) || \" dans ce logement ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Dropdown",
@@ -15808,7 +15808,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 80. \" || \"Quel est le mois de votre arrivée en \" || MAA2A || \" ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -15861,7 +15861,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 81. \" || \"Votre conjoint\" || SEXECJ_E || \" est-\" || SEXECJ_IEL || \" arrivé\" || SEXECJ_E || \" dans ce logement en même temps que vous ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Dropdown",
@@ -16767,7 +16767,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 82. \" || \"En quelle année votre conjoint\" || SEXECJ_E || \" est-\" || SEXECJ_IEL || \" arrivé\" || SEXECJ_E || \" dans ce logement ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -16848,7 +16848,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 83. \" || \"Depuis environ combien d’années votre conjoint\" || SEXECJ_E || \" est-\" || SEXECJ_IEL || \" arrivé\" || SEXECJ_E || \" dans ce logement ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Dropdown",
@@ -16980,7 +16980,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 84. \" || \"Quel est le mois de son arrivée dans le logement en \" || MAA2AC || \" ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -17041,7 +17041,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 85. \" || \"Parmi les membres de votre ménage actuel, une personne habitait-elle déjà dans ce logement, au moment de \" || libMAA3 || \" ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Dropdown",
@@ -17974,7 +17974,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 86. \" || \"En quelle année cette personne est-elle arrivée dans ce logement ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Dropdown",
@@ -18109,7 +18109,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 87. \" || \"Quel est le mois de son arrivée dans le logement en \" || MAA3A || \" ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -18162,7 +18162,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 88. \" || \"Avez-vous\" || libSDEJA || \" déjà été propriétaire d’une résidence principale autre que celle-ci ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Sequence",
@@ -18305,7 +18305,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 89. \" || \"Votre logement dispose-t-il d’une cuisine ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -18372,7 +18372,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 90. \" || \"Quelle est la surface de la cuisine ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Subsequence",
@@ -18464,7 +18464,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 91. \" || \"Par rapport à l’exercice du télétravail, quelle note entre 0 et 10 donneriez-vous à vos conditions de logement ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "HELP",
@@ -18651,7 +18651,7 @@
 					}
 				]
 			],
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Subsequence",
@@ -18736,7 +18736,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 93. \" || \"Y a-t-il, dans le logement, des [pièces réservées exclusivement à une activité professionnelle](. 'Ne rentrent pas dans cette catégorie les pièces à usage mixte, utilisées également par les membres de la famille.'), comme un cabinet de dentiste ou d’avocat par exemple ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "STATEMENT",
@@ -18830,7 +18830,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 94. \" || \"Combien avez-vous de pièces à usage exclusivement professionnel ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "HELP",
@@ -18909,7 +18909,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 95. \" || \"Quelle est la surface totale de \" || libHSP || \" à usage exclusivement professionnel ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"unit": "mètres carrés",
 			"bindingDependencies": ["libHSP", "HSP"],
 			"min": 1,
@@ -19003,7 +19003,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 96. \" || \"Y a-t-il des pièces annexes à usage d’habitation rattachées au logement avec une entrée indépendante, telles que des chambres de bonne ou d’anciens garages réaménagés en studios par exemple ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "INSTRUCTION",
@@ -19088,7 +19088,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 97. \" || \"Combien avez-vous de [pièces annexes](. 'Pièces rattachées au logement avec une entrée indépendante telles que des chambres de bonne ou d’anciens garages réaménagés en studios par exemple') à usage d’habitation ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"bindingDependencies": ["HPA"],
 			"min": 1,
 			"response": {
@@ -19156,7 +19156,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 98. \" || \"Quel usage faites-vous de la pièce annexe ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "CheckboxGroup",
@@ -19313,7 +19313,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 100. \" || \"Parmi les \" || cast(HPA,string) || \" pièces annexes, combien sont-elles réservées à votre usage personnel ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"bindingDependencies": ["HPA", "HPI1"],
 			"min": 1,
 			"response": {
@@ -19402,7 +19402,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 101. \" || \"Parmi les \" || cast(HPA,string) || \" pièces annexes, combien sont-elles réservées au logement d’un salarié à votre service ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"bindingDependencies": ["HPA", "HPI2"],
 			"min": 1,
 			"response": {
@@ -19470,7 +19470,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 102. \" || \"Quelle est la surface totale de \" || libHSI1 || \" à votre usage personnel ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"unit": "mètres carrés",
 			"bindingDependencies": ["libHSI1", "HSI1"],
 			"min": 1,
@@ -19539,7 +19539,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 103. \" || \"Quelle est la surface totale de \" || libHSI2 || \" au logement d’un salarié à votre service ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"unit": "mètres carrés",
 			"bindingDependencies": ["libHSI2", "HSI2"],
 			"min": 1,
@@ -19682,7 +19682,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 104. \" || \"Combien avez-vous de pièces d’habitation (ou de pièces habitables) ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "HELP",
@@ -19818,7 +19818,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 105. \" || \"Parmi ces \" || cast(HPH,string) || \" pièces, combien de chambres avez-vous ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "INSTRUCTION",
@@ -19939,7 +19939,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 106. \" || \"Quelle est la surface totale habitable de votre logement\" || libHST || \" ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "INSTRUCTION",
@@ -20051,7 +20051,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 107. \" || \"Compte tenu du nombre de personnes de votre ménage, comment estimez-vous le nombre de pièces dont vous disposez ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -20111,7 +20111,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 108. \" || \"Quelle est la [hauteur sous plafond](. 'Lorsque la pièce principale est située sous des combles, la hauteur sous plafond varie. Choisir la réponse correspondant à la partie la plus haute de la pièce.') de votre pièce principale ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Subsequence",
@@ -20196,7 +20196,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 109. \" || \"Avez-vous une véranda ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "INSTRUCTION",
@@ -20267,7 +20267,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 110. \" || \"Quelle est la surface de cette véranda ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"unit": "mètres carrés",
 			"bindingDependencies": ["KSV"],
 			"min": 1,
@@ -20329,7 +20329,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 111. \" || \"La surface de la véranda (\" || cast(KSV,string) || \" m²) a t-elle été prise en compte dans la surface totale du logement (\" || cast(HST,string) || \" m²) que vous avez indiquée précédemment ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -20382,7 +20382,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 112. \" || \"Avez-vous un balcon, une terrasse ou une loggia ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "InputNumber",
@@ -20442,7 +20442,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 113. \" || \"Quelle est la surface totale des balcons\"|| libKBA || \" ou loggias ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"unit": "mètres carrés",
 			"bindingDependencies": ["libKBA", "KSB"],
 			"min": 1,
@@ -20504,7 +20504,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 114. \" || libKJA || \" un jardin, un terrain ou une cour réservés à votre usage personnel ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "InputNumber",
@@ -20578,7 +20578,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 115. \" || \"Quelle est la surface totale de votre terrain ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "INSTRUCTION",
@@ -20688,7 +20688,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 116. \" || \"Pouvez-vous néanmoins indiquer dans quelle tranche se situe la surface du terrain ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "InputNumber",
@@ -20762,7 +20762,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 117. \" || \"Quelle est la surface de terrain couverte par la maison (emprise au sol) ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "INSTRUCTION",
@@ -20851,7 +20851,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 118. \" || \"Quelle est la surface de ces espaces privatifs attenants au logement ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"unit": "mètres carrés",
 			"bindingDependencies": ["KSJPC"],
 			"min": 1,
@@ -20913,7 +20913,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 119. \" || \"Disposez-vous d’espaces extérieurs (jardin, terrain, cour...) en tant que parties communes de la résidence ou de la copropriété ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "INSTRUCTION",
@@ -20991,7 +20991,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 120. \" || \"Quelle est la surface de ces espaces partagés ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -21058,7 +21058,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 121. \" || \"De combien de voitures les habitants de ce logement disposent-ils ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "HELP",
@@ -21344,7 +21344,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 124. \" || \"Disposez-vous d’une cave ou d’un sous-sol (même si vous ne l’utilisez pas) ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "INSTRUCTION",
@@ -21415,7 +21415,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 125. \" || \"Disposez-vous, dans les parties communes de \" || libKVELO || \", d’un local fermé où vous pouvez déposer un vélo ou une poussette ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "INSTRUCTION",
@@ -21479,7 +21479,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 126. \" || \"Disposez-vous d’un grenier ou de combles aménageables, mais non aménagés en pièces d’habitation ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -21532,7 +21532,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 127. \" || \"Disposez-vous d’un sous-sol non aménagé en pièces d’habitation ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -21585,7 +21585,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 128. \" || \"Disposez-vous d’une grange non aménagée en pièces d’habitation ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -21638,7 +21638,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 129. \" || \"Avez-vous une piscine fixe d’une profondeur de plus de 1 mètre ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "INSTRUCTION",
@@ -21741,7 +21741,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 130. \" || \"Comment votre logement est-il alimenté en eau ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -21801,7 +21801,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 131. \" || \"Disposez-vous de W-C à l’intérieur du logement ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Table",
@@ -22031,7 +22031,7 @@
 					}
 				]
 			],
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -22084,7 +22084,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 133. \" || \"Possédez-vous une salle d’eau ou une salle de bain (pièce contenant une douche ou une baignoire) ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Table",
@@ -22314,7 +22314,7 @@
 					}
 				]
 			],
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -22367,7 +22367,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 135. \" || \"Avez-vous une douche ou une baignoire installée dans une pièce destinée à un autre usage ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -22434,7 +22434,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 136. \" || \"Disposez-vous d’un ou plusieurs lavabos ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Sequence",
@@ -22544,7 +22544,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 137. \" || \"Comment estimez-vous vos conditions actuelles de logement ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "InputNumber",
@@ -22610,7 +22610,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 138. \" || \"En tant qu’endroit pour vivre, quelle note globale de 1 à 10 donneriez-vous à votre logement ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "HELP",
@@ -22822,7 +22822,7 @@
 					}
 				]
 			],
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Table",
@@ -23015,7 +23015,7 @@
 					}
 				]
 			],
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Table",
@@ -23142,7 +23142,7 @@
 					}
 				]
 			],
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -23187,7 +23187,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 142. \" || \"Est-il difficile de trouver un lieu d’éducation qui vous convienne à proximité de votre logement ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -23239,7 +23239,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 143. \" || \"Vous plaisez-vous dans votre quartier (ou village) ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "InputNumber",
@@ -23305,7 +23305,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 144. \" || \"Quelle note globale de 1 à 10 donneriez-vous à votre quartier (ou village) ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "HELP",
@@ -23683,7 +23683,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 146. \" || \"Comment la chambre d’hôtel était-elle payée ?\""
 					},
-					"mandatory": false
+					"isMandatory": false
 				},
 				{
 					"componentType": "Radio",
@@ -23746,7 +23746,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 147. \" || \"Était-ce un centre d’hébergement pour demandeurs d’asile ou réfugiés ?\""
 					},
-					"mandatory": false
+					"isMandatory": false
 				},
 				{
 					"componentType": "Radio",
@@ -23821,7 +23821,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 148. \" || \"Combien de situations de ce type \" || (if (PRENOM=PRENOMREF) then \"avez-vous\" else PRENOM || \" a-t-\" || LIB_SUJET) || \" connues ?\""
 					},
-					"mandatory": false
+					"isMandatory": false
 				},
 				{
 					"componentType": "Radio",
@@ -23919,7 +23919,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 149. \" || \"Combien de temps au total \" || (if (PRENOM=PRENOMREF) then \"avez-vous\" else PRENOM || \" a-t-\" || LIB_SUJET) || \" été dans \" || libSDT || \" ?\""
 					},
-					"mandatory": false
+					"isMandatory": false
 				},
 				{
 					"componentType": "Radio",
@@ -24030,7 +24030,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 150. \" || if (PRENOM=PRENOMREF) then \"Quelle est la première situation de ce type que vous avez connue ?\" else \"Quelle est la première situation de ce type que \" || PRENOM || \" a connue ?\""
 					},
-					"mandatory": false
+					"isMandatory": false
 				},
 				{
 					"componentType": "Dropdown",
@@ -24954,7 +24954,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 151. \" || \"En quelle année \" || if (isnull(SDN1)) then ( if (PRENOM=PRENOMREF) then \"avez-vous été pour la première fois dans une de ces situations ?\" else PRENOM || \" a-t-\" || LIB_SUJET || \" été pour la première fois dans une de ces situations ?\" ) else (if (SDN1=\"1\") then \"cette situation a-t-elle débuté ?\" else ( if (PRENOM=PRENOMREF) then \"avez-vous été dans cette première situation ?\" else PRENOM || \" a-t-\" || LIB_SUJET || \" été dans cette première situation ?\" ))"
 					},
-					"mandatory": false
+					"isMandatory": false
 				},
 				{
 					"componentType": "Radio",
@@ -25045,7 +25045,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 152. \" || \"La première fois que \" || (if (PRENOM=PRENOMREF) then \"vous avez été\" else PRENOM || \" a été\") || \" dans cette situation, combien de temps cela a-t-il duré ?\""
 					},
-					"mandatory": false
+					"isMandatory": false
 				},
 				{
 					"componentType": "Radio",
@@ -25156,7 +25156,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 153. \" || if (PRENOM=PRENOMREF) then \"Quelle est la dernière situation de ce type que vous avez connue ?\" else \"Quelle est la dernière situation de ce type que \" || PRENOM || \" a connue ?\""
 					},
-					"mandatory": false
+					"isMandatory": false
 				},
 				{
 					"componentType": "Dropdown",
@@ -26079,7 +26079,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 154. \" || \"En quelle année \" || ( if (PRENOM=PRENOMREF) then \"avez-vous été dans cette dernière situation ?\" else PRENOM || \" a-t-\" || LIB_SUJET || \" été dans cette dernière situation ?\" )"
 					},
-					"mandatory": false
+					"isMandatory": false
 				},
 				{
 					"componentType": "Radio",
@@ -26175,7 +26175,7 @@
 						"type": "VTL|MD",
 						"value": "\"➡ 155. \" || \"La dernière fois que \" || (if (PRENOM=PRENOMREF) then \"vous avez été\" else PRENOM || \" a été\") || \" dans cette situation, combien de temps cela a-t-il duré ?\""
 					},
-					"mandatory": false
+					"isMandatory": false
 				}
 			],
 			"bindingDependencies": [
@@ -26723,7 +26723,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 159. \" || \"Depuis le 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \", un des membres de votre ménage actuel, y compris vous-même, a-t-il vendu un ou plusieurs logements ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "INSTRUCTION",
@@ -26808,7 +26808,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 160. \" || \"Comment aviez-vous fait l’acquisition de ce logement maintenant vendu ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "INSTRUCTION",
@@ -26889,7 +26889,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 161. \" || libVFLA || \" était-il votre résidence principale ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -26949,7 +26949,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 162. \" || \"Depuis le 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \", un des membres de votre ménage actuel, y compris vous-même, a-t-il acheté un ou plusieurs logements, comme une résidence principale, secondaire, un logement destiné à être loué, etc. ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -27009,7 +27009,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 163. \" || \"Par rapport au prix du \" || libVBILLOG1 || \", comment était le prix du \" || libVBILLOG2 || \" ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Subsequence",
@@ -27126,7 +27126,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 164. \" || \"Où habitiez-vous le 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \" ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "STATEMENT",
@@ -27195,7 +27195,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 165. \" || \"Dans quelle commune habitiez-vous le 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \" ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "INSTRUCTION",
@@ -27265,7 +27265,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 166. \" || \"Dans quel département habitiez-vous le 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \" ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "INSTRUCTION",
@@ -27326,7 +27326,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 167. \" || \"Indiquer le nom complet de la commune :\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 30
 		},
 		{
@@ -27376,7 +27376,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 168. \" || \"Dans quel pays résidiez-vous le 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \" ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 30,
 			"declarations": [
 				{
@@ -27455,7 +27455,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 169. \" || \"Au 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \", quelle était votre situation ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -27542,7 +27542,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 170. \" || \"Au 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \", comment votre ménage occupait-il ce logement ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -27619,7 +27619,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 171. \" || \"Quel était le régime juridique du loyer ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "InputNumber",
@@ -27724,7 +27724,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 172. \" || \"Quel était le montant du loyer mensuel au 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \" ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "HELP",
@@ -27814,7 +27814,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 173. \" || \"Bénéficiez-vous au 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \" de l’allocation logement ou de l’aide personnalisée au logement (APL) ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "InputNumber",
@@ -27888,7 +27888,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 174. \" || \"Combien de personnes résidaient dans ce logement au 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \", y compris vous-même ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"bindingDependencies": ["libMOISENQ", "ANNEENQmoins4", "VIN"],
 			"min": 1,
 			"response": {
@@ -28010,7 +28010,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 175. \" || \"À quoi correspondait le logement occupé au 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \" ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "InputNumber",
@@ -28070,7 +28070,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 176. \" || \"Quelle était la surface habitable de ce logement occupé au 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \" ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "INSTRUCTION",
@@ -28173,7 +28173,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 177. \" || \"Quel était le nombre de pièces d’habitation de ce logement occupé au 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \" ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "HELP",
@@ -28261,7 +28261,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 178. \" || \"Combien d’années avez-vous vécu dans ce logement occupé au 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \" ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"unit": "années",
 			"bindingDependencies": ["libMOISENQ", "ANNEENQmoins4", "VANCIEN"],
 			"min": 0,
@@ -28391,7 +28391,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 179. \" || \"Quelle était votre situation professionnelle au 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \" ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Subsequence",
@@ -28520,7 +28520,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 180. \" || \"Combien de fois avez-vous déménagé depuis le 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \" ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"bindingDependencies": ["libMOISENQ", "ANNEENQmoins4", "VND"],
 			"min": 0,
 			"response": {
@@ -28593,7 +28593,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 181. \" || \"Juste avant d’habiter dans votre logement actuel, où résidiez-vous ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "STATEMENT",
@@ -28684,7 +28684,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 182. \" || \"Avant d’occuper votre logement actuel, quelle était votre situation ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -28772,7 +28772,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 183. \" || \"Comment votre ménage occupait-il le précédent logement ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -28847,7 +28847,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 184. \" || \"Quel était le régime juridique du loyer ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Subsequence",
@@ -28960,7 +28960,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 185. \" || \"À quoi correspondait votre précédent logement ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "InputNumber",
@@ -29020,7 +29020,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 186. \" || \"Quelle était la surface de votre précédent logement ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "INSTRUCTION",
@@ -29123,7 +29123,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 187. \" || \"Quel était le nombre de pièces de votre précédent logement ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "HELP",
@@ -29243,7 +29243,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 188. \" || \"Avez-vous déménagé pour changer de statut d’occupation ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "CheckboxGroup",
@@ -29765,7 +29765,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 192. \" || \"Vous ou une autre personne de votre ménage, décrochez-vous lorsque votre téléphone fixe sonne ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -29847,7 +29847,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 193. \" || \"Décrochez-vous lorsque votre téléphone mobile sonne ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -29929,7 +29929,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 194. \" || \"Comment avez-vous utilisé Internet, au cours des trois derniers mois, en moyenne ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "INSTRUCTION",
@@ -30025,7 +30025,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 195. \" || \"Les courriers que nous vous envoyons dans le cadre de cette enquête sont adressés à : \" || libCHGNC || \". Cela vous convient-il ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -30078,7 +30078,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 196. \" || \"Civilité du \" || if (not(isnull(NOMVOUS_D2)) and NOMVOUS_D2<>\"\") then \"premier destinataire :\" else \" destinataire :\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "STATEMENT",
@@ -30126,7 +30126,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 197. \" || \"Prénom du \" || if (not(isnull(NOMVOUS_D2)) and NOMVOUS_D2<>\"\") then \"premier destinataire :\" else \"destinataire :\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 20
 		},
 		{
@@ -30164,7 +30164,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 198. \" || \"Nom du \" || if (not(isnull(NOMVOUS_D2)) and NOMVOUS_D2<>\"\") then \"premier destinataire :\" else \"destinataire :\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 40
 		},
 		{
@@ -30218,7 +30218,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 199. \" || \"Souhaitez-vous ajouter un deuxième destinataire au courrier que nous vous envoyons ?\""
 			},
-			"mandatory": false
+			"isMandatory": false
 		},
 		{
 			"componentType": "Radio",
@@ -30277,7 +30277,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 200. \" || \"Civilité du deuxième destinataire :\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"declarations": [
 				{
 					"declarationType": "STATEMENT",
@@ -30331,7 +30331,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 201. \" || \"Prénom du deuxième destinataire :\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 20
 		},
 		{
@@ -30375,7 +30375,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 202. \" || \"Nom du deuxième destinataire :\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 40
 		},
 		{
@@ -30445,7 +30445,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 203. \" || \"Pourriez-vous indiquer le numéro de téléphone à utiliser pour vous contacter ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 10,
 			"declarations": [
 				{
@@ -30570,7 +30570,7 @@
 				"type": "VTL|MD",
 				"value": "\"Avez-vous des remarques concernant l'enquête ou des commentaires ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 2000
 		}
 	],

--- a/src/stories/questionnaires/logement/source.json
+++ b/src/stories/questionnaires/logement/source.json
@@ -49,7 +49,7 @@
 		{
 			"id": "kb9hlpdc",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "2",
 			"label": {
 				"value": "\"➡ \" || \"Confirmez-vous que vous habitez toujours à l’adresse suivante : \" || ADRESSE || \" ?\"",
@@ -116,7 +116,7 @@
 		{
 			"id": "kbakywwy",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "3",
 			"maxLength": 10,
 			"label": { "value": "\"➡ \" || \"Numéro de voie :\"", "type": "VTL|MD" },
@@ -171,7 +171,7 @@
 		{
 			"id": "kbal4bzb",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "4",
 			"maxLength": 50,
 			"label": {
@@ -224,7 +224,7 @@
 		{
 			"id": "kbalhn4i",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"maxLength": 50,
 			"label": {
@@ -262,7 +262,7 @@
 		{
 			"id": "kbal8crw",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"maxLength": 5,
 			"label": { "value": "\"➡ \" || \"Code postal :\"", "type": "VTL|MD" },
@@ -312,7 +312,7 @@
 		{
 			"id": "kbal9dwk",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "7",
 			"maxLength": 100,
 			"label": { "value": "\"➡ \" || \"Commune :\"", "type": "VTL|MD" },
@@ -375,7 +375,7 @@
 		{
 			"id": "kqweh61i",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"label": {
 				"value": "\"➡ \" || \"Connaissez-vous le nom de la ou des personnes qui vous ont succédé dans le logement situé à l’adresse suivante : \" || ADRESSE || \" ?\"",
@@ -411,7 +411,7 @@
 		{
 			"id": "kqwga16w",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "9",
 			"maxLength": 40,
 			"label": { "value": "\"➡ \" || \"Nom :\"", "type": "VTL|MD" },
@@ -451,7 +451,7 @@
 		{
 			"id": "kqwfswjj",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "10",
 			"maxLength": 20,
 			"label": { "value": "\"➡ \" || \"Prénom :\"", "type": "VTL|MD" },
@@ -480,7 +480,7 @@
 		{
 			"id": "kqwfedoy",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "11",
 			"maxLength": 40,
 			"label": {
@@ -512,7 +512,7 @@
 		{
 			"id": "kqwg9azb",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "12",
 			"maxLength": 20,
 			"label": {
@@ -544,7 +544,7 @@
 		{
 			"id": "kr0e0pav",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "13",
 			"maxLength": 10,
 			"label": {
@@ -592,7 +592,7 @@
 		{
 			"id": "kr0ee3u2",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "14",
 			"maxLength": 249,
 			"label": {
@@ -675,7 +675,7 @@
 		{
 			"id": "kbc1b4k2",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "16",
 			"min": 1,
 			"max": 15,
@@ -874,7 +874,7 @@
 				{
 					"id": "kmno1n7m",
 					"componentType": "Input",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "18",
 					"maxLength": 20,
 					"label": {
@@ -1024,7 +1024,7 @@
 				{
 					"id": "kmoo2fiy",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "19.1",
 					"label": {
 						"value": "\"➡ \" || \"Quel est \" || if (PRENOM=PRENOMREF) then \"votre sexe ?\" else \"le sexe de \" || PRENOM || \" ?\"",
@@ -1075,7 +1075,7 @@
 				{
 					"id": "kmoouamz",
 					"componentType": "Datepicker",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "19.2",
 					"min": "1900-01-01",
 					"max": "2022-12-31",
@@ -1150,7 +1150,7 @@
 				{
 					"id": "kmx6w6n5",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "19.3",
 					"label": {
 						"value": "\"➡ \" || \"Vous n’avez pas indiqué de date de naissance, pouvez-vous indiquer la tranche d’âge dans laquelle \" || if (PRENOM=PRENOMREF) then \"vous vous situez ?\" else \"se situe\" || \" \" || PRENOM || \" ?\"",
@@ -1209,7 +1209,7 @@
 				{
 					"id": "kmookacu",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "19.4",
 					"label": {
 						"value": "\"➡ \" || \"Où \"|| if (PRENOM=PRENOMREF) then \"êtes-vous né\" || LIB_FEM || \" ?\" else \"est né\" || LIB_FEM || \" \" || PRENOM || \" ?\"",
@@ -1267,7 +1267,7 @@
 				{
 					"id": "kmor2z1x",
 					"componentType": "Dropdown",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "19.5",
 					"label": {
 						"value": "\"➡ \" || \"Dans quel département \"|| if (PRENOM=PRENOMREF) then \"êtes-vous né\" || LIB_FEM || \" ?\" else \"est né\" || LIB_FEM || \" \" || PRENOM || \" ?\"",
@@ -1339,7 +1339,7 @@
 				{
 					"id": "kmorege9",
 					"componentType": "Dropdown",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "19.6",
 					"label": {
 						"value": "\"➡ \" || \"Dans quel pays \"|| if (PRENOM=PRENOMREF) then \"êtes-vous né\" || LIB_FEM || \" ?\" else \"est né\" || LIB_FEM || \" \" || PRENOM || \" ?\"",
@@ -1522,7 +1522,7 @@
 				{
 					"id": "kmos2yo6",
 					"componentType": "Dropdown",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "19.8",
 					"label": {
 						"value": "\"➡ \" || \"Quelle est \"|| if (PRENOM=PRENOMREF) then \"votre nationalité étrangère ?\" else \"la nationalité étrangère de \" || PRENOM || \" ?\"",
@@ -1668,7 +1668,7 @@
 				{
 					"id": "kmw4revw",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "20.1",
 					"label": {
 						"value": "\"➡ \" || \"Qui est \"|| PRENOM || \" pour vous ?\"",
@@ -1766,7 +1766,7 @@
 				{
 					"id": "kod271pp",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "20.2",
 					"label": {
 						"value": "\"➡ \" || if (PRENOM=PRENOMREF) then \"Vivez-vous en couple ?\" else PRENOM || \" vit-\" || LIB_SUJET || \" en couple ?\"",
@@ -1980,7 +1980,7 @@
 		{
 			"id": "kwp9ynon",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "21",
 			"label": {
 				"value": "\"➡ \" || (if (INDENF=\"1\") then \"En dehors des enfants décrits précédemment, accueillez-vous \" else \"Accueillez-vous \") || \"un ou plusieurs enfants au titre du droit de visite et d’hébergement ?\"",
@@ -2022,7 +2022,7 @@
 		{
 			"id": "kwpbyciz",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "22",
 			"min": 0,
 			"max": 15,
@@ -2231,7 +2231,7 @@
 				{
 					"id": "kmx8sgeu",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "24.1",
 					"label": {
 						"value": "\"➡ \" || if (PRENOM=PRENOMREF) then \"Vivez-vous uniquement dans ce logement ou aussi dans un autre logement ?\" else PRENOM || \" vit-\" || LIB_SUJET || \" uniquement dans ce logement ou aussi dans un autre logement ?\"",
@@ -2304,7 +2304,7 @@
 				{
 					"id": "kmx97ttc",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "24.2",
 					"label": {
 						"value": "\"➡ \" || if (PRENOM=PRENOMREF) then \"Vous vivez dans le logement situé à l’adresse : \" || ADRCOLLC || \" ... ?\" else PRENOM || \" vit dans ce logement situé à l’adresse : \" || ADRCOLLC || \" ... ?\"",
@@ -2370,7 +2370,7 @@
 				{
 					"id": "kmx97tz1",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "24.3",
 					"label": {
 						"value": "\"➡ \" || if (PRENOM=PRENOMREF) then \"Pour vous, ce logement est... ?\" else \"Pour \" || PRENOM || \", ce logement est... ?\"",
@@ -2474,7 +2474,7 @@
 				{
 					"id": "kmx93med",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "24.4",
 					"label": {
 						"value": "\"➡ \" || if (PRENOM=PRENOMREF) then \"Pour vous, l’autre logement où vous vivez est... ?\" else \"Pour \" || PRENOM || \", l’autre logement où \" || LIB_SUJET || \" vit est... ?\"",
@@ -2589,7 +2589,7 @@
 				{
 					"id": "kmx9punx",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "24.5",
 					"label": {
 						"value": "\"➡ \" || if (PRENOM=PRENOMREF) then \"Êtes-vous en garde alternée entre vos deux parents ?\" else PRENOM || \" est-\" || LIB_SUJET || \" en garde alternée entre ses deux parents ?\"",
@@ -2644,7 +2644,7 @@
 				{
 					"id": "kmx9im0b",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "24.6",
 					"label": {
 						"value": "\"➡ \" || if (PRENOM=PRENOMREF) then \"Où avez-vous dormi la nuit dernière ?\" else \"Où \" || PRENOM || \" a-t-\" || LIB_SUJET || \" dormi la nuit dernière ?\"",
@@ -2724,7 +2724,7 @@
 				{
 					"id": "kqi4zdkk",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "24.7",
 					"label": {
 						"value": "\"➡ \" || if (PRENOM=PRENOMREF) then \"À propos de cet autre logement dans lequel vous vivez, s’agit-il d’une chambre dans une structure collective ?\" else \"À propos de cet autre logement dans lequel vit \" || PRENOM || \", s’agit-il d’une chambre dans une structure collective ?\"",
@@ -2784,7 +2784,7 @@
 				{
 					"id": "kmx9pvyn",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "24.8",
 					"label": {
 						"value": "\"➡ \" || \"De quelle structure s’agit-il ?\"",
@@ -2991,7 +2991,7 @@
 				{
 					"id": "kmxfqrb1",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "25.1",
 					"label": {
 						"value": "\"➡ \" || if (PRENOM=PRENOMREF) then \"Actuellement, quelle est votre situation principale ?\" else \"Actuellement, quelle est la situation principale de \" || PRENOM || \" ?\"",
@@ -3119,7 +3119,7 @@
 				{
 					"id": "kmxg8ci7",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "25.2",
 					"label": {
 						"value": "\"➡ \" || if (PRENOM=PRENOMREF) then \"Avez-vous cependant un emploi ?\" else PRENOM || \" a-t-\" || LIB_SUJET || \" cependant un emploi ?\"",
@@ -3197,7 +3197,7 @@
 				{
 					"id": "kmxgftfs",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "25.3",
 					"label": {
 						"value": "\"➡ \" || if (PRENOM=PRENOMREF) then \"À ce jour, quel est le plus haut diplôme ou titre que vous possédez ?\" else \"À ce jour, quel est le plus haut diplôme ou titre que \" || PRENOM || \" possède ?\"",
@@ -3332,7 +3332,7 @@
 				{
 					"id": "kqi8s71l",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "25.4",
 					"label": {
 						"value": "\"➡ \" || if (PRENOM=PRENOMREF) then \"Plus précisément, quel est votre niveau d’études ?\" else \"Plus précisément, quel est le niveau d’études de \" || PRENOM ||\" ?\"",
@@ -3410,7 +3410,7 @@
 				{
 					"id": "kqi8mfos",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "25.5",
 					"label": {
 						"value": "\"➡ \" || if (PRENOM=PRENOMREF) then \"Plus précisément, quel diplôme de niveau supérieur à bac+2 avez-vous obtenu ?\" else \"Plus précisément, quel diplôme de niveau supérieur à bac+2 \"|| PRENOM || \" a-t-\" || LIB_SUJET || \" obtenu ?\"",
@@ -3489,7 +3489,7 @@
 				{
 					"id": "kp4dw3br",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "25.6",
 					"label": {
 						"value": "\"➡ \" || if (PRENOM=PRENOMREF) then \"Pratiquez-vous le télétravail ?\" else PRENOM || \" pratique-t-\" || LIB_SUJET || \" le télétravail ?\"",
@@ -3550,7 +3550,7 @@
 				{
 					"id": "kvjb8q33",
 					"componentType": "InputNumber",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "25.7",
 					"min": 0,
 					"max": 7,
@@ -3641,7 +3641,7 @@
 		{
 			"id": "kd8qd4ou",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "26",
 			"label": {
 				"value": "\"➡ \" || \"À quoi correspond votre logement ?\"",
@@ -3732,7 +3732,7 @@
 		{
 			"id": "kp4b8f63",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "27",
 			"label": {
 				"value": "\"➡ \" || \"Est-ce que votre logement se trouve en foyer (ou résidence) pour personnes âgées ?\"",
@@ -3771,7 +3771,7 @@
 		{
 			"id": "kp4bwrb9",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "28",
 			"label": {
 				"value": "\"➡ \" || \"Plus précisément, quel est le type de cette résidence ?\"",
@@ -3822,7 +3822,7 @@
 		{
 			"id": "kbgi5n3g",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "29",
 			"label": {
 				"value": "\"➡ \" || \"Le logement fait-il partie d’un immeuble collectif ?\"",
@@ -3876,7 +3876,7 @@
 		{
 			"id": "kbgigljc",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "30",
 			"label": {
 				"value": "\"➡ \" || \"Quel est le type de construction de la maison individuelle ?\"",
@@ -3921,7 +3921,7 @@
 		{
 			"id": "kbgim4v3",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "31",
 			"label": {
 				"value": "\"➡ \" || \"La maison fait-elle partie d’une résidence ou d’un ’village’ en copropriété ?\"",
@@ -3972,7 +3972,7 @@
 		{
 			"id": "kbgidvnm",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "32",
 			"label": {
 				"value": "\"➡ \" || \"Y a-t-il au moins un ascenseur dans l’immeuble collectif ?\"",
@@ -4011,7 +4011,7 @@
 		{
 			"id": "kbgigafp",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "33",
 			"min": 0,
 			"max": 99,
@@ -4063,7 +4063,7 @@
 		{
 			"id": "kbghszh6",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "34",
 			"label": {
 				"value": "\"➡ \" || \"À quelle période a été achevée la construction \"|| libIAATC || \" ?\"",
@@ -4125,7 +4125,7 @@
 		{
 			"id": "kbghz7mp",
 			"componentType": "Dropdown",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "35",
 			"label": {
 				"value": "\"➡ \" || \"En quelle année exactement la construction \" || libIAATC || \" a-t-elle été achevée ?\"",
@@ -4271,7 +4271,7 @@
 		{
 			"id": "jn0cttir",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "37",
 			"label": {
 				"value": "\"➡ \" || \"Comment votre ménage occupe-t-il ce logement ?\"",
@@ -4372,7 +4372,7 @@
 		{
 			"id": "klusnxnh",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "38",
 			"label": {
 				"value": "\"➡ \" || \"Un des occupants actuels du logement est-il propriétaire de ce logement ?\"",
@@ -4436,7 +4436,7 @@
 		{
 			"id": "jn0e3nhg",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "39",
 			"label": {
 				"value": "\"➡ \" || \"Votre ménage occupe-t-il ce logement en pleine propriété ou en propriété partielle ?&#xd;​\"",
@@ -4585,7 +4585,7 @@
 				{
 					"id": "ko9tiu0f",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "40.1",
 					"label": {
 						"value": "\"➡ \" || \"À titre personnel, \" || if (PRENOM=PRENOMREF) then \"votre nom figure-t-il sur l’acte de propriété ?\" else \"le nom de \" || PRENOM || \" figure-t-il sur l’acte de propriété ?\"",
@@ -4670,7 +4670,7 @@
 				{
 					"id": "ko9r0alc",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "40.2",
 					"label": {
 						"value": "\"➡ \" || \"À titre personnel, \" || (if (PRENOM=PRENOMREF) then \"êtes-vous\" else (PRENOM || \" est-\" || LIB_SUJET)) || \" usufruiti\" || LIB_FEM2 || \" de ce logement ?\"",
@@ -4749,7 +4749,7 @@
 				{
 					"id": "ko9t45t9",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "40.3",
 					"label": {
 						"value": "\"➡ \" || \"À titre personnel, \" || if (PRENOM=PRENOMREF) then \"votre nom figure-t-il sur le bail de location ?\" else \"le nom de \" || PRENOM || \" figure-t-il sur le bail de location ?\"",
@@ -4826,7 +4826,7 @@
 				{
 					"id": "knoqewds",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "40.4",
 					"label": {
 						"value": "\"➡ \" || (if (PRENOM=PRENOMREF) then \"Êtes-vous\" else (PRENOM || \" est-\" || LIB_SUJET)) || \" \" || if (isnull(STOC)) then \"locataire, sous-locataire ou colocataire\" else (if (STOC=\"1\" or STOC=\"2\" or STOC=\"3\") then \"locataire ou colocataire\" else \"sous-locataire\") || \" d’une partie du logement ?\"",
@@ -5032,7 +5032,7 @@
 				{
 					"id": "joh8lowu",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "41.1",
 					"label": {
 						"value": "\"➡ \" || PRENOM || \" a-t-\" || LIB_SUJET || \" déjà quitté le logement familial pour vivre dans un logement indépendant pendant plus de trois mois ?\"",
@@ -5129,7 +5129,7 @@
 				{
 					"id": "kppmespv",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "41.2",
 					"label": {
 						"value": "\"➡ \" || PRENOM || \" vit-\" || LIB_SUJET || \" chez vous uniquement pour les vacances, les week-ends ?\"",
@@ -5202,7 +5202,7 @@
 				{
 					"id": "joh8ixt2",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "41.3",
 					"label": {
 						"value": "\"➡ \" || \"Au total, pendant combien de temps \" || PRENOM || \" a-t-\" || LIB_SUJET || \" vécu dans un logement indépendant ?\"",
@@ -5314,7 +5314,7 @@
 				{
 					"id": "kcnccgjg",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "41.4",
 					"label": {
 						"value": "\"➡ \" || \"Depuis quand \" || PRENOM || \" est-\" || LIB_SUJET || \" venu\" || LIB_FEM || \" ou revenu\" || LIB_FEM || \" vivre chez vous ?\"",
@@ -5549,7 +5549,7 @@
 				{
 					"id": "kp5vtjh4",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "41.6",
 					"label": {
 						"value": "\"➡ \" || \"Le fait que \" || PRENOM || \" vit chez vous est-il lié à la crise sanitaire due à l’épidémie de Covid19 ?\"",
@@ -5622,7 +5622,7 @@
 				{
 					"id": "joirni0x",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "41.7",
 					"label": {
 						"value": "\"➡ \" || PRENOM || \" envisage-t-\" || LIB_SUJET || \" d’aller habiter dans un logement indépendant dans les six mois qui viennent ?\"",
@@ -5700,7 +5700,7 @@
 				{
 					"id": "joirve2f",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "41.8",
 					"label": {
 						"value": "\"➡ \" || PRENOM || \" a-t-\" || LIB_SUJET || \" actuellement les moyens financiers lui permettant d’avoir un logement indépendant ?\"",
@@ -5793,7 +5793,7 @@
 				{
 					"id": "joirtz3j",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "41.9",
 					"label": {
 						"value": "\"➡ \" || PRENOM || \" aurait-\" || LIB_SUJET || \" les moyens financiers d’obtenir un logement indépendant ?\"",
@@ -5886,7 +5886,7 @@
 				{
 					"id": "joisp3u9",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "41.10",
 					"label": {
 						"value": "\"➡ \" || \"Si \" || PRENOM || \" en avait les moyens financiers, quitterait-\" || LIB_SUJET || \" le logement familial ?\"",
@@ -6106,7 +6106,7 @@
 				{
 					"id": "joisq6l3",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "42.1",
 					"label": {
 						"value": "\"➡ \" || \"Depuis quand \" || PRENOM || \" vit-\" || LIB_SUJET ||\" chez vous ?\"",
@@ -6339,7 +6339,7 @@
 				{
 					"id": "kppptqlu",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "42.3",
 					"label": {
 						"value": "\"➡ \" || \"Le fait que \" || PRENOM || \" vive chez vous est-il lié à la crise sanitaire due l’épidémie de Covid 19 ?\"",
@@ -6413,7 +6413,7 @@
 				{
 					"id": "joismxwd",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "42.4",
 					"label": {
 						"value": "\"➡ \" || \"Selon vous, \" || PRENOM || \" a-t-\" || LIB_SUJET || \" actuellement les moyens financiers lui permettant d’avoir un logement indépendant ?\"",
@@ -6493,7 +6493,7 @@
 				{
 					"id": "kqv3atis",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "42.5",
 					"label": {
 						"value": "\"➡ \" || \"Est-ce compliqué pour vous d’héberger \" || PRENOM || \" ?\"",
@@ -6575,7 +6575,7 @@
 				{
 					"id": "kqv44b8j",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "42.6",
 					"label": {
 						"value": "\"➡ \" || \"Est-ce que \" || PRENOM || \" a une chambre indépendante dans votre logement ?\"",
@@ -6685,7 +6685,7 @@
 		{
 			"id": "jojtbo85",
 			"componentType": "Dropdown",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "43",
 			"label": {
 				"value": "\"➡ \" || \"En quelle année êtes-vous arrivé\" || (if (isnull(SEXEREF)) then \"\" else (if (cast(SEXEREF,string) = \"2\") then \"e\" else \"\")) || \" dans ce logement ?\"",
@@ -6981,7 +6981,7 @@
 		{
 			"id": "kp6iwd90",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "44",
 			"label": {
 				"value": "\"➡ \" || \"Depuis environ combien d’années êtes-vous arrivé\" || (if (isnull(SEXEREF)) then \"\" else (if (cast(SEXEREF,string) = \"2\") then \"e\" else \"\")) || \" dans ce logement ?\"",
@@ -7044,7 +7044,7 @@
 		{
 			"id": "jojt16mt",
 			"componentType": "Dropdown",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "45",
 			"label": {
 				"value": "\"➡ \" || \"Quel est le mois de votre arrivée en \" || MAA2A || \" ?\"",
@@ -7139,7 +7139,7 @@
 		{
 			"id": "jojt3qxp",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "46",
 			"label": {
 				"value": "\"➡ \" || \"Votre conjoint\" || SEXECJ_E || \" est-\" || SEXECJ_IEL || \" arrivé\" || SEXECJ_E || \" dans ce logement en même temps que vous ?\"",
@@ -7186,7 +7186,7 @@
 		{
 			"id": "jojtnq9z",
 			"componentType": "Dropdown",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "47",
 			"label": {
 				"value": "\"➡ \" || \"En quelle année votre conjoint\" || SEXECJ_E || \" est-\" || SEXECJ_IEL || \" arrivé\" || SEXECJ_E || \" dans ce logement ?\"",
@@ -7481,7 +7481,7 @@
 		{
 			"id": "kp6ja40b",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "48",
 			"label": {
 				"value": "\"➡ \" || \"Depuis environ combien d’années votre conjoint\" || SEXECJ_E || \" est-\" || SEXECJ_IEL || \" arrivé\" || SEXECJ_E || \" dans ce logement ?\"",
@@ -7556,7 +7556,7 @@
 		{
 			"id": "jor73af6",
 			"componentType": "Dropdown",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "49",
 			"label": {
 				"value": "\"➡ \" || \"Quel est le mois de son arrivée dans le logement en \" || MAA2AC || \" ?\"",
@@ -7648,7 +7648,7 @@
 		{
 			"id": "jojtsgsr",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "50",
 			"label": {
 				"value": "\"➡ \" || \"Parmi les membres de votre ménage actuel, une personne habitait-elle déjà dans ce logement, au moment de \" || libMAA3 || \" ?\"",
@@ -7698,7 +7698,7 @@
 		{
 			"id": "jojtutyy",
 			"componentType": "Dropdown",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "51",
 			"label": {
 				"value": "\"➡ \" || \"En quelle année cette personne est-elle arrivée dans ce logement ?\"",
@@ -8014,7 +8014,7 @@
 		{
 			"id": "jojtizrx",
 			"componentType": "Dropdown",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "52",
 			"label": {
 				"value": "\"➡ \" || \"Quel est le mois de son arrivée dans le logement en \" || MAA3A || \" ?\"",
@@ -8179,7 +8179,7 @@
 		{
 			"id": "jojuueml",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "54",
 			"label": {
 				"value": "\"➡ \" || \"Votre logement dispose-t-il d’une cuisine ?\"",
@@ -8243,7 +8243,7 @@
 		{
 			"id": "jojuno0d",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "55",
 			"label": {
 				"value": "\"➡ \" || \"Quelle est la surface de la cuisine ?\"",
@@ -8328,7 +8328,7 @@
 		{
 			"id": "klv34du0",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "56",
 			"label": {
 				"value": "\"➡ \" || \"Avez-vous une pièce dédiée spécifiquement au télétravail dans votre logement ?\"",
@@ -8397,7 +8397,7 @@
 		{
 			"id": "jojuwst2",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "57",
 			"label": {
 				"value": "\"➡ \" || \"Y a-t-il, dans le logement, des [pièces réservées exclusivement à une activité professionnelle](. 'Ne rentrent pas dans cette catégorie les pièces à usage mixte, utilisées également par les membres de la famille.'), comme un cabinet de dentiste ou d’avocat par exemple ?\"",
@@ -8454,7 +8454,7 @@
 		{
 			"id": "jojv1e5e",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "58",
 			"min": 1,
 			"max": 9,
@@ -8514,7 +8514,7 @@
 		{
 			"id": "jojuz9k3",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "59",
 			"min": 1,
 			"max": 997,
@@ -8582,7 +8582,7 @@
 		{
 			"id": "jojv79ut",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "60",
 			"label": {
 				"value": "\"➡ \" || \"Y a-t-il des pièces annexes à usage d’habitation rattachées au logement avec une entrée indépendante, telles que des chambres de bonne ou d’anciens garages réaménagés en studios par exemple ?\"",
@@ -8632,7 +8632,7 @@
 		{
 			"id": "jojv3ha7",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "61",
 			"min": 1,
 			"max": 9,
@@ -8684,7 +8684,7 @@
 		{
 			"id": "kmd6o006",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "62",
 			"label": {
 				"value": "\"➡ \" || \"Quel usage faites-vous de la pièce annexe ?\"",
@@ -8816,7 +8816,7 @@
 		{
 			"id": "jojuzbus",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "64",
 			"min": 1,
 			"max": 9,
@@ -8875,7 +8875,7 @@
 		{
 			"id": "klv4iusu",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "65",
 			"min": 1,
 			"max": 9,
@@ -8934,7 +8934,7 @@
 		{
 			"id": "jojv5bnw",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "66",
 			"min": 1,
 			"max": 999,
@@ -8972,7 +8972,7 @@
 		{
 			"id": "klw36l7v",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "67",
 			"min": 1,
 			"max": 999,
@@ -9040,7 +9040,7 @@
 		{
 			"id": "jojvgfei",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "68",
 			"min": 1,
 			"max": 100,
@@ -9142,7 +9142,7 @@
 		{
 			"id": "jojv4yqe",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "69",
 			"min": 0,
 			"max": 100,
@@ -9233,7 +9233,7 @@
 		{
 			"id": "jojvc0vt",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "70",
 			"min": 1,
 			"max": 1000,
@@ -9345,7 +9345,7 @@
 		{
 			"id": "jojv1ux1",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "71",
 			"label": {
 				"value": "\"➡ \" || \"Compte tenu du nombre de personnes de votre ménage, comment estimez-vous le nombre de pièces dont vous disposez ?\"",
@@ -9399,7 +9399,7 @@
 		{
 			"id": "kv29cjdq",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "72",
 			"label": {
 				"value": "\"➡ \" || \"Quelle est la [hauteur sous plafond](. 'Lorsque la pièce principale est située sous des combles, la hauteur sous plafond varie. Choisir la réponse correspondant à la partie la plus haute de la pièce.') de votre pièce principale ?\"",
@@ -9476,7 +9476,7 @@
 		{
 			"id": "jrupq1i5",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "73",
 			"label": {
 				"value": "\"➡ \" || \"Avez-vous une véranda ?\"",
@@ -9523,7 +9523,7 @@
 		{
 			"id": "jrupsr80",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "74",
 			"min": 1,
 			"max": 999,
@@ -9558,7 +9558,7 @@
 		{
 			"id": "jrupy93h",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "75",
 			"label": {
 				"value": "\"➡ \" || \"La surface de la véranda (\" || cast(KSV,string) || \" m²) a t-elle été prise en compte dans la surface totale du logement (\" || cast(HST,string) || \" m²) que vous avez indiquée précédemment ?\"",
@@ -9594,7 +9594,7 @@
 		{
 			"id": "jrupzl7m",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "76",
 			"label": {
 				"value": "\"➡ \" || \"Avez-vous un balcon\" || libKBA1 || \" ou une loggia ?\"",
@@ -9630,7 +9630,7 @@
 		{
 			"id": "jrupx7iz",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "77",
 			"min": 1,
 			"max": 999,
@@ -9665,7 +9665,7 @@
 		{
 			"id": "jruq98v2",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "78",
 			"label": {
 				"value": "\"➡ \" || libKJA || \" un jardin, un terrain ou une cour réservés à votre usage personnel ?\"",
@@ -9701,7 +9701,7 @@
 		{
 			"id": "jruq8x6e",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "79",
 			"min": 1,
 			"max": 100000,
@@ -9769,7 +9769,7 @@
 		{
 			"id": "jruq85av",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "80",
 			"label": {
 				"value": "\"➡ \" || \"Pouvez-vous néanmoins indiquer dans quelle tranche se situe la surface du terrain ?\"",
@@ -9833,7 +9833,7 @@
 		{
 			"id": "jruq4was",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "81",
 			"min": 1,
 			"max": 99999,
@@ -9904,7 +9904,7 @@
 		{
 			"id": "jruq6fv0",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "82",
 			"min": 1,
 			"max": 99999,
@@ -9939,7 +9939,7 @@
 		{
 			"id": "jruqlf39",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "83",
 			"label": {
 				"value": "\"➡ \" || \"Disposez-vous d’espaces extérieurs (jardin, terrain, cour...) en tant que parties communes de la résidence ou de la copropriété ?\"",
@@ -9986,7 +9986,7 @@
 		{
 			"id": "jrusmgfq",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "84",
 			"label": {
 				"value": "\"➡ \" || \"Quelle est la surface de ces espaces partagés ?\"",
@@ -10246,7 +10246,7 @@
 		{
 			"id": "jrut0i0j",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "87",
 			"label": {
 				"value": "\"➡ \" || \"Disposez-vous d’une cave ou d’un sous-sol (même si vous ne l’utilisez pas) ?\"",
@@ -10293,7 +10293,7 @@
 		{
 			"id": "jrusu349",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "88",
 			"label": {
 				"value": "\"➡ \" || \"Disposez-vous, dans les parties communes de \" || libKVELO || \", d’un local fermé où vous pouvez déposer un vélo ou une poussette ?\"",
@@ -10342,7 +10342,7 @@
 		{
 			"id": "jrutj5co",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "89",
 			"label": {
 				"value": "\"➡ \" || \"Disposez-vous d’un grenier ou de combles aménageables, mais non aménagés en pièces d’habitation ?\"",
@@ -10378,7 +10378,7 @@
 		{
 			"id": "jruu4ry3",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "90",
 			"label": {
 				"value": "\"➡ \" || \"Disposez-vous d’un sous-sol non aménagé en pièces d’habitation ?\"",
@@ -10414,7 +10414,7 @@
 		{
 			"id": "jruubukg",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "91",
 			"label": {
 				"value": "\"➡ \" || \"Disposez-vous d’une grange non aménagée en pièces d’habitation ?\"",
@@ -10450,7 +10450,7 @@
 		{
 			"id": "jruue197",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "92",
 			"label": {
 				"value": "\"➡ \" || \"Avez-vous une piscine fixe d’une profondeur de plus de 1 mètre ?\"",
@@ -10521,7 +10521,7 @@
 		{
 			"id": "jruuncm0",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "93",
 			"label": {
 				"value": "\"➡ \" || \"Comment votre logement est-il alimenté en eau ?\"",
@@ -10568,7 +10568,7 @@
 		{
 			"id": "jruv1cla",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "94",
 			"label": {
 				"value": "\"➡ \" || \"Disposez-vous de W-C à l’intérieur du logement ?\"",
@@ -10615,7 +10615,7 @@
 		{
 			"id": "kmeu61l4",
 			"componentType": "Table",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "95",
 			"label": {
 				"value": "\"➡ \" || \"Combien avez-vous de W-C ?\"",
@@ -10737,7 +10737,7 @@
 		{
 			"id": "jruva8uu",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "96",
 			"label": {
 				"value": "\"➡ \" || \"Possédez-vous une salle d’eau ou une salle de bain (pièce contenant une douche ou une baignoire) ?\"",
@@ -10773,7 +10773,7 @@
 		{
 			"id": "kksgd6fv",
 			"componentType": "Table",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "97",
 			"label": {
 				"value": "\"➡ \" || \"Combien avez-vous de salle d’eau ou salle de bain ?\"",
@@ -10892,7 +10892,7 @@
 		{
 			"id": "kmf0xcox",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "98",
 			"label": {
 				"value": "\"➡ \" || \"Avez-vous une douche ou une baignoire installée dans une pièce destinée à un autre usage ?\"",
@@ -10928,7 +10928,7 @@
 		{
 			"id": "jruv164k",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "99",
 			"label": {
 				"value": "\"➡ \" || \"Disposez-vous d’un ou plusieurs lavabos ?\"",
@@ -11059,7 +11059,7 @@
 		{
 			"id": "joicolgp",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "101",
 			"label": {
 				"value": "\"➡ \" || \"Comment estimez-vous vos conditions actuelles de logement ?\"",
@@ -11119,7 +11119,7 @@
 		{
 			"id": "joiccm1l",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "102",
 			"min": 1,
 			"max": 10,
@@ -11185,7 +11185,7 @@
 		{
 			"id": "knio1w9d",
 			"componentType": "Table",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "103",
 			"label": {
 				"value": "\"➡ \" || \"Votre logement présente-t-il les défauts suivants ?\"",
@@ -11333,7 +11333,7 @@
 		{
 			"id": "kninrf3p",
 			"componentType": "Table",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "104",
 			"label": {
 				"value": "\"➡ \" || \"Votre logement présente-t-il les autres défauts suivants ?\"",
@@ -11472,7 +11472,7 @@
 		{
 			"id": "knioggcs",
 			"componentType": "Table",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "105",
 			"label": {
 				"value": "\"➡ \" || \"L’environnement de votre logement présente-t-il les défauts suivants ?\"",
@@ -11600,7 +11600,7 @@
 		{
 			"id": "kniwyjy0",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "106",
 			"label": {
 				"value": "\"➡ \" || \"Vous plaisez-vous dans votre quartier (ou village) ?\"",
@@ -11647,7 +11647,7 @@
 		{
 			"id": "joidpl4s",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "107",
 			"min": 1,
 			"max": 10,
@@ -11746,7 +11746,7 @@
 		{
 			"id": "kcvx4gaz",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "108",
 			"label": {
 				"value": "\"➡ \" || \"Au cours des 12 derniers mois, l’un des membres du ménage, y compris vous-même, a-t-il déposé ou renouvelé une demande de HLM ?\"",
@@ -11859,7 +11859,7 @@
 		{
 			"id": "joieoqtu",
 			"componentType": "Table",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "110",
 			"label": {
 				"value": "\"➡ \" || \"Auprès de qui \" || libOIH || \" déposé cette demande de HLM ?\"",
@@ -12024,7 +12024,7 @@
 		{
 			"id": "joieparb",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "111",
 			"label": {
 				"value": "\"➡ \" || \"Depuis combien de temps \" || libOIH || \" déposé cette demande de HLM ?\"",
@@ -12117,7 +12117,7 @@
 		{
 			"id": "joiegq0p",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "112",
 			"label": {
 				"value": "\"➡ \" || \"Depuis le dépôt de cette demande de HLM, \" || libOIH || \" refusé une ou plusieurs propositions de logements ?\"",
@@ -12293,7 +12293,7 @@
 		{
 			"id": "joifgmrr",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "114",
 			"label": {
 				"value": "\"➡ \" || \"Souhaitez-vous changer de logement ?\"",
@@ -12335,7 +12335,7 @@
 		{
 			"id": "joifoap2",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "115",
 			"label": {
 				"value": "\"➡ \" || \"Pensez-vous être contraint de quitter votre logement dans les trois ans à venir ?\"",
@@ -12382,7 +12382,7 @@
 		{
 			"id": "joifcbgf",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "116",
 			"label": {
 				"value": "\"➡ \" || \"Pour quelle raison pensez-vous être contraint de quitter votre logement ?\"",
@@ -12460,7 +12460,7 @@
 		{
 			"id": "joifzvkd",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "117",
 			"label": {
 				"value": "\"➡ \" || \"Avez-vous fait une demande de logement dans le cadre de la loi Dalo ([Droit au logement opposable](. 'La loi sur le droit au logement opposable (Dalo) du 5 mars 2007 a instauré un recours pour les personnes mal-logées. La loi désigne l’État comme le garant du droit au logement. La mise en œuvre de cette garantie s’appuie sur un recours amiable ou un recours contentieux.')) ?\"",
@@ -12502,7 +12502,7 @@
 		{
 			"id": "joifs2y7",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "118",
 			"label": {
 				"value": "\"➡ \" || \"Suite à votre demande, avez-vous obtenu un logement dans le cadre de la loi Dalo ?\"",
@@ -12544,7 +12544,7 @@
 		{
 			"id": "joig627d",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "119",
 			"label": {
 				"value": "\"➡ \" || \"Envisagez-vous de quitter votre commune ?\"",
@@ -12591,7 +12591,7 @@
 		{
 			"id": "joig7qe3",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "120",
 			"label": {
 				"value": "\"➡ \" || \"Où envisagez-vous d’aller vous installer ?\"",
@@ -12657,7 +12657,7 @@
 		{
 			"id": "joigb7rg",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "121",
 			"label": {
 				"value": "\"➡ \" || \"Plus précisément, où comptez-vous vivre ?\"",
@@ -12718,7 +12718,7 @@
 		{
 			"id": "joig56ii",
 			"componentType": "Dropdown",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "122",
 			"label": {
 				"value": "\"➡ \" || \"Dans quel département envisagez-vous de vous installer ou de rester ?\"",
@@ -12764,7 +12764,7 @@
 		{
 			"id": "joigkrjq",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "123",
 			"label": {
 				"value": "\"➡ \" || \"Plus précisément, où comptez-vous vivre ?\"",
@@ -12814,7 +12814,7 @@
 		{
 			"id": "joigdh1o",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "124",
 			"label": {
 				"value": "\"➡ \" || \"Plus précisément, où comptez-vous vivre ?\"",
@@ -12884,7 +12884,7 @@
 		{
 			"id": "joigr611",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "125",
 			"label": {
 				"value": "\"➡ \" || \"Quel type de logement envisagez-vous d’occuper ?\"",
@@ -12947,7 +12947,7 @@
 		{
 			"id": "joigyk2a",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "126",
 			"label": {
 				"value": "\"➡ \" || \"Par rapport à votre logement actuel, quelle serait la taille du logement que vous envisagez d’occuper ?\"",
@@ -12999,7 +12999,7 @@
 		{
 			"id": "joigwqiq",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "127",
 			"label": {
 				"value": "\"➡ \" || \"Dans votre futur logement, quel statut d’occupation envisagez-vous ?\"",
@@ -13051,7 +13051,7 @@
 		{
 			"id": "joigrs80",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "128",
 			"min": 1,
 			"max": 1.0e7,
@@ -13129,7 +13129,7 @@
 		{
 			"id": "joigx4x8",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "129",
 			"min": 1,
 			"max": 1.0e7,
@@ -13196,7 +13196,7 @@
 		{
 			"id": "joih1sgy",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "130",
 			"label": {
 				"value": "\"➡ \" || \"Où en êtes-vous de vos démarches ?\"",
@@ -13263,7 +13263,7 @@
 		{
 			"id": "joigwfan",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "131",
 			"label": {
 				"value": "\"➡ \" || \"Quand envisagez-vous de quitter votre logement ?\"",
@@ -13326,7 +13326,7 @@
 		{
 			"id": "knk8j9xd",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "132",
 			"label": {
 				"value": "\"➡ \" || \"Pourquoi n’avez vous pas déposé de demande HLM ?\"",
@@ -13784,7 +13784,7 @@
 				{
 					"id": "kqr0kx1e",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "134.2",
 					"label": {
 						"value": "\"➡ \" || \"Comment la chambre d’hôtel était-elle payée ?\"",
@@ -13859,7 +13859,7 @@
 				{
 					"id": "kpb8b0vw",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "134.3",
 					"label": {
 						"value": "\"➡ \" || \"Était-ce un centre d’hébergement pour demandeurs d’asile ou réfugiés ?\"",
@@ -13911,7 +13911,7 @@
 				{
 					"id": "joio5w41",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "134.4",
 					"label": {
 						"value": "\"➡ \" || \"Combien de situations de ce type \" || (if (PRENOM=PRENOMREF) then \"avez-vous\" else PRENOM || \" a-t-\" || LIB_SUJET) || \" connues ?\"",
@@ -13979,7 +13979,7 @@
 				{
 					"id": "joioebt6",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "134.5",
 					"label": {
 						"value": "\"➡ \" || \"Combien de temps au total \" || (if (PRENOM=PRENOMREF) then \"avez-vous\" else PRENOM || \" a-t-\" || LIB_SUJET) || \" été dans \" || libSDT || \" ?\"",
@@ -14073,7 +14073,7 @@
 				{
 					"id": "kudultmi",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "134.6",
 					"label": {
 						"value": "\"➡ \" || if (PRENOM=PRENOMREF) then \"Quelle est la première situation de ce type que vous avez connue ?\" else \"Quelle est la première situation de ce type que \" || PRENOM || \" a connue ?\"",
@@ -14191,7 +14191,7 @@
 				{
 					"id": "joo0yx5k",
 					"componentType": "Dropdown",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "134.7",
 					"label": {
 						"value": "\"➡ \" || \"En quelle année \" || if (isnull(SDN1)) then ( if (PRENOM=PRENOMREF) then \"avez-vous été pour la première fois dans une de ces situations ?\" else PRENOM || \" a-t-\" || LIB_SUJET || \" été pour la première fois dans une de ces situations ?\" ) else (if (SDN1=\"1\") then \"cette situation a-t-elle débuté ?\" else ( if (PRENOM=PRENOMREF) then \"avez-vous été dans cette première situation ?\" else PRENOM || \" a-t-\" || LIB_SUJET || \" été dans cette première situation ?\" ))",
@@ -14869,7 +14869,7 @@
 				{
 					"id": "joo1m3x2",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "134.8",
 					"label": {
 						"value": "\"➡ \" || \"La première fois que \" || (if (PRENOM=PRENOMREF) then \"vous avez été\" else PRENOM || \" a été\") || \" dans cette situation, combien de temps cela a-t-il duré ?\"",
@@ -14961,7 +14961,7 @@
 				{
 					"id": "kudvobyc",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "134.9",
 					"label": {
 						"value": "\"➡ \" || if (PRENOM=PRENOMREF) then \"Quelle est la dernière situation de ce type que vous avez connue ?\" else \"Quelle est la dernière situation de ce type que \" || PRENOM || \" a connue ?\"",
@@ -15079,7 +15079,7 @@
 				{
 					"id": "kudvxpft",
 					"componentType": "Dropdown",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "134.10",
 					"label": {
 						"value": "\"➡ \" || \"En quelle année \" || ( if (PRENOM=PRENOMREF) then \"avez-vous été dans cette dernière situation ?\" else PRENOM || \" a-t-\" || LIB_SUJET || \" été dans cette dernière situation ?\" )",
@@ -15756,7 +15756,7 @@
 				{
 					"id": "kudwrcyp",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "134.11",
 					"label": {
 						"value": "\"➡ \" || \"La dernière fois que \" || (if (PRENOM=PRENOMREF) then \"vous avez été\" else PRENOM || \" a été\") || \" dans cette situation, combien de temps cela a-t-il duré ?\"",
@@ -16264,7 +16264,7 @@
 		{
 			"id": "jopgtrq1",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "139",
 			"label": {
 				"value": "\"➡ \" || \"Depuis le 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \", un des membres de votre ménage actuel, y compris vous-même, a-t-il vendu un ou plusieurs logements ?\"",
@@ -16330,7 +16330,7 @@
 		{
 			"id": "jopgvwb0",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "140",
 			"label": {
 				"value": "\"➡ \" || \"Comment aviez-vous fait l’acquisition de ce logement maintenant vendu ?\"",
@@ -16404,7 +16404,7 @@
 		{
 			"id": "jopgzovi",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "141",
 			"label": {
 				"value": "\"➡ \" || libVFLA || \" était-il votre résidence principale ?\"",
@@ -16463,7 +16463,7 @@
 		{
 			"id": "koeabibm",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "142",
 			"label": {
 				"value": "\"➡ \" || \"Depuis le 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \", un des membres de votre ménage actuel, y compris vous-même, a-t-il acheté un ou plusieurs logements, comme une résidence principale, secondaire, un logement destiné à être loué, etc. ?\"",
@@ -16518,7 +16518,7 @@
 		{
 			"id": "joph9za3",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "143",
 			"label": {
 				"value": "\"➡ \" || \"Par rapport au prix du \" || libVBILLOG1 || \", comment était le prix du \" || libVBILLOG2 || \" ?\"",
@@ -16597,7 +16597,7 @@
 		{
 			"id": "jopkquw3",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "144",
 			"label": {
 				"value": "\"➡ \" || \"Où habitiez-vous le 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \" ?\"",
@@ -16690,7 +16690,7 @@
 		{
 			"id": "jopl7p41",
 			"componentType": "Dropdown",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "145",
 			"label": {
 				"value": "\"➡ \" || \"Dans quelle commune habitiez-vous le 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \" ?\"",
@@ -16758,7 +16758,7 @@
 		{
 			"id": "joplihpv",
 			"componentType": "Dropdown",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "146",
 			"label": {
 				"value": "\"➡ \" || \"Dans quel département habitiez-vous le 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \" ?\"",
@@ -16827,7 +16827,7 @@
 		{
 			"id": "joplkxrd",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "147",
 			"maxLength": 30,
 			"label": {
@@ -16875,7 +16875,7 @@
 		{
 			"id": "jopldlvn",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "148",
 			"maxLength": 30,
 			"label": {
@@ -16938,7 +16938,7 @@
 		{
 			"id": "joplorns",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "149",
 			"label": {
 				"value": "\"➡ \" || \"Au 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \", quelle était votre situation ?\"",
@@ -17010,7 +17010,7 @@
 		{
 			"id": "joplzrmo",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "150",
 			"label": {
 				"value": "\"➡ \" || \"Au 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \", comment votre ménage occupait-il ce logement ?\"",
@@ -17100,7 +17100,7 @@
 		{
 			"id": "jopri4xh",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "151",
 			"label": {
 				"value": "\"➡ \" || \"Quel était le régime juridique du loyer ?\"",
@@ -17176,7 +17176,7 @@
 		{
 			"id": "joprsm9u",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "152",
 			"min": 0,
 			"max": 1.0e6,
@@ -17270,7 +17270,7 @@
 		{
 			"id": "joprlyql",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "153",
 			"label": {
 				"value": "\"➡ \" || \"Bénéficiez-vous au 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \" de l’allocation logement ou de l’aide personnalisée au logement (APL) ?\"",
@@ -17331,7 +17331,7 @@
 		{
 			"id": "joprp441",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "154",
 			"min": 1,
 			"max": 24,
@@ -17422,7 +17422,7 @@
 		{
 			"id": "jopruzlo",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "155",
 			"label": {
 				"value": "\"➡ \" || \"À quoi correspondait le logement occupé au 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \" ?\"",
@@ -17492,7 +17492,7 @@
 		{
 			"id": "jopsc29x",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "156",
 			"min": 1,
 			"max": 999,
@@ -17559,7 +17559,7 @@
 		{
 			"id": "jops4c0x",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "157",
 			"min": 1,
 			"max": 20,
@@ -17640,7 +17640,7 @@
 		{
 			"id": "jopsjl1n",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "158",
 			"min": 0,
 			"max": 100,
@@ -17720,7 +17720,7 @@
 		{
 			"id": "jopsiigq",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "159",
 			"label": {
 				"value": "\"➡ \" || \"Quelle était votre situation professionnelle au 1er \" || libMOISENQ || \" \" || cast(ANNEENQmoins4,string) || \" ?\"",
@@ -17843,7 +17843,7 @@
 		{
 			"id": "jopsrdb3",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "160",
 			"min": 0,
 			"max": 9,
@@ -17914,7 +17914,7 @@
 		{
 			"id": "joptkb9d",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "161",
 			"label": {
 				"value": "\"➡ \" || \"Juste avant d’habiter dans votre logement actuel, où résidiez-vous ?\"",
@@ -17982,7 +17982,7 @@
 		{
 			"id": "jopu7wfr",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "162",
 			"label": {
 				"value": "\"➡ \" || \"Avant d’occuper votre logement actuel, quelle était votre situation ?\"",
@@ -18065,7 +18065,7 @@
 		{
 			"id": "jopua1hn",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "163",
 			"label": {
 				"value": "\"➡ \" || \"Comment votre ménage occupait-il le précédent logement ?\"",
@@ -18154,7 +18154,7 @@
 		{
 			"id": "jopuofnr",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "164",
 			"label": {
 				"value": "\"➡ \" || \"Quel était le régime juridique du loyer ?\"",
@@ -18264,7 +18264,7 @@
 		{
 			"id": "jopuhzbr",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "165",
 			"label": {
 				"value": "\"➡ \" || \"À quoi correspondait votre précédent logement ?\"",
@@ -18329,7 +18329,7 @@
 		{
 			"id": "jopukm75",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "166",
 			"min": 1,
 			"max": 997,
@@ -18391,7 +18391,7 @@
 		{
 			"id": "joputbjc",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "167",
 			"min": 1,
 			"max": 20,
@@ -19009,7 +19009,7 @@
 		{
 			"id": "kp55gaf4",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "173",
 			"label": {
 				"value": "\"➡ \" || \"Comment est votre état de santé en général ?\"",
@@ -19046,7 +19046,7 @@
 		{
 			"id": "kp56b045",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "174",
 			"label": {
 				"value": "\"➡ \" || \"Avez-vous une maladie ou un problème de santé qui soit chronique ou de caractère durable ?\"",
@@ -19088,7 +19088,7 @@
 		{
 			"id": "kp56ml0f",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "175",
 			"label": {
 				"value": "\"➡ \" || \"Êtes-vous limité\" || (if (isnull(SEXEREF)) then \"\" else (if (cast(SEXEREF,string) = \"2\") then \"e\" else \"\")) || \", depuis au moins 6 mois, à cause d’un problème de santé, dans les activités que les gens font habituellement ?\"",
@@ -19196,7 +19196,7 @@
 				{
 					"id": "kp56qgdl",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "176.1",
 					"label": {
 						"value": "\"➡ \" || \"Comment est l’état de santé de \" || PRENOM || \" en général ?\"",
@@ -19252,7 +19252,7 @@
 				{
 					"id": "kp56xi4v",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "176.2",
 					"label": {
 						"value": "\"➡ \" || PRENOM || \" a-t-\" || LIB_SUJET || \" une maladie ou un problème de santé qui soit chronique ou de caractère durable ?\"",
@@ -19305,7 +19305,7 @@
 				{
 					"id": "kp5712k1",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "176.3",
 					"label": {
 						"value": "\"➡ \" || PRENOM || \" est-\" || LIB_SUJET || \" limité\" || LIB_FEM || \", depuis au moins 6 mois, à cause d’un problème de santé, dans les activités que les gens font habituellement ?\"",
@@ -19401,7 +19401,7 @@
 		{
 			"id": "kp59rky6",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "177",
 			"label": {
 				"value": "\"➡ \" || \"Où est né votre père ?\"",
@@ -19465,7 +19465,7 @@
 		{
 			"id": "kp59rmtt",
 			"componentType": "Dropdown",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "178",
 			"label": {
 				"value": "\"➡ \" || \"Dans quel pays est né votre père ?\"",
@@ -19614,7 +19614,7 @@
 		{
 			"id": "kp59tm8h",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "180",
 			"label": {
 				"value": "\"➡ \" || \"Où est née votre mère ?\"",
@@ -19667,7 +19667,7 @@
 		{
 			"id": "kp59nici",
 			"componentType": "Dropdown",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "181",
 			"label": {
 				"value": "\"➡ \" || \"Dans quel pays est née votre mère ?\"",
@@ -19862,7 +19862,7 @@
 		{
 			"id": "kp5apvf3",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "184",
 			"label": {
 				"value": "\"➡ \" || \"Vous ou une autre personne de votre ménage, décrochez-vous lorsque votre téléphone fixe sonne ?\"",
@@ -19938,7 +19938,7 @@
 		{
 			"id": "kp5au0iu",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "185",
 			"label": {
 				"value": "\"➡ \" || \"Décrochez-vous lorsque votre téléphone mobile sonne ?\"",
@@ -20014,7 +20014,7 @@
 		{
 			"id": "kp5bjbzg",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "186",
 			"label": {
 				"value": "\"➡ \" || \"Comment avez-vous utilisé Internet, au cours des trois derniers mois, en moyenne ?\"",
@@ -20119,7 +20119,7 @@
 		{
 			"id": "kbamkrlv",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "187",
 			"label": {
 				"value": "\"➡ \" || \"Les courriers que nous vous envoyons dans le cadre de cette enquête sont adressés à : \" || libCHGNC || \". Cela vous convient-il ?\"",
@@ -20158,7 +20158,7 @@
 		{
 			"id": "kbaxq9l0",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "188",
 			"label": {
 				"value": "\"➡ \" || \"Civilité du \" || if (not(isnull(NOMVOUS_D2)) and NOMVOUS_D2<>\"\") then \"premier destinataire :\" else \" destinataire :\"",
@@ -20208,7 +20208,7 @@
 		{
 			"id": "kr0fw3n6",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "189",
 			"maxLength": 20,
 			"label": {
@@ -20243,7 +20243,7 @@
 		{
 			"id": "kr0fn06f",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "190",
 			"maxLength": 40,
 			"label": {
@@ -20278,7 +20278,7 @@
 		{
 			"id": "kwjivaa1",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "191",
 			"label": {
 				"value": "\"➡ \" || \"Souhaitez-vous ajouter un deuxième destinataire au courrier que nous vous envoyons ?\"",
@@ -20317,7 +20317,7 @@
 		{
 			"id": "kr0fr82y",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "192",
 			"label": {
 				"value": "\"➡ \" || \"Civilité du deuxième destinataire :\"",
@@ -20373,7 +20373,7 @@
 		{
 			"id": "kbbzjgn8",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "193",
 			"maxLength": 20,
 			"label": {
@@ -20414,7 +20414,7 @@
 		{
 			"id": "kbbzhtx3",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "194",
 			"maxLength": 40,
 			"label": {
@@ -20482,7 +20482,7 @@
 		{
 			"id": "kbay0xfi",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "195",
 			"maxLength": 10,
 			"label": {

--- a/src/stories/questionnaires/recensement/source.json
+++ b/src/stories/questionnaires/recensement/source.json
@@ -36,7 +36,7 @@
 		{
 			"id": "kkxuu8ov",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "2",
 			"maxLength": 80,
 			"label": {
@@ -71,7 +71,7 @@
 		{
 			"id": "kkxv0qgj",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "2",
 			"maxLength": 249,
 			"label": {
@@ -106,7 +106,7 @@
 		{
 			"id": "l8twtrc9",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "2",
 			"maxLength": 4,
 			"label": { "value": "\"➡ 3. \" || \"N°\"", "type": "VTL|MD" },
@@ -146,7 +146,7 @@
 		{
 			"id": "l8twwcvn",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "2",
 			"maxLength": 4,
 			"label": { "value": "\"➡ 4. \" || \"Bis, ...\"", "type": "VTL|MD" },
@@ -175,7 +175,7 @@
 		{
 			"id": "l8twyzo4",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "2",
 			"maxLength": 27,
 			"label": { "value": "\"➡ 5. \" || \"Rue, Av, ...\"", "type": "VTL|MD" },
@@ -204,7 +204,7 @@
 		{
 			"id": "l8twy1k6",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "2",
 			"maxLength": 80,
 			"label": {
@@ -236,7 +236,7 @@
 		{
 			"id": "l8tx81u3",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "2",
 			"maxLength": 40,
 			"label": {
@@ -268,7 +268,7 @@
 		{
 			"id": "l8tx1vsp",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "2",
 			"maxLength": 20,
 			"label": { "value": "\"➡ 8. \" || \"Bâtiment\"", "type": "VTL|MD" },
@@ -297,7 +297,7 @@
 		{
 			"id": "l8txj55d",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "2",
 			"maxLength": 10,
 			"label": { "value": "\"➡ 9. \" || \"Escalier\"", "type": "VTL|MD" },
@@ -326,7 +326,7 @@
 		{
 			"id": "l8txiop1",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "2",
 			"maxLength": 3,
 			"label": { "value": "\"➡ 10. \" || \"Étage\"", "type": "VTL|MD" },
@@ -355,7 +355,7 @@
 		{
 			"id": "l8txsdqj",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "2",
 			"maxLength": 40,
 			"label": {
@@ -387,7 +387,7 @@
 		{
 			"id": "l8txcnai",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "2",
 			"maxLength": 5,
 			"label": { "value": "\"➡ 12. \" || \"Code postal\"", "type": "VTL|MD" },
@@ -416,7 +416,7 @@
 		{
 			"id": "l8txo3fk",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "2",
 			"maxLength": 80,
 			"label": {
@@ -469,7 +469,7 @@
 		{
 			"id": "klqmzxr4",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "4",
 			"label": {
 				"value": "\"➡ 14. \" || \"Quel est le type de logement ?\"",
@@ -536,7 +536,7 @@
 		{
 			"id": "klqmu096",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "4",
 			"label": {
 				"value": "\"➡ 15. \" || \"Ce logement est-il desservi par un ascenseur ?\"",
@@ -578,7 +578,7 @@
 		{
 			"id": "klqn2o7t",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "5",
 			"label": {
 				"value": "\"➡ 16. \" || \"Quelle est l’année d’achèvement de la construction de la maison ou de l’immeuble ?\"",
@@ -655,7 +655,7 @@
 		{
 			"id": "klqn3zmk",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "6",
 			"min": 2006,
 			"max": 2023,
@@ -714,7 +714,7 @@
 		{
 			"id": "klqncpes",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "7",
 			"maxLength": 4,
 			"label": {
@@ -775,7 +775,7 @@
 		{
 			"id": "klqns4rj",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"min": 0,
 			"max": 200,
@@ -872,7 +872,7 @@
 		{
 			"id": "klqnxdxp",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "8",
 			"label": {
 				"value": "\"➡ 20. \" || \"Quelle est la surface de ce logement ?\"",
@@ -964,7 +964,7 @@
 		{
 			"id": "klqns2qd",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "9",
 			"label": { "value": "\"➡ 21. \" || \"Êtes-vous :\"", "type": "VTL|MD" },
 			"conditionFilter": { "value": "true", "type": "VTL" },
@@ -1029,7 +1029,7 @@
 		{
 			"id": "klqnr6f5",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "9",
 			"label": {
 				"value": "\"➡ 22. \" || \"Ce logement appartient-il à un organisme d’HLM ?\"",
@@ -1068,7 +1068,7 @@
 		{
 			"id": "klqobgcg",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "10",
 			"label": {
 				"value": "\"➡ 23. \" || \"Quelles sont les installations sanitaires de ce logement ?\"",
@@ -1125,7 +1125,7 @@
 		{
 			"id": "klqnzaud",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "11",
 			"label": {
 				"value": "\"➡ 24. \" || \"Quel est le principal moyen de chauffage de ce logement ?\"",
@@ -1193,7 +1193,7 @@
 		{
 			"id": "klqo6tay",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "11",
 			"label": {
 				"value": "\"➡ 25. \" || \"Quel est le combustible principal de chauffage ?\"",
@@ -1267,7 +1267,7 @@
 		{
 			"id": "klqor7p0",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "12",
 			"label": {
 				"value": "\"➡ 26. \" || \"De combien de voitures les habitants de ce logement disposent-ils ?\"",
@@ -1333,7 +1333,7 @@
 		{
 			"id": "klqolz63",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "12",
 			"label": {
 				"value": "\"➡ 27. \" || \"Disposez-vous d’un emplacement de stationnement réservé à votre usage personnel ?\"",
@@ -1566,7 +1566,7 @@
 				{
 					"id": "klqpfz6h",
 					"componentType": "Input",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "14",
 					"maxLength": 50,
 					"label": { "value": "\"➡ 28. \" || \"Nom\"", "type": "VTL|MD" },
@@ -1595,7 +1595,7 @@
 				{
 					"id": "l4r3a6xc",
 					"componentType": "Input",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "14",
 					"maxLength": 50,
 					"label": { "value": "\"➡ 29. \" || \"Prénom\"", "type": "VTL|MD" },
@@ -1625,7 +1625,7 @@
 				{
 					"id": "l4r3hyyi",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "14",
 					"label": { "value": "\"➡ 30. \" || \"Sexe\"", "type": "VTL|MD" },
 					"conditionFilter": { "value": "true", "type": "VTL" },
@@ -1659,7 +1659,7 @@
 				{
 					"id": "l4r33zxd",
 					"componentType": "Datepicker",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "14",
 					"min": "1900-01-01",
 					"max": "2050-01-01",
@@ -1913,7 +1913,7 @@
 				{
 					"id": "l4si0s6m",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "35.1",
 					"label": {
 						"value": "\"➡ 33. \" || \"Est-ce que \" || (if (isnull(PRENOM)) then \"cet habitant\" else PRENOM) || \" \" || (if (isnull(NOM)) then \"\" else NOM) || \" vit dans ce logement de façon permanente la plus grande partie de l’année ?\"",
@@ -1949,7 +1949,7 @@
 				{
 					"id": "la1116gn",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "35.2",
 					"label": {
 						"value": "\"➡ 34. \" || \"Est-ce que \" || (if isnull(PRENOM) then \"cet habitant\" else PRENOM) || \" \" || (if isnull(NOM) then \"\" else NOM) || \" vit aussi dans un autre logement?\"",
@@ -1992,7 +1992,7 @@
 				{
 					"id": "la10e1vu",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "35.3",
 					"label": {
 						"value": "\"➡ 35. \" || \"Est-ce que \" || (if isnull(PRENOM) then \"cet habitant\" else PRENOM) || \" \" || (if isnull(NOM) then \"\" else NOM) || \" vit aussi dans un autre logement:\"",
@@ -2064,7 +2064,7 @@
 				{
 					"id": "l4shx8xq",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "35.4",
 					"label": {
 						"value": "\"➡ 36. \" || \"En raison de ses études, \" || (if isnull(PRENOM) then \"cet habitant\" else PRENOM) || \" \" || (if isnull(NOM) then \"\" else NOM)",
@@ -2124,7 +2124,7 @@
 				{
 					"id": "l4siaw4u",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "35.5",
 					"label": {
 						"value": "\"➡ 37. \" || \"Pour des raisons professionnelles, \" || (if isnull(PRENOM) then \"cet habitant\" else PRENOM) || \" \" || (if isnull(NOM) then \"\" else NOM)",
@@ -2183,7 +2183,7 @@
 				{
 					"id": "l4sif8zo",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "35.6",
 					"label": {
 						"value": "\"➡ 38. \" || \"Suite à une séparation ou un divorce, \" || (if (isnull(PRENOM)) then \"cet habitant\" else PRENOM) || \" \" || (if (isnull(NOM)) then \"\" else NOM) || \" [habite également chez son autre parent (père ou mère) et](. 'Il s’agit d’indiquer le temps moyen passé par l’enfant sur l’ensemble de l’année civile.'):\"",
@@ -2250,7 +2250,7 @@
 				{
 					"id": "l4sib0y2",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "35.7",
 					"label": {
 						"value": "\"➡ 39. \" || \"A-t-\" || LIB_ILELLE || \" dormi ici la nuit du début du recensement, [soit du dimanche 31 août au lundi 1 septembre](. 'En cas d’égalité de temps passé chez chacun de ses parents, l’enfant est recensé dans le logement où il a dormi la nuit du premier jour de la collecte, c’est-à-dire la nuit du dimanche 31 août au lundi 1 septembre. En effet, l’Insee utilise une règle pour définir chez lequel des deux parents un enfant doit être recensé pour éviter de compter deux fois le même enfant. Il n’y a dans cette règle, ni jugement de valeur, ni incidence sur la vie des parents ou celle des enfants puisque les questionnaires seront anonymisés dès la collecte terminée. La vocation de cette règle est purement statistique.') ?\"",
@@ -2298,7 +2298,7 @@
 				{
 					"id": "l4sijh95",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "35.8",
 					"label": {
 						"value": "\"➡ 40. \" || (if isnull(PRENOM) then \"cet habitant\" else PRENOM) || \" \" || (if isnull(NOM) then \"\" else NOM) || \" est dans une autre situation, car \" || LIB_ILELLE || \" :\"",
@@ -2519,7 +2519,7 @@
 				{
 					"id": "l4pt4wej",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.2",
 					"label": {
 						"value": "\"➡ 41. \" || \"[Quel est votre lieu de naissance ?](. 'Le lieu de naissance permet de savoir si les personnes vivent toujours dans le même département que celui de leur naissance. <br><br> Si vous êtes né dans une ancienne colonie ou un ancien département français, <br><br> veuillez cocher ’ né à l’étranger ’ et indiquer le nom actuel de l’ancienne colonie ou département. <br><br> Par exemple, si vous êtes né à Alger en 1948 alors ancien département français, <br><br> veuillez cocher « né à l’étranger » et indiquer dans les cases suivantes, Commune : Alger, Pays : Algérie. <br><br> Pour l’année d’arrivée en France, indiquez l’année d’arrivée en France métropolitaine, <br> <br> dans un DOM (La Réunion, Guadeloupe, Martinique, Guyane, Mayotte) ou dans une COM (Wallis et Futuna, Nouvelle-Calédonie, Polynésie Française, Saint-Martin, Saint-Barthélemy, Saint-Pierre-et-Miquelon.')\"",
@@ -2595,7 +2595,7 @@
 				{
 					"id": "l4siytrb",
 					"componentType": "Input",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.3",
 					"maxLength": 249,
 					"label": {
@@ -2651,7 +2651,7 @@
 				{
 					"id": "l4sivtf2",
 					"componentType": "Suggester",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.4",
 					"maxLength": 249,
 					"label": {
@@ -2711,7 +2711,7 @@
 				{
 					"id": "l4sjc30k",
 					"componentType": "Input",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.5",
 					"maxLength": 249,
 					"label": {
@@ -2770,7 +2770,7 @@
 				{
 					"id": "l4sjeuhw",
 					"componentType": "Suggester",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.6",
 					"label": {
 						"value": "\"➡ 45. \" || \"Indiquez le pays de naissance\"",
@@ -4048,7 +4048,7 @@
 				{
 					"id": "l4pt6jhk",
 					"componentType": "Input",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.7",
 					"maxLength": 4,
 					"label": {
@@ -4098,7 +4098,7 @@
 				{
 					"id": "l4qqmjj7",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.8",
 					"label": {
 						"value": "\"➡ 47. \" || \"[Quelle est votre nationalité ?](. 'Toutes les personnes habitant en France sont recensées, y compris les étrangers vivant en France, quelque soit leur situation légale. <br><br>Cette question permet d’établir des statistiques sur la composition de la population de la France et son évolution. <br><br> Elle permet également une meilleure connaissance des populations étrangères vivant en France : origine, structure par âge et par sexe, activité professionnelle...')\"",
@@ -4168,7 +4168,7 @@
 				{
 					"id": "l4qqb3h6",
 					"componentType": "Dropdown",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.9",
 					"label": {
 						"value": "\"➡ 48. \" || \"Indiquez votre nationalité à la naissance\"",
@@ -5200,7 +5200,7 @@
 				{
 					"id": "l4qqnfp1",
 					"componentType": "Dropdown",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.10",
 					"label": {
 						"value": "\"➡ 49. \" || \"Indiquez votre nationalité\"",
@@ -6224,7 +6224,7 @@
 				{
 					"id": "l4qqjvo0",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.11",
 					"label": {
 						"value": "\"➡ 50. \" || \"[Êtes-vous inscrit dans un établissement d’enseignement pour l’année scolaire en cours ?](. 'Si votre enfant est inscrit dans une crèche (municipale, associative...) cochez Non. <br><br> Pour les personnes inscrites dans un établissement d’enseignement à distance, <br><br> cochez oui et indiquez que votre établissement est situé dans votre commune de résidence. <br><br> Cette question a en effet pour objectif principal de mesurer les distances entre le domicile et le lieu d’études. <br><br> Le lieu d’études donne également des informations utilisées, par exemple, par les pouvoirs publics pour mettre en place des transports adaptés tels que les cars de ramassage scolaire.')\"",
@@ -6285,7 +6285,7 @@
 				{
 					"id": "l4qqhypl",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.12",
 					"label": {
 						"value": "\"➡ 51. \" || \"Où est situé cet établissement d’enseignement ?\"",
@@ -6343,7 +6343,7 @@
 				{
 					"id": "l4qqdyj7",
 					"componentType": "Input",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.13",
 					"maxLength": 249,
 					"label": {
@@ -6380,7 +6380,7 @@
 				{
 					"id": "l4sjftkz",
 					"componentType": "Input",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.14",
 					"maxLength": 249,
 					"label": {
@@ -6417,7 +6417,7 @@
 				{
 					"id": "la11kurt",
 					"componentType": "Input",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.15",
 					"maxLength": 249,
 					"label": {
@@ -6460,7 +6460,7 @@
 				{
 					"id": "l8ve1ppw",
 					"componentType": "Dropdown",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.16",
 					"label": {
 						"value": "\"➡ 55. \" || \"Indiquez le pays\"",
@@ -7721,7 +7721,7 @@
 				{
 					"id": "l4qqjzhe",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.17",
 					"label": {
 						"value": "\"➡ 56. \" || \"Où habitiez-vous le 1er janvier 2022?\"",
@@ -7800,7 +7800,7 @@
 				{
 					"id": "l4qqsn31",
 					"componentType": "Input",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.18",
 					"maxLength": 249,
 					"label": {
@@ -7859,7 +7859,7 @@
 				{
 					"id": "l4sje88c",
 					"componentType": "Input",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.19",
 					"maxLength": 249,
 					"label": {
@@ -7909,7 +7909,7 @@
 				{
 					"id": "l4wupd9t",
 					"componentType": "Input",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.20",
 					"maxLength": 249,
 					"label": {
@@ -7968,7 +7968,7 @@
 				{
 					"id": "l4sje7o2",
 					"componentType": "Dropdown",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.21",
 					"label": {
 						"value": "\"➡ 60. \" || \"Indiquez cet autre pays\"",
@@ -9263,7 +9263,7 @@
 				{
 					"id": "l4qqx4rt",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.22",
 					"label": {
 						"value": "\"➡ 61. \" || \"Vivez-vous en couple ?\"",
@@ -9610,7 +9610,7 @@
 				{
 					"id": "l4qsy1vz",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.25",
 					"label": {
 						"value": "\"➡ 64. \" || \"Quelle est votre situation principale ?\"",
@@ -9719,7 +9719,7 @@
 				{
 					"id": "l4qspm1d",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.26",
 					"label": {
 						"value": "\"➡ 65. \" || \"[Travaillez-vous actuellement ?](. 'Si vous êtes en congé parental cochez « Non ».')\"",
@@ -9779,7 +9779,7 @@
 				{
 					"id": "l4qsqmx0",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.27",
 					"label": {
 						"value": "\"➡ 66. \" || \"Avez-vous déjà travaillé ?\"",
@@ -9833,7 +9833,7 @@
 				{
 					"id": "l4qsubmh",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.28",
 					"label": {
 						"value": "\"➡ 67. \" || \"Etiez-vous\"",
@@ -9920,7 +9920,7 @@
 				{
 					"id": "l4qzqr81",
 					"componentType": "Input",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.29",
 					"maxLength": 249,
 					"label": {
@@ -9976,7 +9976,7 @@
 				{
 					"id": "l4r06i85",
 					"componentType": "CheckboxOne",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.30",
 					"label": {
 						"value": "\"➡ 69. \" || \"[Cherchez-vous un emploi ?](. 'Si vous cherchez un emploi, cochez « oui » que vous soyez inscrit ou non au Pôle Emploi. La recherche d’emploi s’entend par des contact avec le Pôle Emploi ou une agence d’intérim ou des contacts personnels, des envois de candidatures, la recherche sur petites annonces, par concours, etc.')\"",
@@ -10090,7 +10090,7 @@
 				{
 					"id": "l9cwedq8",
 					"componentType": "Input",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.32",
 					"maxLength": 249,
 					"label": {
@@ -10188,7 +10188,7 @@
 				{
 					"id": "l4r03u32",
 					"componentType": "Input",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.33",
 					"maxLength": 249,
 					"label": {
@@ -10259,7 +10259,7 @@
 				{
 					"id": "l4wtzdtq",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.34",
 					"label": {
 						"value": "\"➡ 72. \" || \"[Votre lieu de travail](. 'Les questions sur le lieu de travail permettent d’établir des statistiques sur la distance <br><br> et le temps de transport entre le domicile et le lieu de travail de la population afin de déterminer les moyens de transport à développer.<br><br> Si vous exercez plusieurs emplois, répondez uniquement pour votre emploi principal.<br><br> Si vous êtes employé par plusieurs particuliers vous rémunérant en chèques emploi-service, indiquez « Particuliers »<br><br> Si vous êtes assistante maternelle, cochez « à votre domicile » si vous accueillez les enfants chez vous <br><br> ou « chez un particulier » si vous gardez les enfants dans leur famille.')\"",
@@ -10356,7 +10356,7 @@
 				{
 					"id": "l4r0f6dh",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.35",
 					"label": {
 						"value": "\"➡ 73. \" || \"[Votre lieu de travail](. 'L’adresse du lieu de travail permet d’une part de déterminer l’activité économique de l’employeur <br><br> à partir du répertoire des entreprises (Sirene) géré par l’Insee. <br><br> Cette information permet d’autre part d’établir des statistiques sur la distance et le temps de transport entre le domicile et le lieu de travail de la population <br><br> afin de déterminer les moyens de transport à développer.<br><br> Si vous exercez plusieurs emplois, répondez uniquement pour votre emploi principal.') se situe-t-il principalement dans la commune où vous résidez?\"",
@@ -10414,7 +10414,7 @@
 				{
 					"id": "l4r0k3r8",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.36",
 					"label": {
 						"value": "\"➡ 74. \" || \"L’adresse de votre lieu de travail est-elle:\"",
@@ -10474,7 +10474,7 @@
 				{
 					"id": "l4r0g12m",
 					"componentType": "Input",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.37",
 					"maxLength": 249,
 					"label": {
@@ -10518,7 +10518,7 @@
 				{
 					"id": "l8voyq7i",
 					"componentType": "Input",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.38",
 					"maxLength": 249,
 					"label": {
@@ -10569,7 +10569,7 @@
 				{
 					"id": "l8vp7req",
 					"componentType": "Dropdown",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.39",
 					"label": {
 						"value": "\"➡ 77. \" || \"Indiquez le pays:\"",
@@ -11838,7 +11838,7 @@
 				{
 					"id": "l4r0vnk8",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.40",
 					"label": {
 						"value": "\"➡ 78. \" || \"[Quel mode de transport principal utilisez-vous le plus souvent pour aller travailler ?](. 'Si vous exercez plusieurs emplois, répondez uniquement pour votre emploi principal.<br><br> En cas de covoiturage cochez « Voiture, camion ou fourgonnette »')\"",
@@ -11927,7 +11927,7 @@
 				{
 					"id": "l4r0qt6t",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.41",
 					"label": {
 						"value": "\"➡ 79. \" || \"[Occupez-vous votre emploi :](. 'Si vous exercez plusieurs emplois, répondez uniquement pour votre emploi principal.')\"",
@@ -11987,7 +11987,7 @@
 				{
 					"id": "l4r0vfv4",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.42",
 					"label": {
 						"value": "\"➡ 80. \" || \"[Etes-vous](. 'Si vous exercez plusieurs emplois, répondez uniquement pour votre emploi principal.')\"",
@@ -12066,7 +12066,7 @@
 				{
 					"id": "l4r0r5tt",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.43",
 					"label": {
 						"value": "\"➡ 81. \" || \"[Combien de salariés employez-vous ?](. 'Ne comptez que les salariés : ne comptez pas les personnes qui vous aident sans être rémunérées. <br><br> Si vous exercez plusieurs emplois, répondez uniquement pour votre emploi principal.')\"",
@@ -12124,7 +12124,7 @@
 				{
 					"id": "l4r10bz9",
 					"componentType": "Input",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.44",
 					"maxLength": 249,
 					"label": {
@@ -12212,7 +12212,7 @@
 				{
 					"id": "l4r16kh4",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.45",
 					"label": {
 						"value": "\"➡ 83. \" || \"Quel est votre [type de contrat ou d'emploi](. 'CES : contrat d’emploi solidarité<br><br> Si vous êtes en Contrat initiative emploi (CIE) ou en contrat d’accompagnement à l’emploi (CAE) cochez « Emploi jeune, CES, contrat de qualification ou autre emploi »<br><br> Si vous exercez plusieurs emplois, répondez uniquement pour votre emploi principal.') ?\"",
@@ -12316,7 +12316,7 @@
 				{
 					"id": "l4r2lvm2",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.46",
 					"label": {
 						"value": "\"➡ 84. \" || \"[Dans votre emploi, êtes-vous](. 'Si vous êtes instituteur, cochez « agent de catégorie B ».<br> Si vous êtes professeur des écoles, cochez « agent de catégorie A ».<br><br> VRP : Voyageur, Représentant, Placier<br><br>Si vous exercez plusieurs emplois, répondez uniquement pour votre emploi principal.')\"",
@@ -12444,7 +12444,7 @@
 				{
 					"id": "l4r2pald",
 					"componentType": "Input",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.47",
 					"maxLength": 249,
 					"label": {
@@ -12511,7 +12511,7 @@
 				{
 					"id": "l4r2ho48",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.48",
 					"label": {
 						"value": "\"➡ 86. \" || \"Dans votre emploi, quelle est votre [fonction principale](. 'Pour les emplois occasionnels ou de très courte durée,<br> précisez l’emploi saisonnier actuel.<br> Si vous exercez plusieurs emplois,<br> répondez uniquement pour votre emploi principal.') ?\"",
@@ -12638,7 +12638,7 @@
 				{
 					"id": "l4wve0rs",
 					"componentType": "CheckboxBoolean",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "37.49",
 					"label": {
 						"value": "\"➡ 87. \" || \"Le questionnaire de \" || (if (isnull(PRENOM)) then \"cet habitant\" else PRENOM) || \" \" || (if (isnull(NOM)) then \"\" else NOM) || \" est terminé. Pour valider le questionnaire, veuillez cocher la case puis cliquer sur le bouton \"Suivant\". \"",
@@ -12718,7 +12718,7 @@
 		{
 			"id": "COMMENT-QUESTION",
 			"componentType": "Textarea",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "22",
 			"maxLength": 2000,
 			"label": {

--- a/src/stories/questionnaires/rp/source.json
+++ b/src/stories/questionnaires/rp/source.json
@@ -30,7 +30,7 @@
 		{
 			"id": "com",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "1",
 			"maxLength": 60,
 			"label": {
@@ -46,7 +46,7 @@
 		{
 			"id": "code_dep",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "1",
 			"maxLength": 3,
 			"label": {
@@ -62,7 +62,7 @@
 		{
 			"id": "code_com",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "1",
 			"maxLength": 3,
 			"label": {
@@ -78,7 +78,7 @@
 		{
 			"id": "iris",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "1",
 			"maxLength": 3,
 			"label": {
@@ -94,7 +94,7 @@
 		{
 			"id": "rang-a",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "1",
 			"maxLength": 3,
 			"label": {
@@ -110,7 +110,7 @@
 		{
 			"id": "rang-l",
 			"componentType": "Input",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "1",
 			"maxLength": 3,
 			"label": {
@@ -134,7 +134,7 @@
 		{
 			"id": "log-indic-coll",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "2",
 			"label": {
 				"value": "\"Votre batiment d'habitation ne comprend qu'un seul logement ?\"",
@@ -152,7 +152,7 @@
 		{
 			"id": "log-isole-coll",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "2",
 			"label": {
 				"value": "\"Votre logement possède au moins un mur mitoyen avec un autre batiment ?\"",

--- a/src/stories/questionnaires/simpsons/source.json
+++ b/src/stories/questionnaires/simpsons/source.json
@@ -978,7 +978,7 @@
 					"conditionFilter": { "type": "VTL", "value": "true" },
 					"id": "j6p3dkx6",
 					"page": "2",
-					"mandatory": true,
+					"isMandatory": true,
 					"maxLength": 500
 				}
 			],
@@ -1008,7 +1008,7 @@
 					"conditionFilter": { "type": "VTL", "value": "true" },
 					"id": "j6p0np9q",
 					"page": "3",
-					"mandatory": false
+					"isMandatory": false
 				}
 			],
 			"id": "question-j6p0np9q",
@@ -1081,7 +1081,7 @@
 					"conditionFilter": { "type": "VTL", "value": "true" },
 					"id": "j3343qhx",
 					"page": "4",
-					"mandatory": false,
+					"isMandatory": false,
 					"maxLength": 30
 				}
 			],
@@ -1163,7 +1163,7 @@
 					"conditionFilter": { "type": "VTL", "value": "true" },
 					"id": "j6q9h8tj",
 					"page": "5",
-					"mandatory": true
+					"isMandatory": true
 				}
 			],
 			"id": "question-j6q9h8tj",
@@ -1218,7 +1218,7 @@
 					"conditionFilter": { "type": "VTL", "value": "true" },
 					"id": "kiq71eoi",
 					"page": "6",
-					"mandatory": false
+					"isMandatory": false
 				}
 			],
 			"id": "question-kiq71eoi",
@@ -1283,7 +1283,7 @@
 					"conditionFilter": { "type": "VTL", "value": "true" },
 					"id": "k5nvty2o",
 					"page": "7",
-					"mandatory": false
+					"isMandatory": false
 				}
 			],
 			"id": "question-k5nvty2o",
@@ -1349,7 +1349,7 @@
 					"conditionFilter": { "type": "VTL", "value": "true" },
 					"id": "k5nw1fir",
 					"page": "8",
-					"mandatory": false
+					"isMandatory": false
 				}
 			],
 			"id": "question-k5nw1fir",
@@ -1429,7 +1429,7 @@
 					"conditionFilter": { "type": "VTL", "value": "true" },
 					"id": "k5nw0w05",
 					"page": "9",
-					"mandatory": false
+					"isMandatory": false
 				}
 			],
 			"id": "question-k5nw0w05",
@@ -1498,7 +1498,7 @@
 					"conditionFilter": { "type": "VTL", "value": "true" },
 					"id": "k5nvu98z",
 					"page": "10",
-					"mandatory": false
+					"isMandatory": false
 				}
 			],
 			"id": "question-k5nvu98z",
@@ -1567,7 +1567,7 @@
 					"conditionFilter": { "type": "VTL", "value": "true" },
 					"id": "k5nw8ei1",
 					"page": "11",
-					"mandatory": false
+					"isMandatory": false
 				}
 			],
 			"id": "question-k5nw8ei1",
@@ -1636,7 +1636,7 @@
 					"conditionFilter": { "type": "VTL", "value": "true" },
 					"id": "k5nw9dk4",
 					"page": "12",
-					"mandatory": false
+					"isMandatory": false
 				}
 			],
 			"id": "question-k5nw9dk4",
@@ -1674,7 +1674,7 @@
 					"conditionFilter": { "type": "VTL", "value": "true" },
 					"id": "k5nw6hr0",
 					"page": "13",
-					"mandatory": true
+					"isMandatory": true
 				}
 			],
 			"id": "question-k5nw6hr0",
@@ -1712,7 +1712,7 @@
 					"conditionFilter": { "type": "VTL", "value": "true" },
 					"id": "k5nweurr",
 					"page": "14",
-					"mandatory": false
+					"isMandatory": false
 				}
 			],
 			"id": "question-k5nweurr",
@@ -1750,7 +1750,7 @@
 					"conditionFilter": { "type": "VTL", "value": "true" },
 					"id": "kiq51oqq",
 					"page": "15",
-					"mandatory": false
+					"isMandatory": false
 				}
 			],
 			"id": "question-kiq51oqq",
@@ -1819,7 +1819,7 @@
 					"conditionFilter": { "type": "VTL", "value": "true" },
 					"id": "j6z06z1e",
 					"page": "16",
-					"mandatory": false
+					"isMandatory": false
 				}
 			],
 			"id": "question-j6z06z1e",
@@ -1890,7 +1890,7 @@
 					"conditionFilter": { "type": "VTL", "value": "true" },
 					"id": "j3343clt",
 					"page": "18",
-					"mandatory": true
+					"isMandatory": true
 				}
 			],
 			"id": "question-j3343clt",
@@ -1945,7 +1945,7 @@
 					"conditionFilter": { "type": "VTL", "value": "true" },
 					"id": "j6qdfhvw",
 					"page": "19",
-					"mandatory": false
+					"isMandatory": false
 				}
 			],
 			"id": "question-j6qdfhvw",
@@ -2042,7 +2042,7 @@
 					"conditionFilter": { "type": "VTL", "value": "true" },
 					"id": "j4nw5cqz",
 					"page": "20",
-					"mandatory": false
+					"isMandatory": false
 				}
 			],
 			"id": "question-j4nw5cqz",
@@ -2233,7 +2233,7 @@
 							}
 						]
 					],
-					"mandatory": false
+					"isMandatory": false
 				}
 			],
 			"id": "question-j6p29i81",
@@ -2361,7 +2361,7 @@
 							}
 						]
 					],
-					"mandatory": false
+					"isMandatory": false
 				}
 			],
 			"id": "question-j6qefnga",
@@ -2559,7 +2559,7 @@
 							}
 						]
 					],
-					"mandatory": false
+					"isMandatory": false
 				}
 			],
 			"id": "question-j6yzoc6g",
@@ -2999,7 +2999,7 @@
 							}
 						]
 					],
-					"mandatory": false
+					"isMandatory": false
 				}
 			],
 			"id": "question-j4nwc63q",
@@ -3270,7 +3270,7 @@
 							}
 						]
 					],
-					"mandatory": false
+					"isMandatory": false
 				}
 			],
 			"id": "question-k9cg2q5t",
@@ -3496,7 +3496,7 @@
 							}
 						]
 					],
-					"mandatory": false
+					"isMandatory": false
 				}
 			],
 			"id": "question-kbkjvgel",
@@ -3711,7 +3711,7 @@
 							}
 						]
 					],
-					"mandatory": false
+					"isMandatory": false
 				}
 			],
 			"id": "question-j6p2lwuj",
@@ -3785,7 +3785,7 @@
 						"min": { "type": "VTL", "value": "1" },
 						"max": { "type": "VTL", "value": "5" }
 					},
-					"mandatory": false
+					"isMandatory": false
 				}
 			],
 			"id": "question-kvkvfojo",
@@ -3915,7 +3915,7 @@
 							}
 						]
 					],
-					"mandatory": false
+					"isMandatory": false
 				}
 			],
 			"id": "question-jvxux0mi",
@@ -4230,7 +4230,7 @@
 							}
 						]
 					],
-					"mandatory": false
+					"isMandatory": false
 				}
 			],
 			"id": "question-jvxwy68n",
@@ -4310,7 +4310,7 @@
 					"conditionFilter": { "type": "VTL", "value": "true" },
 					"id": "kiq612ky",
 					"page": "36",
-					"mandatory": false
+					"isMandatory": false
 				}
 			],
 			"id": "question-kiq612ky",
@@ -4381,7 +4381,7 @@
 							"conditionFilter": { "type": "VTL", "value": "true" },
 							"id": "kiq66gtw",
 							"page": "37",
-							"mandatory": false,
+							"isMandatory": false,
 							"maxLength": 30
 						}
 					],
@@ -4450,7 +4450,7 @@
 							"conditionFilter": { "type": "VTL", "value": "true" },
 							"id": "kiq5r8wu",
 							"page": "37",
-							"mandatory": false
+							"isMandatory": false
 						}
 					],
 					"id": "question-kiq5r8wu",
@@ -4535,7 +4535,7 @@
 							"conditionFilter": { "type": "VTL", "value": "true" },
 							"id": "kiq65x3c",
 							"page": "38.2",
-							"mandatory": false
+							"isMandatory": false
 						}
 					],
 					"id": "question-kiq65x3c",
@@ -4564,7 +4564,7 @@
 							"conditionFilter": { "type": "VTL", "value": "true" },
 							"id": "kiq651zv",
 							"page": "38.3",
-							"mandatory": false,
+							"isMandatory": false,
 							"maxLength": 255
 						}
 					],
@@ -4626,7 +4626,7 @@
 					"conditionFilter": { "type": "VTL", "value": "true" },
 					"id": "j6z0z3us",
 					"page": "40",
-					"mandatory": false,
+					"isMandatory": false,
 					"maxLength": 255
 				}
 			],

--- a/src/stories/radio/source.json
+++ b/src/stories/radio/source.json
@@ -3,7 +3,7 @@
 		{
 			"id": "radio",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "3",
 			"label": {
 				"value": "\"Label for a Radio component\"",

--- a/src/stories/radio/sourceDetail.json
+++ b/src/stories/radio/sourceDetail.json
@@ -5,7 +5,7 @@
 		{
 			"id": "radio",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "1",
 			"label": {
 				"value": "\"Label for a Radio component\"",

--- a/src/stories/radio/sourceHorizontal.json
+++ b/src/stories/radio/sourceHorizontal.json
@@ -5,7 +5,7 @@
 		{
 			"id": "radio",
 			"componentType": "Radio",
-			"mandatory": false,
+			"isMandatory": false,
 			"orientation": "horizontal",
 			"page": "1",
 			"label": {

--- a/src/stories/roundabout/source.json
+++ b/src/stories/roundabout/source.json
@@ -4,7 +4,7 @@
 		{
 			"id": "how",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "1",
 			"min": 1,
 			"max": 10,
@@ -32,7 +32,7 @@
 				{
 					"id": "prenom",
 					"componentType": "Input",
-					"mandatory": false,
+					"isMandatory": false,
 					"maxLength": 20,
 					"label": {
 						"value": "\"Prénom\"))",
@@ -92,7 +92,7 @@
 				{
 					"id": "radio",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "3.1",
 					"label": {
 						"value": "\"Connaissez-vous le recensement de la population ?\"",

--- a/src/stories/suggester/source-arbitrary-response.json
+++ b/src/stories/suggester/source-arbitrary-response.json
@@ -72,7 +72,7 @@
 					"type": "VTL"
 				}
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 249
 		},
 		{
@@ -90,7 +90,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 2. Vous aimez \" || PRODUCT_NAME || \" à \" || cast(PRODUCT_PRICE, string) || \"€ mais quel est votre prénom ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 249
 		}
 	],

--- a/src/stories/suggester/source-error.json
+++ b/src/stories/suggester/source-error.json
@@ -49,7 +49,7 @@
 					"type": "VTL"
 				}
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 249
 		},
 		{
@@ -67,7 +67,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 2. Vous aimez \" || PRODUCT_NAME || \" à \" || cast(PRODUCT_PRICE, string) || \"€ mais quel est votre prénom ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 249
 		}
 	],

--- a/src/stories/suggester/source-multiline.json
+++ b/src/stories/suggester/source-multiline.json
@@ -173,7 +173,7 @@
 							"typeOfControl": "FORMAT"
 						}
 					],
-					"mandatory": false,
+					"isMandatory": false,
 					"components": [
 						{
 							"id": "lsvppebo-RDOP-lyphsg13",
@@ -240,7 +240,7 @@
 					"response": {
 						"name": "QUELESTLEP"
 					},
-					"mandatory": false,
+					"isMandatory": false,
 					"storeName": "L_DECHETS",
 					"componentType": "Suggester"
 				}

--- a/src/stories/suggester/source-option-responses.json
+++ b/src/stories/suggester/source-option-responses.json
@@ -61,7 +61,7 @@
 					}
 				}
 			],
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 249
 		},
 		{
@@ -79,7 +79,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 2. Vous aimez \" || PRODUCT_NAME || \" à \" || cast(PRODUCT_PRICE, string) || \"€ mais quel est votre prénom ?\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 249
 		}
 	],

--- a/src/stories/suggester/source.json
+++ b/src/stories/suggester/source.json
@@ -204,7 +204,7 @@
 				"type": "VTL",
 				"value": "\"id || \" - \" || label\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 249
 		},
 		{
@@ -223,7 +223,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 2. \" || \"Variable Pays\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 249
 		},
 		{
@@ -242,7 +242,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 3. \" || \"Variable Nationalité\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 249
 		},
 		{
@@ -262,7 +262,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 4. \" || \"VARIABLE_PCS\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 249
 		},
 		{
@@ -281,7 +281,7 @@
 				"type": "VTL|MD",
 				"value": "\"➡ 5. \" || \"VARIABLE_BAILLEURS_SOCIAUX\""
 			},
-			"mandatory": false,
+			"isMandatory": false,
 			"maxLength": 249
 		}
 	],

--- a/src/stories/summary/source.json
+++ b/src/stories/summary/source.json
@@ -15,7 +15,7 @@
 		{
 			"id": "how",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "2",
 			"min": 1,
 			"max": 10,
@@ -30,7 +30,7 @@
 		{
 			"id": "hoew",
 			"componentType": "InputNumber",
-			"mandatory": false,
+			"isMandatory": false,
 			"page": "2",
 			"min": 42,
 			"max": 42,
@@ -58,7 +58,7 @@
 				{
 					"id": "prenom",
 					"componentType": "Input",
-					"mandatory": false,
+					"isMandatory": false,
 					"maxLength": 20,
 					"label": {
 						"value": "\"Prénom\"))",
@@ -133,7 +133,7 @@
 				{
 					"id": "radio",
 					"componentType": "Radio",
-					"mandatory": false,
+					"isMandatory": false,
 					"page": "4.1",
 					"label": {
 						"value": "\"Connaissez-vous le recensement de la population ?\"",

--- a/src/stories/switch/data-forced.json
+++ b/src/stories/switch/data-forced.json
@@ -3,7 +3,7 @@
 		{
 			"id": "1",
 			"componentType": "Switch",
-			"mandatory": false,
+			"isMandatory": false,
 			"label": "➡ 1. Are you ready?",
 			"response": {
 				"name": "READY"
@@ -12,7 +12,7 @@
 		{
 			"id": "2",
 			"componentType": "Switch",
-			"mandatory": false,
+			"isMandatory": false,
 			"label": "➡ 2. Are you always ready?",
 			"response": {
 				"name": "READY2"

--- a/src/stories/switch/source.json
+++ b/src/stories/switch/source.json
@@ -3,7 +3,7 @@
 		{
 			"id": "1",
 			"componentType": "Switch",
-			"mandatory": false,
+			"isMandatory": false,
 			"label": { "value": "\"➡ 1. Are you ready?\"", "type": "VTL|MD" },
 			"statusLabel": { "true": "Yes", "false": "No" },
 			"response": {
@@ -16,7 +16,7 @@
 		{
 			"id": "2",
 			"componentType": "Switch",
-			"mandatory": false,
+			"isMandatory": false,
 			"label": { "value": "\"➡ 2. Are you always ready?\"", "type": "VTL|MD" },
 			"response": {
 				"name": "READY2"

--- a/src/stories/table/source-colspan.json
+++ b/src/stories/table/source-colspan.json
@@ -5,7 +5,7 @@
 			"page": "1",
 			"id": "j4nwc63q",
 			"componentType": "Table",
-			"mandatory": false,
+			"isMandatory": false,
 			"label": {
 				"value": "\"➡ \" || \"Please, specify the percentage of Jay’s expenses in the Kwik-E-Mart for each product?\"",
 				"type": "VTL|MD"

--- a/src/stories/table/source.json
+++ b/src/stories/table/source.json
@@ -6,7 +6,7 @@
 			"page": "1",
 			"id": "j6p29i81",
 			"componentType": "Table",
-			"mandatory": false,
+			"isMandatory": false,
 			"header": [
 				{ "label": { "value": "\"<=>\"", "type": "VTL|MD" } },
 				{ "label": { "value": "\"Header 1\"", "type": "VTL|MD" } },

--- a/src/stories/table/table-dynamique.json
+++ b/src/stories/table/table-dynamique.json
@@ -46,7 +46,7 @@
 				"min": { "type": "VTL", "value": "1" },
 				"max": { "type": "VTL", "value": "4" }
 			},
-			"mandatory": false
+			"isMandatory": false
 		}
 	],
 	"pagination": "question",

--- a/src/stories/text/source-roster.json
+++ b/src/stories/text/source-roster.json
@@ -164,7 +164,7 @@
 					"value": "5"
 				}
 			},
-			"mandatory": false
+			"isMandatory": false
 		}
 	],
 	"pagination": "question",

--- a/src/stories/text/source-table.json
+++ b/src/stories/text/source-table.json
@@ -250,7 +250,7 @@
 					}
 				]
 			],
-			"mandatory": false
+			"isMandatory": false
 		}
 	],
 	"maxPage": "1"

--- a/src/type.source.ts
+++ b/src/type.source.ts
@@ -338,7 +338,7 @@ export type ComponentDefinitionBase = {
 	conditionFilter?: VTLScalarExpression;
 	controls?: ControlDefinition[];
 	id: string;
-	mandatory?: boolean;
+	isMandatory?: boolean;
 	missingResponse?: ResponseDefinition;
 };
 export type Declaration = {

--- a/src/use-lunatic/commons/fill-components/fill-component.spec.ts
+++ b/src/use-lunatic/commons/fill-components/fill-component.spec.ts
@@ -38,7 +38,7 @@ describe('fillComponents', () => {
 					type: 'VTL|MD',
 					value: '"Input label"',
 				},
-				mandatory: true,
+				isMandatory: true,
 				maxLength: 15,
 			},
 		];

--- a/src/use-lunatic/commons/fill-components/fill-components.ts
+++ b/src/use-lunatic/commons/fill-components/fill-components.ts
@@ -49,7 +49,7 @@ export const fillComponent = (
 		goNextPage: state.goNextPage,
 		goPreviousPage: state.goPreviousPage,
 		iteration: state.pager.iteration,
-		required: 'mandatory' in component ? component.mandatory : false,
+		required: 'isMandatory' in component ? component.isMandatory : false,
 		value: value,
 		missingResponse: getMissingResponseProp(component, state),
 		management: state.management,


### PR DESCRIPTION
- rename `mandatory` to `isMandatory` in model => ⚠️  we assume it's a breaking change for old questionnaires having "mandatory" prop (that will not be read anymore)
- improve accessibility for required inputs
- add some tests for required components