### PR TITLE
feat: add an option in handleChanges to stop array casting

### DIFF
--- a/src/use-lunatic/actions.ts
+++ b/src/use-lunatic/actions.ts
@@ -14,6 +14,8 @@ export type ActionHandleChanges = {
 			name: string;
 			value: unknown;
 			iteration?: number[];
+			/** Force a vector when an iteration is set and the value was a scalar **/
+			ignoreIterationOnScalar?: boolean;
 			[extra: string]: unknown;
 		}[];
 	};

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
@@ -124,6 +124,18 @@ describe('lunatic-variables-store', () => {
 		expect(variables.get('FIRSTNAME')).toEqual('Jane');
 	});
 
+	it('should ignore iteration when updating a scalar value', () => {
+		variables.set('FIRSTNAME', 'John'); // Start with a scalar value
+		expect(variables.get('FIRSTNAME')).toEqual('John');
+		variables.set('FIRSTNAME', 'Jane', {
+			iteration: [1],
+			ignoreIterationOnScalar: true,
+		});
+		expect(variables.get('FIRSTNAME')).toEqual('Jane');
+		variables.set('FIRSTNAME', 'Marc', { iteration: [1] });
+		expect(variables.get('FIRSTNAME')).toEqual([null, 'Marc']);
+	});
+
 	describe('event listener', () => {
 		it('should trigger onChange', () => {
 			variables.set('FIRSTNAME', 'John');

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.ts
@@ -35,6 +35,8 @@ export type EventArgs = {
 		iteration?: IterationLevel | undefined;
 		/** What triggered this change. */
 		cause?: 'resizing' | 'cleaning';
+		/** Force a vector when an iteration is set and the value was a scalar **/
+		ignoreIterationOnScalar?: boolean;
 		/** Extra sent when setting the variable. */
 		[extra: string]: unknown;
 	};
@@ -168,7 +170,10 @@ export class LunaticVariablesStore {
 	public set(
 		name: string,
 		value: unknown,
-		args: Pick<EventArgs['change'], 'iteration' | 'cause'> = {}
+		args: Pick<
+			EventArgs['change'],
+			'iteration' | 'cause' | 'ignoreIterationOnScalar'
+		> = {}
 	): LunaticVariable {
 		if (!this.dictionary.has(name)) {
 			this.dictionary.set(
@@ -188,7 +193,7 @@ export class LunaticVariablesStore {
 			);
 		}
 		const variable = this.dictionary.get(name)!;
-		if (variable.setValue(value, args.iteration)) {
+		if (variable.setValue(value, args)) {
 			this.eventTarget.dispatchEvent(
 				new CustomEvent('change', {
 					detail: {
@@ -390,7 +395,9 @@ class LunaticVariable {
 		// this.calculatedCount++;
 		// Remember the value
 		try {
-			this.setValue(interpretVTL(this.expression, bindings), iteration);
+			this.setValue(interpretVTL(this.expression, bindings), {
+				iteration: iteration,
+			});
 		} catch {
 			throw new VTLInterpretationError(this.expression!, bindings);
 		}
@@ -401,7 +408,11 @@ class LunaticVariable {
 	/**
 	 * Set the value and returns true if the variable is touched
 	 */
-	setValue(value: unknown, iteration?: IterationLevel): boolean {
+	setValue(
+		value: unknown,
+		opts: { iteration?: IterationLevel; ignoreIterationOnScalar?: boolean }
+	): boolean {
+		const { iteration, ignoreIterationOnScalar } = opts;
 		if (value === this.getSavedValue(iteration)) {
 			return false;
 		}
@@ -411,6 +422,10 @@ class LunaticVariable {
 		}
 		// We want to save a value at a specific iteration, but the value is not an array yet
 		if (iteration !== undefined && !Array.isArray(this.value)) {
+			// Ignore the iteration since the value is not an array
+			if (ignoreIterationOnScalar) {
+				return this.setValue(value, {});
+			}
 			this.value = [];
 		}
 		this.value = !Array.isArray(iteration)
@@ -445,7 +460,7 @@ class LunaticVariable {
 		// Update every item of the array and look if we changed one item
 		const oneValueChanged =
 			times(Math.max(oldSize, newSize), (k) =>
-				this.setValue(value[k], [k])
+				this.setValue(value[k], { iteration: [k] })
 			).find((v) => v) !== undefined;
 		// New array is smaller, shorten the array
 		if (oldSize > newSize && Array.isArray(this.value)) {

--- a/src/use-lunatic/reducer/reducer.ts
+++ b/src/use-lunatic/reducer/reducer.ts
@@ -5,7 +5,7 @@ import { reduceHandleChanges } from './reduce-handle-changes';
 import { reduceGoPreviousPage } from './reduce-go-previous-page';
 import { reduceGoToPage } from './reduce-go-to-page';
 
-// Action that trigger a change in the store
+// Actions that trigger a change in the store
 const commitActions: ActionKind[] = [
 	ActionKind.GO_PREVIOUS_PAGE,
 	ActionKind.GO_NEXT_PAGE,

--- a/src/use-lunatic/type.ts
+++ b/src/use-lunatic/type.ts
@@ -366,5 +366,6 @@ export type LunaticChangesHandler = (
 		name: string;
 		value: any;
 		iteration?: number[];
+		ignoreIterationOnScalar?: boolean;
 	}[]
 ) => void;

--- a/src/use-lunatic/use-lunatic.test.ts
+++ b/src/use-lunatic/use-lunatic.test.ts
@@ -59,6 +59,45 @@ describe('use-lunatic()', () => {
 		expect(components[0].id).toBe('kiq5xw5p');
 	});
 
+	describe('handleChange()', () => {
+		it('should change variable value', () => {
+			const { result } = renderHook(() => useLunatic(...defaultParams));
+			act(() => {
+				result.current.handleChanges([
+					{
+						name: 'COMMENT',
+						value: 'Mon commentaire',
+					},
+				]);
+			});
+			act(() => {
+				expect(
+					result.current.getData(false, ['COMMENT']).COLLECTED!.COMMENT
+						.COLLECTED
+				).toBe('Mon commentaire');
+			});
+		});
+		it('should ignore iteration for scalar value', () => {
+			const { result } = renderHook(() => useLunatic(...defaultParams));
+			act(() => {
+				result.current.handleChanges([
+					{
+						name: 'COMMENT',
+						value: 'Mon commentaire 2',
+						iteration: [1],
+						ignoreIterationOnScalar: true,
+					},
+				]);
+			});
+			act(() => {
+				expect(
+					result.current.getData(false, ['COMMENT']).COLLECTED!.COMMENT
+						.COLLECTED
+				).toBe('Mon commentaire 2');
+			});
+		});
+	});
+
 	describe('Provider', () => {
 		it('should not generate a new Provider every render', () => {
 			const { result } = renderHook(() => {


### PR DESCRIPTION
Ajout d'une nouvelle option dans le `handleChanges()` pour éviter de transformer une variable scalaire en tableau si une itération est passée.

## Exemple

En considérent que la variable `PRENOM` vaut `"John"`

```js
handleChanges([{name:'PRENOM',value: 'Jane', iteration: [1]}])
```

Transforme PRENOM en `[null, 'Jane']` 
Cette option permet de ne pas changer le type de la variable si elle n'est pas un tableau. Si on reprend la valeur initiale :

```js
handleChanges([{name:'PRENOM',value: 'Jane', iteration: [1], ignoreIterationOnScalar: true}])
```

Transforme PRENOM en `"Jane"` en ignorant iteration vu que la variable PRENOM n'est pas un tableau

Cela permet de contrebalancer un problème que certains orchestrateur ont car ils ne sont pas capable de détermine si ils sont dans une boucle ou non.

Fix #1233