### PR TITLE
feat: handle detail max length in radio/checkbox

### DIFF
--- a/lunatic-schema.json
+++ b/lunatic-schema.json
@@ -837,6 +837,9 @@
 									"label": {
 										"$ref": "#/$defs/VTLExpression"
 									},
+									"maxLength": {
+										"type": "integer"
+									},
 									"response": {
 										"$ref": "#/$defs/ResponseDefinition"
 									}
@@ -1353,6 +1356,9 @@
 						"properties": {
 							"label": {
 								"$ref": "#/$defs/VTLExpression"
+							},
+							"maxLength": {
+								"type": "integer"
 							},
 							"response": {
 								"type": "object",

--- a/src/components/shared/Checkbox/CheckboxOption.tsx
+++ b/src/components/shared/Checkbox/CheckboxOption.tsx
@@ -18,6 +18,7 @@ export type CheckboxOptionProps = {
 	invalid?: boolean;
 	detailAlwaysDisplayed?: boolean;
 	detailLabel?: ReactNode;
+	detailMaxLength?: number;
 	detailValue?: string | null;
 	onDetailChange?: (value: string) => void;
 };
@@ -32,6 +33,7 @@ function LunaticCheckboxOption({
 	description,
 	detailAlwaysDisplayed,
 	detailLabel,
+	detailMaxLength,
 	detailValue,
 	onDetailChange,
 	codeModality,
@@ -105,6 +107,7 @@ function LunaticCheckboxOption({
 					id="detailId"
 					label={detailLabel ?? 'Précisez :'}
 					value={typeof detailValue === 'string' ? detailValue : ''}
+					maxLength={detailMaxLength}
 					onChange={onDetailChange}
 					disabled={disabled}
 				/>

--- a/src/components/shared/Radio/RadioOption.tsx
+++ b/src/components/shared/Radio/RadioOption.tsx
@@ -38,6 +38,7 @@ function LunaticRadioOption({
 	onDetailChange,
 	detailAlwaysDisplayed,
 	detailLabel,
+	detailMaxLength,
 	detailValue,
 	onCheck,
 	onUncheck,
@@ -127,6 +128,7 @@ function LunaticRadioOption({
 					id="detailId"
 					label={detailLabel ?? 'Précisez :'}
 					value={typeof detailValue === 'string' ? detailValue : ''}
+					maxLength={detailMaxLength}
 					onChange={onDetailChange}
 					disabled={disabled}
 				/>

--- a/src/components/type.ts
+++ b/src/components/type.ts
@@ -195,8 +195,9 @@ export type ComponentPropsByType = {
 				description?: ReactNode;
 				onCheck: (b: boolean) => void;
 				onDetailChange?: (v: string) => void;
-				detailValue?: string | null;
 				detailLabel?: ReactNode;
+				detailMaxLength?: number;
+				detailValue?: string | null;
 			}[];
 			orientation?: 'horizontal' | 'vertical';
 			detailAlwaysDisplayed?: boolean;

--- a/src/type.source.ts
+++ b/src/type.source.ts
@@ -145,6 +145,7 @@ export type ComponentCheckboxGroupDefinition = ComponentDefinitionBase & {
 		id: string;
 		detail?: {
 			label?: VTLExpression;
+			maxLength?: number;
 			response: ResponseDefinition;
 		};
 	}[];
@@ -164,6 +165,7 @@ export type OptionsWithDetail = {
 	description?: VTLExpression;
 	detail?: {
 		label: VTLExpression;
+		maxLength?: number;
 		response: {
 			name: string;
 		};

--- a/src/use-lunatic/props/propOptions.spec.ts
+++ b/src/use-lunatic/props/propOptions.spec.ts
@@ -117,6 +117,94 @@ describe('getOptionsProp()', () => {
 				{ name: 'O2', value: false },
 			]);
 		});
+		it('should create detail props correctly for checkboxGroup', () => {
+			const definition = {
+				...checkboxGroupDefinition,
+				responses: [
+					{
+						label: 'Option 1',
+						response: { name: 'O1' },
+						id: 'id1',
+						detail: {
+							label: 'Precize:',
+							response: { name: 'DETAIL' },
+							maxLength: 50,
+						},
+					},
+					{
+						label: 'Option 2',
+						response: { name: 'O2' },
+						id: 'id2',
+						detail: {
+							label: 'Precize:',
+							response: { name: 'DETAILBIS' },
+						},
+					},
+				],
+			} satisfies DeepTranslateExpression<LunaticComponentDefinition>;
+
+			variables.set('DETAIL', true);
+
+			const options = getOptionsProp(
+				definition,
+				variables,
+				mockChange,
+				undefined,
+				undefined,
+				mockLogger
+			);
+
+			expect(options).toHaveLength(2);
+			expect(options[0].detailLabel).toBe('Precize:');
+			expect(options[1].detailLabel).toBe('Precize:');
+			expect(options[0].detailValue).toBe(true);
+			expect(options[1].detailValue).toBeNull();
+			expect(options[0].detailMaxLength).toBe(50);
+			expect(options[1].detailMaxLength).toBeUndefined();
+		});
+		it('should create detail props correctly for Radiogroup', () => {
+			const definition = {
+				...radioDefinition,
+				options: [
+					{
+						label: 'Option 1',
+						value: 'id1',
+						detail: {
+							label: 'Precize:',
+							response: { name: 'DETAIL' },
+							maxLength: 50,
+						},
+					},
+					{
+						label: 'Option 2',
+						value: 'id2',
+						detail: {
+							label: 'Precize:',
+							response: { name: 'DETAILBIS' },
+						},
+					},
+				],
+			} satisfies DeepTranslateExpression<LunaticComponentDefinition>;
+
+			variables.set('DETAIL', true);
+
+			const options = getOptionsProp(
+				definition,
+				variables,
+				mockChange,
+				undefined,
+				undefined,
+				mockLogger
+			);
+
+			expect(options).toHaveLength(2);
+			expect(options[0].detailLabel).toBe('Precize:');
+			expect(options[1].detailLabel).toBe('Precize:');
+			expect(options[0].detailValue).toBe(true);
+			expect(options[1].detailValue).toBeNull();
+			expect(options[0].detailMaxLength).toBe(50);
+			expect(options[1].detailMaxLength).toBeUndefined();
+		});
 		it('should filter responses (CheckboxGroup) with conditionFilter evaluated to false', () => {
 			const definition = {
 				...checkboxGroupDefinition,

--- a/src/use-lunatic/props/propOptions.ts
+++ b/src/use-lunatic/props/propOptions.ts
@@ -18,6 +18,7 @@ export type InterpretedOption = {
 	description?: ReactNode;
 	detailLabel?: ReactNode;
 	detailValue?: string | null;
+	detailMaxLength?: number;
 	onDetailChange?: (value: string) => void;
 	onCheck?: () => void;
 	onUncheck?: () => void;
@@ -61,6 +62,7 @@ export function getOptionsProp(
 				detailValue: response.detail?.response
 					? variables.get(response.detail.response.name, iteration)
 					: undefined,
+				detailMaxLength: response.detail?.maxLength,
 				onCheck: (checked: boolean) => {
 					handleChanges([{ name: response.response.name, value: checked }]);
 				},
@@ -108,6 +110,12 @@ export function getOptionsProp(
 			value: option.value,
 			checked: value === option.value,
 			detailLabel: 'detail' in option ? option.detail?.label : undefined,
+			detailValue:
+				'detail' in option && option.detail
+					? variables.get(option.detail.response.name, iteration)
+					: null,
+			detailMaxLength:
+				'detail' in option ? option.detail?.maxLength : undefined,
 			onCheck: () => {
 				handleChanges([
 					{ name: definition.response.name, value: option.value },
@@ -117,10 +125,6 @@ export function getOptionsProp(
 			onUncheck: () => {
 				handleChanges([{ name: definition.response.name, value: null }]);
 			},
-			detailValue:
-				'detail' in option && option.detail
-					? variables.get(option.detail.response.name, iteration)
-					: null,
 			onDetailChange:
 				'detail' in option && option.detail
 					? (value: string) => {


### PR DESCRIPTION
Handle max length for detail (for every component : radio/checkboxOne/checkboxGroup) , like we already did for Input