### PR TITLE
feat: tag components when they should be filtered

### DIFF
--- a/src/components/type.ts
+++ b/src/components/type.ts
@@ -263,10 +263,7 @@ export type ComponentPropsByType = {
 			response: { name: string };
 			componentType?: 'Textarea';
 		};
-	FilterDescription: Pick<
-		LunaticBaseProps<string>,
-		'id' | 'label' | 'shouldBeFiltered'
-	> &
+	FilterDescription: Pick<LunaticBaseProps<string>, 'id' | 'label'> &
 		LunaticExtraProps & {
 			componentType?: 'FilterDescription';
 		};

--- a/src/components/type.ts
+++ b/src/components/type.ts
@@ -35,6 +35,7 @@ export type LunaticBaseProps<ValueType = unknown> = {
 	className?: string;
 	style?: CSSProperties;
 	iteration?: number;
+	shouldBeFiltered?: boolean;
 	declarations?: {
 		id: string;
 		declarationType:
@@ -103,12 +104,17 @@ export type ComponentPropsByType = {
 		};
 	Sequence: Pick<
 		LunaticBaseProps<string>,
-		'id' | 'label' | 'style' | 'declarations' | 'description'
+		| 'id'
+		| 'label'
+		| 'style'
+		| 'declarations'
+		| 'description'
+		| 'shouldBeFiltered'
 	> &
 		LunaticExtraProps & { componentType?: 'Sequence' };
 	Subsequence: Pick<
 		LunaticBaseProps<string>,
-		'id' | 'label' | 'declarations' | 'description'
+		'id' | 'label' | 'declarations' | 'description' | 'shouldBeFiltered'
 	> &
 		LunaticExtraProps & { componentType?: 'Subsequence' };
 	Question: Pick<
@@ -121,6 +127,7 @@ export type ComponentPropsByType = {
 		| 'errors'
 		| 'disabled'
 		| 'readOnly'
+		| 'shouldBeFiltered'
 	> &
 		LunaticExtraProps & {
 			components: LunaticComponentProps[];
@@ -256,7 +263,10 @@ export type ComponentPropsByType = {
 			response: { name: string };
 			componentType?: 'Textarea';
 		};
-	FilterDescription: Pick<LunaticBaseProps<string>, 'id' | 'label'> &
+	FilterDescription: Pick<
+		LunaticBaseProps<string>,
+		'id' | 'label' | 'shouldBeFiltered'
+	> &
 		LunaticExtraProps & {
 			componentType?: 'FilterDescription';
 		};

--- a/src/use-lunatic/commons/fill-components/fill-component.spec.ts
+++ b/src/use-lunatic/commons/fill-components/fill-component.spec.ts
@@ -647,4 +647,61 @@ describe('fillComponents', () => {
 		expect(input.conditionFilter).toBe(undefined);
 		expect(input.shouldBeFiltered).toBe(true);
 	});
+
+	it('should tag options with shouldBeFiltered=true if the component should be filtered', () => {
+		const components = [
+			{
+				id: 'radio1',
+				componentType: 'Radio',
+				page: '1',
+				label: {
+					type: 'VTL|MD',
+					value: '"Radio label"',
+				},
+				options: [
+					{ value: 'yes', label: { value: '"Yes"', type: 'VTL|MD' } },
+					{ value: 'no', label: { value: '"No"', type: 'VTL|MD' } },
+				],
+				response: {
+					name: 'TESTRADIO',
+				},
+				conditionFilter: {
+					type: 'VTL',
+					// value should be string, but did not find how to execute correctly with mocks
+					// for having a false conditionFilter at the end
+					value: false,
+				},
+			},
+		];
+
+		const mockVariables = LunaticVariablesStore.makeFromObject({
+			TESTINPUT: 'Filled input',
+			TESTRADIO: 'yes',
+		});
+
+		const mockState = {
+			...defaultMockState,
+			disableFilters: true,
+			variables: mockVariables,
+		};
+
+		const filledComponents = fillComponents(
+			components as LunaticComponentDefinition[],
+			mockState as unknown as FillComponentArgs
+		) as any;
+
+		const radio = filledComponents[0];
+
+		expect(radio.componentType).toBe('Radio');
+		expect(radio.conditionFilter).toBe(false);
+		expect(radio.shouldBeFiltered).toBe(true);
+
+		expect(radio.options[0].label).toBe('"Yes"');
+		expect(radio.options[0].conditionFilter).toBe(undefined);
+		expect(radio.options[0].shouldBeFiltered).toBe(true);
+
+		expect(radio.options[1].label).toBe('"No"');
+		expect(radio.options[1].conditionFilter).toBe(undefined);
+		expect(radio.options[1].shouldBeFiltered).toBe(true);
+	});
 });

--- a/src/use-lunatic/commons/fill-components/fill-component.spec.ts
+++ b/src/use-lunatic/commons/fill-components/fill-component.spec.ts
@@ -66,6 +66,7 @@ describe('fillComponents', () => {
 		expect(input.required).toBe(true);
 		expect(input.maxLength).toBe(15);
 		expect(input.conditionFilter).toBe(true);
+		expect(input.shouldBeFiltered).toBe(false);
 	});
 
 	it('should fill a Radio component correctly with options', () => {
@@ -136,6 +137,7 @@ describe('fillComponents', () => {
 		expect(radio.options[0].label).toBe('"oui"');
 		expect(radio.options[1].label).toBe('"non"');
 		expect(radio.conditionFilter).toBe(true);
+		expect(radio.shouldBeFiltered).toBe(false);
 		expect(radio.response.name).toBe('TESTRADIO');
 	});
 
@@ -187,6 +189,7 @@ describe('fillComponents', () => {
 		expect(question.id).toBe('question-m8ilvkbt');
 		expect(question.label).toBe('"Question label"');
 		expect(question.conditionFilter).toBe(true);
+		expect(question.shouldBeFiltered).toBe(false);
 		expect(question.components.length).toBe(1);
 
 		const input = question.components[0];
@@ -258,12 +261,16 @@ describe('fillComponents', () => {
 		expect(input.componentType).toBe('Input');
 		expect(input.response.name).toBe('TESTINPUT');
 		expect(input.maxLength).toBe(100);
+		expect(input.conditionFilter).toBe(true);
+		expect(input.shouldBeFiltered).toBe(false);
 
 		const radio = filledComponents[1];
 		expect(radio.componentType).toBe('Radio');
 		expect(radio.response.name).toBe('TESTRADIO');
 		expect(radio.options[0].label).toBe('"Yes"');
 		expect(radio.options[1].label).toBe('"No"');
+		expect(radio.conditionFilter).toBe(true);
+		expect(radio.shouldBeFiltered).toBe(false);
 	});
 
 	it('should filter out FilterDescription components if disableFiltersDescription is true', () => {
@@ -453,6 +460,7 @@ describe('fillComponents', () => {
 		const input = filledComponents[0];
 		expect(input.id).toBe('input1');
 		expect(input.conditionFilter).toBe(false);
+		expect(input.shouldBeFiltered).toBe(true);
 	});
 
 	it('should transform components into Text with empty label when conditionFilter is false and parentType is RosterForLoop', () => {
@@ -507,6 +515,8 @@ describe('fillComponents', () => {
 		expect(input.componentType).toBe('Text');
 		expect(input.label).toBe('');
 		expect(input.id).toBe('input1');
+		expect(input.conditionFilter).toBe(false);
+		expect(input.shouldBeFiltered).toBe(true);
 
 		// Check the second component that has conditionFilter: true
 		const radio = filledComponents[1];
@@ -569,6 +579,8 @@ describe('fillComponents', () => {
 		// The component should remain unchanged
 		expect(input.componentType).toBe('Input');
 		expect(input.label).toBe('"Input label"');
+		expect(input.conditionFilter).toBe(false);
+		expect(input.shouldBeFiltered).toBe(true);
 
 		// Check the second component that has conditionFilter: true
 		const radio = filledComponents[1];
@@ -577,5 +589,62 @@ describe('fillComponents', () => {
 		expect(radio.label).toBe('"Radio label"');
 		expect(radio.options[0].label).toBe('"Yes"');
 		expect(radio.options[1].label).toBe('"No"');
+	});
+
+	it('should tag children components with shouldBeFiltered=true if the parent component should be filtered', () => {
+		const components = [
+			{
+				id: 'question-m8ilvkbt',
+				componentType: 'Question',
+				page: '1',
+				label: {
+					value: '"Question label"',
+					type: 'VTL|MD',
+				},
+				conditionFilter: {
+					type: 'VTL',
+					// value should be string, but did not find how to execute correctly with mocks
+					// for having a false conditionFilter at the end
+					value: false,
+				},
+				components: [
+					{
+						id: 'm8ilvkbt',
+						componentType: 'Input',
+						page: '1',
+						maxLength: 249,
+						response: {
+							name: 'TESTTEXTE',
+						},
+					},
+				],
+			},
+		];
+
+		const mockVariables = LunaticVariablesStore.makeFromObject({
+			TESTTEXTE: 'some value',
+		});
+
+		const mockState = {
+			...defaultMockState,
+			disableFilters: true,
+			variables: mockVariables,
+		};
+
+		const filledComponents = fillComponents(
+			components as LunaticComponentDefinition[],
+			mockState as unknown as FillComponentArgs
+		) as any;
+
+		const question = filledComponents[0];
+
+		expect(question.componentType).toBe('Question');
+		expect(question.conditionFilter).toBe(false);
+		expect(question.shouldBeFiltered).toBe(true);
+
+		const input = question.components[0];
+		expect(input.componentType).toBe('Input');
+		expect(input.conditionFilter).toBe(undefined);
+		expect(input.shouldBeFiltered).toBe(true);
 	});
 });

--- a/src/use-lunatic/commons/fill-components/fill-components.ts
+++ b/src/use-lunatic/commons/fill-components/fill-components.ts
@@ -74,7 +74,8 @@ export const fillComponent = (
 			state.pager.iteration,
 			value,
 			state.logger,
-			state.disableFilters
+			state.disableFilters,
+			shouldBeFiltered
 		),
 		...getComponentTypeProps(interpretedProps, state),
 		// This is too dynamic to be typed correctly, so we allow any here

--- a/src/use-lunatic/commons/fill-components/fill-components.ts
+++ b/src/use-lunatic/commons/fill-components/fill-components.ts
@@ -13,6 +13,7 @@ import { getValueProp } from '../../props/propValue';
 import { getIterationsProp } from '../../props/propIterations';
 import { getOptionsProp } from '../../props/propOptions';
 import { LunaticLogger } from '../../logger/type';
+import { VTLScalarExpression } from '../../../type.source';
 
 export type FillComponentArgs = {
 	disableFilters?: boolean;
@@ -35,9 +36,20 @@ export type FillComponentArgs = {
  */
 export const fillComponent = (
 	component: LunaticComponentDefinition,
-	state: FillComponentArgs
+	state: FillComponentArgs,
+	// the given parentConditionFilter is typed as VTLScalarExpression, but it's actually a boolean or undefined
+	parentConditionFilter?: any
 ): LunaticComponentProps & { conditionFilter?: boolean } => {
 	const interpretedProps = fillComponentExpressions(component, state);
+
+	const shouldParentBeFiltered = parentConditionFilter === false;
+
+	const shouldBeFiltered =
+		shouldParentBeFiltered ||
+		('conditionFilter' in interpretedProps
+			? !interpretedProps.conditionFilter
+			: false);
+
 	const value = getValueProp(component, state);
 	return {
 		...interpretedProps,
@@ -48,6 +60,7 @@ export const fillComponent = (
 		shortcut: state.shortcut,
 		goNextPage: state.goNextPage,
 		goPreviousPage: state.goPreviousPage,
+		shouldBeFiltered: shouldBeFiltered,
 		iteration: state.pager.iteration,
 		required: 'isMandatory' in component ? component.isMandatory : false,
 		value: value,
@@ -74,7 +87,8 @@ export const fillComponent = (
 export function fillComponents(
 	components: LunaticComponentDefinition[],
 	state: FillComponentArgs,
-	parentType?: LunaticComponentDefinition['componentType']
+	parentType?: LunaticComponentDefinition['componentType'],
+	parentConditionFilter?: VTLScalarExpression
 ): LunaticComponentProps[] {
 	// Flatmap to directly remove FilterDescription components if disableFiltersDescription is true
 	const filledComponents = components.flatMap((component) => {
@@ -85,7 +99,7 @@ export function fillComponents(
 			return [];
 		}
 
-		return [fillComponent(component, state)];
+		return [fillComponent(component, state, parentConditionFilter)];
 	});
 
 	if (state.disableFilters) {

--- a/src/use-lunatic/props/getComponentTypeProps.ts
+++ b/src/use-lunatic/props/getComponentTypeProps.ts
@@ -45,7 +45,12 @@ function getChildComponents(
 	state: State
 ) {
 	return {
-		components: fillComponents(component.components, state),
+		components: fillComponents(
+			component.components,
+			state,
+			undefined,
+			component.conditionFilter
+		),
 	};
 }
 

--- a/src/use-lunatic/props/propOptions.spec.ts
+++ b/src/use-lunatic/props/propOptions.spec.ts
@@ -305,5 +305,62 @@ describe('getOptionsProp()', () => {
 			// the option should would have been filtered if we did not disable filters
 			expect(options[0].shouldBeFiltered).toBe(true);
 		});
+		it('should set the response (CheckboxGroup) shouldBeFiltered=true when the parent component should be filtered', () => {
+			const definition = {
+				...checkboxGroupDefinition,
+				responses: [
+					{
+						label: 'Option 1',
+						response: { name: 'O1' },
+						id: 'id1',
+						conditionFilter: { type: 'VTL', value: 'expression' },
+					},
+				],
+			} satisfies DeepTranslateExpression<LunaticComponentDefinition>;
+
+			const options = getOptionsProp(
+				definition,
+				variables,
+				mockChange,
+				undefined,
+				undefined,
+				mockLogger,
+				true, // disableFilters = true
+				true // parent component should be filtered
+			);
+
+			// Ensure the option is not filtered
+			expect(options).toHaveLength(1);
+			// the option would have been filtered if we did not disable filters because its parent would
+			expect(options[0].shouldBeFiltered).toBe(true);
+		});
+		it('should set the option (Radio) shouldBeFiltered=true when the parent component should be filtered', () => {
+			const definition = {
+				...radioDefinition,
+				options: [
+					{
+						label: 'Option 1',
+						value: 'id1',
+						conditionFilter: { type: 'VTL', value: 'expression' },
+					},
+				],
+			} as any as DeepTranslateExpression<LunaticComponentDefinition>;
+
+			const options = getOptionsProp(
+				definition,
+				variables,
+				mockChange,
+				undefined,
+				undefined,
+				mockLogger,
+				true, // disableFilters = true
+				true // parent component should be filtered
+			);
+
+			// Ensure the option is not filtered
+			expect(options).toHaveLength(1);
+			// the option would have been filtered if we did not disable filters because its parent would
+			expect(options[0].shouldBeFiltered).toBe(true);
+		});
 	});
 });

--- a/src/use-lunatic/props/propOptions.spec.ts
+++ b/src/use-lunatic/props/propOptions.spec.ts
@@ -208,6 +208,7 @@ describe('getOptionsProp()', () => {
 
 			// Ensure the option is not filtered
 			expect(options).toHaveLength(1);
+			expect(options[0].shouldBeFiltered).toBe(false);
 		});
 		it('should not filter option (radio) when its conditionFilter evaluation fails', () => {
 			const definition = {
@@ -237,6 +238,7 @@ describe('getOptionsProp()', () => {
 
 			// Ensure the option is not filtered
 			expect(options).toHaveLength(1);
+			expect(options[0].shouldBeFiltered).toBe(false);
 		});
 		it('should not filter any response (CheckboxGroup) when disableFilters is true', () => {
 			const definition = {
@@ -268,6 +270,8 @@ describe('getOptionsProp()', () => {
 
 			// Ensure the option is not filtered
 			expect(options).toHaveLength(1);
+			// the option should would have been filtered if we did not disable filters
+			expect(options[0].shouldBeFiltered).toBe(true);
 		});
 		it('should not filter any option (Radio) when disableFilters is true', () => {
 			const definition = {
@@ -296,7 +300,10 @@ describe('getOptionsProp()', () => {
 				true // disableFilters = true
 			);
 
+			// Ensure the option is not filtered
 			expect(options).toHaveLength(1);
+			// the option should would have been filtered if we did not disable filters
+			expect(options[0].shouldBeFiltered).toBe(true);
 		});
 	});
 });

--- a/src/use-lunatic/props/propOptions.ts
+++ b/src/use-lunatic/props/propOptions.ts
@@ -33,7 +33,8 @@ export function getOptionsProp(
 	pagerIteration: LunaticState['pager']['iteration'],
 	value: unknown,
 	logger: LunaticLogger,
-	disableFilters?: boolean
+	disableFilters?: boolean,
+	shouldParentBeFiltered?: boolean
 ) {
 	const iteration = isNumber(pagerIteration) ? [pagerIteration] : undefined;
 
@@ -43,7 +44,7 @@ export function getOptionsProp(
 				if (disableFilters || !response.conditionFilter) {
 					return true;
 				}
-				return !shouldFilterOutOption(
+				return !isFilteredOutOption(
 					variables,
 					iteration,
 					logger,
@@ -70,12 +71,14 @@ export function getOptionsProp(
 							]);
 						}
 					: undefined,
-				shouldBeFiltered: shouldFilterOutOption(
-					variables,
-					iteration,
-					logger,
-					response.conditionFilter
-				),
+				shouldBeFiltered:
+					shouldParentBeFiltered ||
+					isFilteredOutOption(
+						variables,
+						iteration,
+						logger,
+						response.conditionFilter
+					),
 			}));
 	}
 
@@ -92,7 +95,7 @@ export function getOptionsProp(
 			) {
 				return true;
 			}
-			return !shouldFilterOutOption(
+			return !isFilteredOutOption(
 				variables,
 				iteration,
 				logger,
@@ -125,20 +128,21 @@ export function getOptionsProp(
 						}
 					: null,
 			shouldBeFiltered:
-				'conditionFilter' in option &&
-				shouldFilterOutOption(
-					variables,
-					iteration,
-					logger,
-					option.conditionFilter
-				),
+				shouldParentBeFiltered ||
+				('conditionFilter' in option &&
+					isFilteredOutOption(
+						variables,
+						iteration,
+						logger,
+						option.conditionFilter
+					)),
 		}));
 }
 
 /**
  * Check if an option should be filtered, depending on its conditionFilter.
  */
-function shouldFilterOutOption(
+function isFilteredOutOption(
 	variables: LunaticVariablesStore,
 	iteration: number[] | undefined,
 	logger: LunaticLogger,

--- a/src/use-lunatic/props/propOptions.ts
+++ b/src/use-lunatic/props/propOptions.ts
@@ -8,6 +8,7 @@ import type { DeepTranslateExpression } from '../commons/fill-components/fill-co
 import { isNumber } from '../../utils/number';
 import type { LunaticVariablesStore } from '../commons/variables/lunatic-variables-store';
 import { LunaticLogger } from '../logger/type';
+import { VtlExpression } from '../../components/type';
 
 /* Used for radio option and checkbox one option */
 export type InterpretedOption = {
@@ -35,7 +36,6 @@ export function getOptionsProp(
 	disableFilters?: boolean
 ) {
 	const iteration = isNumber(pagerIteration) ? [pagerIteration] : undefined;
-	//const iteration = pagerIteration ? [pagerIteration] : undefined;
 
 	if (definition.componentType === 'CheckboxGroup') {
 		return definition.responses
@@ -43,16 +43,12 @@ export function getOptionsProp(
 				if (disableFilters || !response.conditionFilter) {
 					return true;
 				}
-				try {
-					return variables.run(response.conditionFilter.value, { iteration });
-				} catch (e) {
-					// If there is an error interpreting a variable, we do not filter
-					logger({
-						type: 'ERROR',
-						error: e as Error,
-					});
-					return true;
-				}
+				return !shouldFilterOutOption(
+					variables,
+					iteration,
+					logger,
+					response.conditionFilter
+				);
 			})
 			.map((response) => ({
 				label: response.label,
@@ -74,6 +70,12 @@ export function getOptionsProp(
 							]);
 						}
 					: undefined,
+				shouldBeFiltered: shouldFilterOutOption(
+					variables,
+					iteration,
+					logger,
+					response.conditionFilter
+				),
 			}));
 	}
 
@@ -90,16 +92,12 @@ export function getOptionsProp(
 			) {
 				return true;
 			}
-			try {
-				return variables.run(option.conditionFilter.value, { iteration });
-			} catch (e) {
-				// If there is an error interpreting a variable, we do not filter
-				logger({
-					type: 'ERROR',
-					error: e as Error,
-				});
-				return true;
-			}
+			return !shouldFilterOutOption(
+				variables,
+				iteration,
+				logger,
+				option.conditionFilter
+			);
 		})
 		.map((option) => ({
 			label: option.label,
@@ -126,5 +124,31 @@ export function getOptionsProp(
 							handleChanges([{ name: option.detail!.response.name, value }]);
 						}
 					: null,
+			shouldBeFiltered:
+				'conditionFilter' in option &&
+				shouldFilterOutOption(
+					variables,
+					iteration,
+					logger,
+					option.conditionFilter
+				),
 		}));
+}
+
+/**
+ * Check if an option should be filtered, depending on its conditionFilter.
+ */
+function shouldFilterOutOption(
+	variables: LunaticVariablesStore,
+	iteration: number[] | undefined,
+	logger: LunaticLogger,
+	conditionFilter?: VtlExpression
+): boolean {
+	if (!conditionFilter) return false;
+	try {
+		return !variables.run(conditionFilter.value, { iteration });
+	} catch (e) {
+		logger({ type: 'ERROR', error: e as Error });
+		return false;
+	}
 }


### PR DESCRIPTION
For every component (and options for radio/checkbox), add a new prop `shouldBeFiltered` that can be used in slot components by applications disabling filters.

Full description : https://github.com/InseeFr/Lunatic/issues/1235

---

- when filling a component :
  - if the component has a conditionFilter evaluated to false, then it should be filtered
  - if the component parent should be filtered (for example an Input that is in a Question), then the component should be filtered (even if it does not have a conditionFilter or has a one evaluated to true)

- when filling radio/checkbox options : 
  - if the option has a conditionFilter evaluated to false, then it should be filtered
  -  if the component parent should be filtered, then the option should be filtered