### PR TITLE
fix: display roundabout row controls

### DIFF
--- a/e2e/roundabout.spec.ts
+++ b/e2e/roundabout.spec.ts
@@ -90,4 +90,21 @@ test.describe('Roundabout', () => {
 			await expectPageToHaveText(page, 'Complété');
 		});
 	});
+
+	test(`triggers roundabout simple and row controls`, async ({ page }) => {
+		await goToStory(page, 'components-roundabout--with-control');
+		// go to roundabout main page
+		await gotoNextPage(page, 3);
+		// go next for triggering controls
+		await gotoNextPage(page);
+
+		// simple control (specified on the roundabout scope)
+		await expectPageToHaveText(
+			page,
+			'la somme des ages des individus est supérieure à 20 ans.'
+		);
+
+		// row control (specified on iteration scope)
+		await expectPageToHaveText(page, "L'individu Pierre a plus de 35 ans.");
+	});
 });

--- a/src/use-lunatic/commons/compile-controls.ts
+++ b/src/use-lunatic/commons/compile-controls.ts
@@ -24,6 +24,11 @@ type InterpretedLoopComponent = DeepTranslateExpression<
 		componentType: 'Loop' | 'RosterForLoop';
 	}
 >;
+type InterpretedRoundaboutComponent = DeepTranslateExpression<
+	ComponentDefinition & {
+		componentType: 'Roundabout';
+	}
+>;
 
 /**
  * Check if the component is a Loop or a RosterForLoop
@@ -32,6 +37,15 @@ const isLoopComponent = (
 	component: ComponentDefinition | InterpretedComponent
 ): component is InterpretedLoopComponent => {
 	return ['Loop', 'RosterForLoop'].includes(component.componentType);
+};
+
+/**
+ * Check if the component is a Roundabout
+ */
+const isRoundaboutComponent = (
+	component: ComponentDefinition | InterpretedComponent
+): component is InterpretedRoundaboutComponent => {
+	return component.componentType === 'Roundabout';
 };
 
 const isQuestionComponent = (
@@ -64,6 +78,10 @@ function checkComponents(
 			}
 		}
 
+		// For Loop and RosterForLoop, inspect iterations for row controls
+		if (isRoundaboutComponent(component))
+			errors = checkRoundabout(state, component, errors);
+
 		// For Loop and RosterForLoop, inspect children
 		if (isLoopComponent(component))
 			errors = checkLoop(state, component, errors);
@@ -73,6 +91,22 @@ function checkComponents(
 			errors = checkComponents(state, component.components, errors);
 	}
 
+	return errors;
+}
+
+function checkRoundabout(
+	state: StateForControls,
+	component: InterpretedRoundaboutComponent,
+	errors: Record<string, LunaticError[]>
+) {
+	const rowControls = component.controls?.filter((c) => c.type === 'ROW');
+	if (rowControls?.length) {
+		errors = checkComponentInLoop(
+			state,
+			{ ...component, controls: rowControls },
+			errors
+		);
+	}
 	return errors;
 }
 
@@ -151,7 +185,10 @@ function computeIterations(
  */
 function checkComponentInLoop(
 	state: StateForControls,
-	component: ComponentDefinition | InterpretedLoopComponent,
+	component:
+		| ComponentDefinition
+		| InterpretedLoopComponent
+		| InterpretedRoundaboutComponent,
 	errors: Record<string, LunaticError[]>
 ): Record<string, LunaticError[]> {
 	// For Question, loop over children


### PR DESCRIPTION
During https://github.com/InseeFr/Lunatic/pull/1262, on roundabout page i removed the check of the controls in the loop (to remove the controls that are specified in the questions in the loop).
But it also removed the check of the raw controls specified on the roundabout.

Now we check for roundabout page :
- simple controls specified on the roundabout
- raw controls specified on the roundabout, checking all iterations