### PR TITLE
Performance : prevent reevaluating static expressions

### DIFF
--- a/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
@@ -268,7 +268,7 @@ describe('lunatic-variables-store', () => {
 			variables.run('"hello"', { iteration: [0] });
 			variables.run('"hello"', { iteration: [1] });
 			expect(variables.run('"hello"')).toEqual('hello');
-			expect(variables.interpretCount).toBe(3);
+			expect(variables.interpretCount).toBe(1); // only 1 interpretation by the engine since optimisation for primitive value
 		});
 		it('should handle deep refresh', () => {
 			variables.set('LIENS', [

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.ts
@@ -371,9 +371,16 @@ class LunaticVariable {
 
 		// Calculate bindings first to refresh "updatedAt" on calculated dependencies
 		const bindings = this.getDependenciesValues(iteration);
+		const hasNoBinding = Object.keys(bindings).length === 0;
+
+		// A static expression should not be reevaluated
+		if (hasNoBinding && this.value) {
+			return this.value;
+		}
+
 		// A variable without binding is a primitive (string, boolean...)
 		// it yields the same results for every iteration, so we can ignore iteration
-		if (Object.keys(bindings).length === 0) {
+		if (hasNoBinding) {
 			iteration = undefined;
 		}
 		if (this.shapeFrom && !this.isOutdated(iteration)) {


### PR DESCRIPTION
Some VTL expression are just static string, it has no bidings so it's not necessary to rerun it multiple time.