### PR TITLE
feat: handle ignored calculated variables

### DIFF
--- a/lunatic-schema.json
+++ b/lunatic-schema.json
@@ -1165,6 +1165,9 @@
 						"expression": {
 							"$ref": "#/$defs/VTLExpression"
 						},
+						"isIgnoredByLunatic": {
+							"type": "boolean"
+						},
 						"bindingDependencies": {
 							"type": "array",
 							"items": {

--- a/src/stories/questionnaires/simpsons/source.json
+++ b/src/stories/questionnaires/simpsons/source.json
@@ -5,6 +5,12 @@
 		{
 			"variableType": "CALCULATED",
 			"expression": { "type": "VTL", "value": "\"2020\"" },
+			"name": "IGNOREDCALC",
+			"isIgnoredByLunatic": true
+		},
+		{
+			"variableType": "CALCULATED",
+			"expression": { "type": "VTL", "value": "\"2020\"" },
 			"name": "YEAR"
 		},
 		{

--- a/src/type.source.ts
+++ b/src/type.source.ts
@@ -255,6 +255,7 @@ export type Variable =
 			variableType: 'CALCULATED';
 			name: string;
 			expression: VTLExpression;
+			isIgnoredByLunatic?: boolean;
 			bindingDependencies?: string[];
 			shapeFrom?: string[] | string;
 			iterationReference?: string;

--- a/src/use-lunatic/commons/variables/get-questionnaire-data.ts
+++ b/src/use-lunatic/commons/variables/get-questionnaire-data.ts
@@ -40,7 +40,10 @@ export function getQuestionnaireData(
 
 	for (const variable of variables) {
 		// Skip calculated value if necessary
-		if (variable.variableType === 'CALCULATED' && !withCalculated) {
+		if (
+			variable.variableType === 'CALCULATED' &&
+			(variable.isIgnoredByLunatic || !withCalculated)
+		) {
 			continue;
 		}
 

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
@@ -657,6 +657,52 @@ describe('lunatic-variables-store', () => {
 			store.commit();
 			expect(store.get('PRENOM')).toEqual('John');
 		});
+
+		it('should handle calculated variables, ignoring them when `isIgnoredByLunatic` is true ', () => {
+			const store = LunaticVariablesStore.makeFromSource(
+				{
+					components: [],
+					variables: [
+						{
+							name: 'calc1',
+							dimension: 0,
+							expression: {
+								type: 'VTL',
+								value: '"calculated value"',
+							},
+							variableType: 'CALCULATED',
+							isIgnoredByLunatic: true,
+						},
+						{
+							name: 'calc2',
+							dimension: 0,
+							expression: {
+								type: 'VTL',
+								value: '"calculated value"',
+							},
+							variableType: 'CALCULATED',
+							isIgnoredByLunatic: false,
+						},
+						{
+							name: 'calc3',
+							dimension: 0,
+							expression: {
+								type: 'VTL',
+								value: '"calculated value"',
+							},
+							variableType: 'CALCULATED',
+						},
+					],
+				},
+				{},
+				{ current: () => {} }
+			);
+
+			expect(store.get('calc1')).toBeNull();
+			expect(store.get('calc2')).toBe('calculated value');
+			expect(store.get('calc3')).toBe('calculated value');
+		});
+
 		it('should enable cleaning when disableCleaning = false', () => {
 			const cleaningSpy = vi.spyOn(cleaningModule, 'cleaningBehaviour');
 			LunaticVariablesStore.makeFromSource(

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.ts
@@ -88,6 +88,7 @@ export class LunaticVariablesStore {
 		for (const variable of source.variables) {
 			switch (variable.variableType) {
 				case 'CALCULATED':
+					if (variable.isIgnoredByLunatic) break;
 					store.setCalculated(variable.name, variable.expression.value, {
 						dependencies: variable.bindingDependencies,
 						iterationDepth: getIterationDepth(variable.name),


### PR DESCRIPTION
In some cases, we add calculated variables in the source.json, that are not used in the questionnaire (those variables are executed out of Lunatic.), So when using Lunatic we calculate those variables for nothing.

We decided to add an optional prop `isIgnoredByLunatic` to calculated variables, saying that Lunatic can ignore it
=> not calculated anymore
=> not returned anymore when getting data

