### PR TITLE
feat: display roundabout simple controls

### DIFF
--- a/src/components/Roundabout/CustomRoundabout.tsx
+++ b/src/components/Roundabout/CustomRoundabout.tsx
@@ -76,7 +76,16 @@ type Props = Pick<
 
 export const CustomRoundabout = slottableComponent<Props>(
 	'Roundabout',
-	({ declarations, description, id, items, goToIteration, label, locked }) => {
+	({
+		declarations,
+		description,
+		id,
+		items,
+		goToIteration,
+		label,
+		locked,
+		errors,
+	}) => {
 		return (
 			<div className="lunatic-roundabout">
 				<div id={`roundabout-${id}`} className="lunatic-roundabout__label">
@@ -88,6 +97,7 @@ export const CustomRoundabout = slottableComponent<Props>(
 					declarations={declarations}
 					id={id}
 				/>
+				<ComponentErrors errors={errors} />
 				<div className="lunatic-roundabout__items">
 					{items.map((item, k) => (
 						<RoundaboutItem

--- a/src/components/Roundabout/roundabout.spec.tsx
+++ b/src/components/Roundabout/roundabout.spec.tsx
@@ -1,6 +1,12 @@
 import { render, fireEvent } from '@testing-library/react';
 import { CustomRoundabout } from './CustomRoundabout';
 import { describe, it, expect, vi, afterEach } from 'vitest';
+import { LunaticError } from '../../use-lunatic/type';
+import { ComponentErrors } from '../shared/ComponentErrors/ComponentErrors';
+
+vi.mock('../shared/ComponentErrors/ComponentErrors', () => ({
+	ComponentErrors: vi.fn(),
+}));
 
 describe('Roundabout', () => {
 	const mockGoToIteration = vi.fn();
@@ -76,5 +82,37 @@ describe('Roundabout', () => {
 
 		const completeButton = getByText('Complété');
 		expect(completeButton).toBeDisabled();
+	});
+
+	it('displays roundabout errors', () => {
+		const errors: LunaticError[] = [
+			{
+				id: 'error1',
+				errorMessage: 'Error 1 message',
+				criticality: 'ERROR',
+				typeOfControl: 'CONSISTENCY',
+			},
+			{
+				id: 'error2',
+				errorMessage: 'Error 2 message',
+				criticality: 'WARN',
+				typeOfControl: 'CONSISTENCY',
+			},
+		];
+
+		render(
+			<CustomRoundabout
+				id="r1"
+				items={items}
+				goToIteration={mockGoToIteration}
+				locked={true}
+				errors={errors}
+			/>
+		);
+
+		expect(ComponentErrors).toHaveBeenCalledWith(
+			expect.objectContaining({ errors }),
+			expect.anything()
+		);
 	});
 });


### PR DESCRIPTION
On roundabout page, we were only displaying row controls in every concerned iteration.

We also want to display the roundabout simple controls, between roundabout description & iterations table