### PR TITLE
Fix/2.6 store ref

### DIFF
--- a/src/components/lunatic-components.tsx
+++ b/src/components/lunatic-components.tsx
@@ -1,4 +1,5 @@
 import {
+	forwardRef,
 	Fragment,
 	type PropsWithChildren,
 	type ReactNode,
@@ -7,6 +8,23 @@ import {
 import * as lunaticComponents from './index';
 import type { FilledLunaticComponentProps } from '../use-lunatic/commons/fill-components/fill-components';
 import { useAutoFocus } from '../hooks/use-auto-focus';
+
+type LunaticComponentsConatainerType = PropsWithChildren<{
+	autoFocusKey?: string;
+}>;
+
+const LunaticComponentsConatainer = forwardRef<
+	HTMLDivElement,
+	LunaticComponentsConatainerType
+>(function Container(
+	{ children, autoFocusKey }: LunaticComponentsConatainerType,
+	ref
+) {
+	if (autoFocusKey) {
+		return <div ref={ref}>{children}</div>;
+	}
+	return <>{children}</>;
+});
 
 type Props<T extends Record<string, unknown>> = {
 	// List of components to display (coming from getComponents)
@@ -34,14 +52,11 @@ export function LunaticComponents<T extends Record<string, unknown>>({
 }: Props<T>) {
 	const wrapperRef = useRef<HTMLDivElement>(null);
 	const hasComponents = components.length > 0;
-	const WrapperComponent = autoFocusKey ? 'div' : Fragment;
 
 	useAutoFocus(wrapperRef, hasComponents ? autoFocusKey : undefined);
 
 	return (
-		<WrapperComponent
-			ref={WrapperComponent === Fragment ? undefined : wrapperRef}
-		>
+		<LunaticComponentsConatainer ref={wrapperRef} autoFocusKey={autoFocusKey}>
 			{components.map((component, k) => {
 				const props = {
 					...component,
@@ -56,7 +71,7 @@ export function LunaticComponents<T extends Record<string, unknown>>({
 					</Fragment>
 				);
 			})}
-		</WrapperComponent>
+		</LunaticComponentsConatainer>
 	);
 }
 

--- a/src/components/modal/html/modal.tsx
+++ b/src/components/modal/html/modal.tsx
@@ -7,7 +7,7 @@ import './modal.scss';
 
 type Props = Pick<
 	LunaticComponentProps<'ConfirmationModal'>,
-	'id' | 'label' | 'description'
+	'id' | 'label' | 'description' | 'backPage'
 > & {
 	onClose: ReactEventHandler<HTMLDialogElement>;
 	onCancel: ReactEventHandler<HTMLDialogElement>;

--- a/src/components/modal/lunatic-modal.tsx
+++ b/src/components/modal/lunatic-modal.tsx
@@ -7,7 +7,8 @@ import { Modal } from './html/modal';
 function empty() {}
 
 function LunaticModal(props: LunaticComponentProps<'ConfirmationModal'>) {
-	const { id, label, description, goNextPage, goPreviousPage } = props;
+	const { id, label, description, goNextPage, goPreviousPage, backPage } =
+		props;
 
 	const dialogRef = useRef<HTMLDialogElement>(null);
 
@@ -52,6 +53,7 @@ function LunaticModal(props: LunaticComponentProps<'ConfirmationModal'>) {
 				id={id}
 				label={label}
 				description={description}
+				backPage={backPage}
 			/>
 		</LunaticComponent>
 	);

--- a/src/components/suggester/idb-suggester/check-store.tsx
+++ b/src/components/suggester/idb-suggester/check-store.tsx
@@ -59,7 +59,7 @@ function CheckStore({ storeName, version, setStore, children }: Props) {
 	if (ready === 0) {
 		return (
 			<div className="lunatic-suggester-in-progress">
-				Le store {storeName} est en cours de chargement.
+				La liste {storeName} est en cours de chargement.
 			</div>
 		);
 	}

--- a/src/components/type.ts
+++ b/src/components/type.ts
@@ -233,6 +233,7 @@ type ComponentPropsByType = {
 		page: string;
 		goNextPage: () => void;
 		goPreviousPage: () => void;
+		backPage?: string;
 	};
 
 	RemoteComponent: LunaticBaseProps<string | null> & {

--- a/src/use-lunatic/use-suggesters.ts
+++ b/src/use-lunatic/use-suggesters.ts
@@ -94,6 +94,11 @@ export function useSuggesters({
 								setTimestamp(Date.now());
 							}
 						}
+					} catch (e) {
+						console.warn(`Error during suggester's cleaning ${name}`, e);
+					}
+
+					try {
 						if (current[name] === SuggesterStatus.pending) {
 							const data = await getReferentiel(name);
 							const [append, abort] = createAppendTask<any>(
@@ -113,7 +118,7 @@ export function useSuggesters({
 							}
 						}
 					} catch (e: any) {
-						console.error(e);
+						console.error(`Error during suggester's loading ${name}`, e);
 						setStatus(status, name, SuggesterStatus.error);
 						setTimestamp(Date.now());
 					}


### PR DESCRIPTION
Quelques modifications (bug + mise à jour à la demande du métier)
- Suggester : séparation d'un try catch en 2 pour ne plus bloquer le chargement d'un store
- ref sur fragment de lunaticcomponent provoque une erreur même si à undefined
- un nouveau parametre sur la modal (backPage)
- changement d'un libellé d'aler te dans le suggester