### PR TITLE
fix: do not filter options if disableFilters

### DIFF
--- a/src/use-lunatic/commons/fill-components/fill-components.ts
+++ b/src/use-lunatic/commons/fill-components/fill-components.ts
@@ -60,7 +60,8 @@ export const fillComponent = (
 			state.handleChanges,
 			state.pager.iteration,
 			value,
-			state.logger
+			state.logger,
+			state.disableFilters
 		),
 		...getComponentTypeProps(interpretedProps, state),
 		// This is too dynamic to be typed correctly, so we allow any here

--- a/src/use-lunatic/props/propOptions.spec.ts
+++ b/src/use-lunatic/props/propOptions.spec.ts
@@ -25,6 +25,23 @@ describe('getOptionsProp()', () => {
 			},
 		],
 	} satisfies DeepTranslateExpression<LunaticComponentDefinition>;
+
+	const radioDefinition = {
+		id: 'RadioGroup',
+		componentType: 'Radio',
+		response: { name: 'RADIO' },
+		options: [
+			{
+				label: 'Option 1',
+				value: 'id1',
+			},
+			{
+				label: 'Option 2',
+				value: 'id2',
+			},
+		],
+	} satisfies DeepTranslateExpression<LunaticComponentDefinition>;
+
 	let mockChange: LunaticChangesHandler;
 	const mockLogger = vi.fn();
 
@@ -100,6 +117,68 @@ describe('getOptionsProp()', () => {
 				{ name: 'O2', value: false },
 			]);
 		});
+		it('should filter responses (CheckboxGroup) with conditionFilter evaluated to false', () => {
+			const definition = {
+				...checkboxGroupDefinition,
+				responses: [
+					{
+						label: 'Option 1',
+						response: { name: 'O1' },
+						id: 'id1',
+						conditionFilter: { type: 'VTL', value: 'false' },
+					},
+					{
+						label: 'Option 2',
+						response: { name: 'O2' },
+						id: 'id2',
+						conditionFilter: { type: 'VTL', value: 'true' },
+					},
+				],
+			} satisfies DeepTranslateExpression<LunaticComponentDefinition>;
+
+			const options = getOptionsProp(
+				definition,
+				variables,
+				mockChange,
+				undefined,
+				undefined,
+				mockLogger
+			);
+
+			// First option should be filtered out since its conditionFilter is evaluated to false
+			expect(options).toHaveLength(1);
+			expect(options[0].label).toBe('Option 2');
+		});
+		it('should filter options (Radio) with conditionFilter evaluated to false', () => {
+			const definition = {
+				...radioDefinition,
+				options: [
+					{
+						label: 'Option 1',
+						value: 'id1',
+						conditionFilter: { type: 'VTL', value: 'false' },
+					},
+					{
+						label: 'Option 2',
+						value: 'id2',
+						conditionFilter: { type: 'VTL', value: 'true' },
+					},
+				],
+			} as any as DeepTranslateExpression<LunaticComponentDefinition>;
+
+			const options = getOptionsProp(
+				definition,
+				variables,
+				mockChange,
+				undefined,
+				undefined,
+				mockLogger
+			);
+
+			// First option should be filtered out since its conditionFilter is evaluated to false
+			expect(options).toHaveLength(1);
+			expect(options[0].label).toBe('Option 2');
+		});
 		it('should not filter response (checkboxGroup) when its conditionFilter evaluation fails', () => {
 			const definition = {
 				...checkboxGroupDefinition,
@@ -132,8 +211,7 @@ describe('getOptionsProp()', () => {
 		});
 		it('should not filter option (radio) when its conditionFilter evaluation fails', () => {
 			const definition = {
-				id: 'RadioGroup',
-				componentType: 'Radio',
+				...radioDefinition,
 				options: [
 					{
 						label: 'Option 1',
@@ -192,9 +270,8 @@ describe('getOptionsProp()', () => {
 			expect(options).toHaveLength(1);
 		});
 		it('should not filter any option (Radio) when disableFilters is true', () => {
-			const radioDefinition = {
-				id: 'RadioGroup',
-				componentType: 'Radio',
+			const definition = {
+				...radioDefinition,
 				options: [
 					{
 						label: 'Option 1',
@@ -210,7 +287,7 @@ describe('getOptionsProp()', () => {
 			});
 
 			const options = getOptionsProp(
-				radioDefinition,
+				definition,
 				variables,
 				mockChange,
 				undefined,

--- a/src/use-lunatic/props/propOptions.spec.ts
+++ b/src/use-lunatic/props/propOptions.spec.ts
@@ -160,5 +160,66 @@ describe('getOptionsProp()', () => {
 			// Ensure the option is not filtered
 			expect(options).toHaveLength(1);
 		});
+		it('should not filter any response (CheckboxGroup) when disableFilters is true', () => {
+			const definition = {
+				...checkboxGroupDefinition,
+				responses: [
+					{
+						label: 'Option 1',
+						response: { name: 'O1' },
+						id: 'id1',
+						conditionFilter: { type: 'VTL', value: 'expression' },
+					},
+				],
+			} satisfies DeepTranslateExpression<LunaticComponentDefinition>;
+
+			// ensure interpreted expression is false
+			vi.spyOn(variables, 'run').mockImplementation(() => {
+				return false;
+			});
+
+			const options = getOptionsProp(
+				definition,
+				variables,
+				mockChange,
+				undefined,
+				undefined,
+				mockLogger,
+				true // disableFilters = true
+			);
+
+			// Ensure the option is not filtered
+			expect(options).toHaveLength(1);
+		});
+		it('should not filter any option (Radio) when disableFilters is true', () => {
+			const radioDefinition = {
+				id: 'RadioGroup',
+				componentType: 'Radio',
+				options: [
+					{
+						label: 'Option 1',
+						value: 'id1',
+						conditionFilter: { type: 'VTL', value: 'expression' },
+					},
+				],
+			} as any as DeepTranslateExpression<LunaticComponentDefinition>;
+
+			// ensure interpreted expression is false
+			vi.spyOn(variables, 'run').mockImplementation(() => {
+				return false;
+			});
+
+			const options = getOptionsProp(
+				radioDefinition,
+				variables,
+				mockChange,
+				undefined,
+				undefined,
+				mockLogger,
+				true // disableFilters = true
+			);
+
+			expect(options).toHaveLength(1);
+		});
 	});
 });

--- a/src/use-lunatic/props/propOptions.ts
+++ b/src/use-lunatic/props/propOptions.ts
@@ -31,7 +31,8 @@ export function getOptionsProp(
 	handleChanges: LunaticChangesHandler,
 	pagerIteration: LunaticState['pager']['iteration'],
 	value: unknown,
-	logger: LunaticLogger
+	logger: LunaticLogger,
+	disableFilters?: boolean
 ) {
 	const iteration = isNumber(pagerIteration) ? [pagerIteration] : undefined;
 	//const iteration = pagerIteration ? [pagerIteration] : undefined;
@@ -39,7 +40,7 @@ export function getOptionsProp(
 	if (definition.componentType === 'CheckboxGroup') {
 		return definition.responses
 			.filter((response) => {
-				if (!response.conditionFilter) {
+				if (disableFilters || !response.conditionFilter) {
 					return true;
 				}
 				try {
@@ -82,7 +83,11 @@ export function getOptionsProp(
 
 	return definition.options
 		.filter((option) => {
-			if (!('conditionFilter' in option) || !option.conditionFilter) {
+			if (
+				disableFilters ||
+				!('conditionFilter' in option) ||
+				!option.conditionFilter
+			) {
 				return true;
 			}
 			try {


### PR DESCRIPTION
In radio/checkbox, we can filter options.
Since in useLunatic we can provide `disableFilters` param for disabling filters, we want it to apply on options so that they are not filtered if disableFilters=true