### PR TITLE
fix: allow correctly number values depending on min & max

### DIFF
--- a/src/components/InputNumber/InputNumberThousand.tsx
+++ b/src/components/InputNumber/InputNumberThousand.tsx
@@ -6,7 +6,6 @@ import {
 	type OnValueChange,
 } from 'react-number-format';
 import { inputNumberPropsI18N } from '../../i18n';
-import { isNumberInInterval } from '../../utils/number';
 
 type Props = {
 	id?: string;
@@ -31,8 +30,8 @@ export const InputNumberThousand = ({
 	readOnly,
 	required,
 	labelId,
-	min,
-	max,
+	min = -Infinity,
+	max = Infinity,
 	decimals,
 	invalid,
 	unit,
@@ -50,8 +49,12 @@ export const InputNumberThousand = ({
 			const { floatValue } = values;
 			// we accept empty value
 			if (floatValue === undefined) return true;
-			// check if value is in within the min-max range
-			return isNumberInInterval(floatValue, min, max);
+			// if both min & max are negative, accept only negative above min
+			if (min < 0 && max < 0) return floatValue >= min && floatValue < 0;
+			// if both min & max are positive, accept only positive below max
+			if (min > 0 && max > 0) return floatValue <= max && floatValue > 0;
+			// if min & max have different sign or equal to 0, check if value is within the min-max range
+			return floatValue >= min && floatValue <= max;
 		},
 		[min, max]
 	);
@@ -76,7 +79,7 @@ export const InputNumberThousand = ({
 			required={required}
 			lang="en"
 			isAllowed={isAllowed}
-			allowNegative={min === undefined || min < 0}
+			allowNegative={min < 0}
 			allowedDecimalSeparators={inputNumberPropsI18N.allDecimalSeparators}
 			decimalSeparator={inputNumberPropsI18N.decimalSeparator}
 			decimalScale={decimals}

--- a/src/utils/number.spec.ts
+++ b/src/utils/number.spec.ts
@@ -1,54 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { between, isNumberInInterval } from './number';
+import { between } from './number';
 
 describe('between', () => {
 	it('should work', () => {
 		expect(between(0, -5, 100)).toBe(0);
 		expect(between(1000, -5, 100)).toBe(100);
 		expect(between(-23.22, -5, 100)).toBe(-5);
-	});
-});
-
-describe('isNumberInInterval', () => {
-	it('allows value within range', () => {
-		expect(isNumberInInterval(25, 10, 50)).toBe(true);
-	});
-	it('disallows value above max', () => {
-		expect(isNumberInInterval(55, 10, 50)).toBe(false);
-	});
-	it('disallows value below min', () => {
-		expect(isNumberInInterval(5, 10, 50)).toBe(false);
-	});
-	it('allows negative within bounds', () => {
-		expect(isNumberInInterval(-4, -5, 0)).toBe(true);
-	});
-	it('disallows negative if min is 0 or positive', () => {
-		expect(isNumberInInterval(-1, 0, 10)).toBe(false);
-		expect(isNumberInInterval(-1, 5, 10)).toBe(false);
-	});
-	it('allows only value above min when max is undefined', () => {
-		expect(isNumberInInterval(999, 100)).toBe(true);
-		expect(isNumberInInterval(50, 100)).toBe(false);
-	});
-	it('allows only value below max when min is undefined', () => {
-		expect(isNumberInInterval(50, undefined, 100)).toBe(true);
-		// accepts negative values
-		expect(isNumberInInterval(-50, undefined, 100)).toBe(true);
-		expect(isNumberInInterval(150, undefined, 100)).toBe(false);
-	});
-	it('allows decimal value within range', () => {
-		expect(isNumberInInterval(9.99, 0, 10)).toBe(true);
-	});
-	it('disallows decimal value above max', () => {
-		expect(isNumberInInterval(10.01, 0, 10)).toBe(false);
-	});
-	it('disallows decimal value below min', () => {
-		expect(isNumberInInterval(-5.01, -5, 5)).toBe(false);
-	});
-	it('allows decimal value equal to max', () => {
-		expect(isNumberInInterval(10.0, 0, 10)).toBe(true);
-	});
-	it('allows decimal value equal to min', () => {
-		expect(isNumberInInterval(-5.0, -5, 5)).toBe(true);
 	});
 });

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -31,21 +31,3 @@ export function between(n: number, min: number, max: number): number {
 export function isNumber(n: unknown): n is number {
 	return typeof n === 'number' && Number.isFinite(n);
 }
-
-/** Check if a value is within an interval.
- * Both minimum and maximum can be undefined, then we just compare with the defined bounds.
- */
-export function isNumberInInterval(
-	value: number,
-	min?: number,
-	max?: number
-): boolean {
-	if (
-		(min !== undefined && value < min) ||
-		(max !== undefined && value > max)
-	) {
-		return false;
-	}
-
-	return true;
-}


### PR DESCRIPTION
On an InputNumber with min & max, we only allowed values between min & max.
So for most cases the first character was not allowed because not within interval, so the user was blocked