### PR TITLE
fix: display min max loop/roster (min != max)

### DIFF
--- a/e2e/loop.spec.ts
+++ b/e2e/loop.spec.ts
@@ -6,17 +6,21 @@ loopTypes.forEach((loopType) => {
 	test(`can complete a simple ${loopType.split('--')[0]}`, async ({ page }) => {
 		await goToStory(page, `components-${loopType}`);
 		await page.locator('#prenom-0').fill('John');
-		await page.getByRole('button', { name: 'Add row' }).click();
 		await page.locator('#prenom-1').fill('Jane');
+		await page.getByRole('button', { name: 'Add row' }).click();
+		await page.locator('#prenom-2').fill('Janette');
 		await page.getByRole('button', { name: 'Next' }).click();
 		await page.getByLabel('John, quel est vôtre âge ?').fill('18');
 		await page.getByRole('button', { name: 'Next' }).click();
 		await page.getByLabel('Jane, quel est vôtre âge ?').fill('20');
 		await page.getByRole('button', { name: 'Next' }).click();
+		await page.getByLabel('Janette, quel est vôtre âge ?').fill('22');
+		await page.getByRole('button', { name: 'Next' }).click();
 		await expect(page.getByText('PageTag"3"')).toBeVisible();
 		await expectLunaticData(page, 'COLLECTED.PRENOM.COLLECTED', [
 			'John',
 			'Jane',
+			'Janette',
 		]);
 	});
 });

--- a/e2e/loop.spec.ts
+++ b/e2e/loop.spec.ts
@@ -6,6 +6,7 @@ loopTypes.forEach((loopType) => {
 	test(`can complete a simple ${loopType.split('--')[0]}`, async ({ page }) => {
 		await goToStory(page, `components-${loopType}`);
 		await page.locator('#prenom-0').fill('John');
+		await page.getByRole('button', { name: 'Add row' }).click();
 		await page.locator('#prenom-1').fill('Jane');
 		await page.getByRole('button', { name: 'Add row' }).click();
 		await page.locator('#prenom-2').fill('Janette');

--- a/src/components/Loop/Loop.tsx
+++ b/src/components/Loop/Loop.tsx
@@ -20,7 +20,7 @@ import type { LunaticError } from '../../use-lunatic/type';
 export function Loop({
 	lines,
 	iterations,
-	value,
+	value: valueMap,
 	handleChanges,
 	getComponents,
 	errors,
@@ -28,20 +28,27 @@ export function Loop({
 }: LunaticComponentProps<'Loop'>) {
 	const min = lines?.min ?? 0;
 	const max = lines?.max ?? Infinity;
-	const [nbRows, setNbRows] = useState(() => {
-		return Math.max(iterations, min);
-	});
+	const [nbRows, setNbRows] = useState(Math.max(min, iterations));
+
 	const addRow = useCallback(() => {
 		if (nbRows < max) {
-			setNbRows(nbRows + 1);
+			const newNbRows = nbRows + 1;
+			setNbRows(newNbRows);
+			const newResponses = Object.entries(valueMap).map(([k, v]) => {
+				return {
+					name: k,
+					value: [...v, null],
+				};
+			});
+			handleChanges(newResponses);
 		}
-	}, [max, nbRows]);
+	}, [max, nbRows, valueMap, handleChanges]);
 	const removeRow = useCallback(() => {
 		if (nbRows > 1) {
 			const newNbRows = nbRows - 1;
 			setNbRows(newNbRows);
 			// Downsize all variables by 1
-			const newResponses = Object.entries(value).map(([k, v]) => {
+			const newResponses = Object.entries(valueMap).map(([k, v]) => {
 				return {
 					name: k,
 					value: v?.filter((_, i) => i < newNbRows),
@@ -49,7 +56,7 @@ export function Loop({
 			});
 			handleChanges(newResponses);
 		}
-	}, [nbRows, handleChanges, value]);
+	}, [nbRows, handleChanges, valueMap]);
 
 	if (nbRows <= 0) {
 		return null;

--- a/src/components/Loop/Loop.tsx
+++ b/src/components/Loop/Loop.tsx
@@ -1,4 +1,9 @@
-import { type PropsWithChildren, useCallback, useState } from 'react';
+import {
+	type PropsWithChildren,
+	useCallback,
+	useEffect,
+	useState,
+} from 'react';
 import D from '../../i18n';
 import { times } from '../../utils/array';
 import { LunaticComponents } from '../LunaticComponents';
@@ -13,6 +18,7 @@ import {
 	getComponentErrors,
 } from '../shared/ComponentErrors/ComponentErrors';
 import type { LunaticError } from '../../use-lunatic/type';
+import { resizeArrayVariable } from '../../use-lunatic/reducer/commons';
 
 /**
  * Loop without specific markup (stack of subcomponents)
@@ -30,6 +36,19 @@ export function Loop({
 	const max = lines?.max ?? Infinity;
 	const [nbRows, setNbRows] = useState(Math.max(min, iterations));
 
+	useEffect(() => {
+		const initialResponses = Object.entries(valueMap)
+			.filter(([, v]) => v.length < nbRows)
+			.map(([k, v]) => {
+				return {
+					name: k,
+					value: resizeArrayVariable(v, nbRows, null),
+				};
+			});
+		if (initialResponses.length > 0) handleChanges(initialResponses);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [nbRows]);
+
 	const addRow = useCallback(() => {
 		if (nbRows < max) {
 			const newNbRows = nbRows + 1;
@@ -43,6 +62,7 @@ export function Loop({
 			handleChanges(newResponses);
 		}
 	}, [max, nbRows, valueMap, handleChanges]);
+
 	const removeRow = useCallback(() => {
 		if (nbRows > 1) {
 			const newNbRows = nbRows - 1;

--- a/src/components/Loop/Loop.tsx
+++ b/src/components/Loop/Loop.tsx
@@ -1,9 +1,4 @@
-import {
-	type PropsWithChildren,
-	useCallback,
-	useEffect,
-	useState,
-} from 'react';
+import { type PropsWithChildren } from 'react';
 import D from '../../i18n';
 import { times } from '../../utils/array';
 import { LunaticComponents } from '../LunaticComponents';
@@ -18,67 +13,16 @@ import {
 	getComponentErrors,
 } from '../shared/ComponentErrors/ComponentErrors';
 import type { LunaticError } from '../../use-lunatic/type';
-import { resizeArrayVariable } from '../../use-lunatic/reducer/commons';
+import { useLoopUtils } from './utils';
 
 /**
  * Loop without specific markup (stack of subcomponents)
  */
-export function Loop({
-	lines,
-	iterations,
-	value: valueMap,
-	handleChanges,
-	getComponents,
-	errors,
-	...props
-}: LunaticComponentProps<'Loop'>) {
-	const min = lines?.min ?? 0;
-	const max = lines?.max ?? Infinity;
-	const [nbRows, setNbRows] = useState(Math.max(min, iterations));
+export function Loop(props: LunaticComponentProps<'Loop'>) {
+	const { min, max, nbRows, addRow, removeRow } = useLoopUtils(props);
+	const { getComponents, errors } = props;
 
-	useEffect(() => {
-		const initialResponses = Object.entries(valueMap)
-			.filter(([, v]) => v.length < nbRows)
-			.map(([k, v]) => {
-				return {
-					name: k,
-					value: resizeArrayVariable(v, nbRows, null),
-				};
-			});
-		if (initialResponses.length > 0) handleChanges(initialResponses);
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [nbRows]);
-
-	const addRow = useCallback(() => {
-		if (nbRows < max) {
-			const newNbRows = nbRows + 1;
-			setNbRows(newNbRows);
-			const newResponses = Object.entries(valueMap).map(([k, v]) => {
-				return {
-					name: k,
-					value: [...v, null],
-				};
-			});
-			handleChanges(newResponses);
-		}
-	}, [max, nbRows, valueMap, handleChanges]);
-
-	const removeRow = useCallback(() => {
-		if (nbRows > 1) {
-			const newNbRows = nbRows - 1;
-			setNbRows(newNbRows);
-			// Downsize all variables by 1
-			const newResponses = Object.entries(valueMap).map(([k, v]) => {
-				return {
-					name: k,
-					value: v?.filter((_, i) => i < newNbRows),
-				};
-			});
-			handleChanges(newResponses);
-		}
-	}, [nbRows, handleChanges, valueMap]);
-
-	if (nbRows <= 0) {
+	if (nbRows === 0) {
 		return null;
 	}
 

--- a/src/components/Loop/utils.ts
+++ b/src/components/Loop/utils.ts
@@ -15,7 +15,7 @@ export const useLoopUtils = (
 
 	useEffect(() => {
 		const initialResponses = Object.entries(valueMap)
-			.filter(([, v]) => v.length < nbRows)
+			.filter(([, v]) => (v?.length ?? 0) < nbRows)
 			.map(([k, v]) => {
 				return {
 					name: k,

--- a/src/components/Loop/utils.ts
+++ b/src/components/Loop/utils.ts
@@ -1,0 +1,60 @@
+import { useCallback, useEffect, useState } from 'react';
+import { LunaticComponentProps } from '../type';
+import { resizeArrayVariable } from '../../use-lunatic/reducer/commons';
+
+const DEFAULT_MIN_ROWS = 1;
+const DEFAULT_MAX_ROWS = 12;
+
+export const useLoopUtils = (
+	props: LunaticComponentProps<'RosterForLoop'> | LunaticComponentProps<'Loop'>
+) => {
+	const { lines, iterations, value: valueMap, handleChanges } = props;
+	const min = lines?.min ?? DEFAULT_MIN_ROWS;
+	const max = lines?.max ?? DEFAULT_MAX_ROWS;
+	const [nbRows, setNbRows] = useState(Math.max(min, iterations));
+
+	useEffect(() => {
+		const initialResponses = Object.entries(valueMap)
+			.filter(([, v]) => v.length < nbRows)
+			.map(([k, v]) => {
+				return {
+					name: k,
+					value: resizeArrayVariable(v, nbRows, null),
+				};
+			});
+		if (initialResponses.length > 0) handleChanges(initialResponses);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [nbRows]);
+
+	const addRow = useCallback(() => {
+		if (nbRows < max) {
+			const newNbRows = nbRows + 1;
+			setNbRows(newNbRows);
+			const newResponses = Object.entries(valueMap).map(([k, v]) => {
+				return {
+					name: k,
+					value: [...v, null],
+				};
+			});
+			handleChanges(newResponses);
+		}
+	}, [max, nbRows, valueMap, handleChanges]);
+
+	const removeRow = useCallback(() => {
+		if (nbRows <= min) {
+			return;
+		}
+		const newNbRows = nbRows - 1;
+		setNbRows(newNbRows);
+		// Downsize all variables by 1
+		const newResponses = Object.entries(valueMap).map(([k, v]) => {
+			return {
+				name: k,
+				value: v?.filter((_, i) => i < newNbRows),
+			};
+		});
+		handleChanges(newResponses);
+	}, [nbRows, min, valueMap, handleChanges]);
+
+	return { min, max, nbRows, addRow, removeRow };
+};

--- a/src/components/RosterForLoop/RosterForLoop.tsx
+++ b/src/components/RosterForLoop/RosterForLoop.tsx
@@ -40,9 +40,17 @@ export const RosterForLoop = (
 
 	const addRow = useCallback(() => {
 		if (nbRows < max) {
-			setNbRows(nbRows + 1);
+			const newNbRows = nbRows + 1;
+			setNbRows(newNbRows);
+			const newResponses = Object.entries(valueMap).map(([k, v]) => {
+				return {
+					name: k,
+					value: [...v, null],
+				};
+			});
+			handleChanges(newResponses);
 		}
-	}, [max, nbRows]);
+	}, [max, nbRows, valueMap, handleChanges]);
 
 	const removeRow = useCallback(() => {
 		if (nbRows <= min) {

--- a/src/components/RosterForLoop/RosterForLoop.tsx
+++ b/src/components/RosterForLoop/RosterForLoop.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useCallback, useState } from 'react';
+import { Fragment, useCallback, useEffect, useState } from 'react';
 import type { LunaticComponentProps } from '../type';
 import { Table, Tbody, Td, Tr, TableHeader } from '../shared/Table';
 import { times } from '../../utils/array';
@@ -9,6 +9,7 @@ import {
 	getComponentErrors,
 } from '../shared/ComponentErrors/ComponentErrors';
 import { CustomLoop } from '../Loop/Loop';
+import { resizeArrayVariable } from '../../use-lunatic/reducer/commons';
 
 const DEFAULT_MIN_ROWS = 1;
 const DEFAULT_MAX_ROWS = 12;
@@ -37,6 +38,19 @@ export const RosterForLoop = (
 	const min = lines?.min ?? DEFAULT_MIN_ROWS;
 	const max = lines?.max ?? DEFAULT_MAX_ROWS;
 	const [nbRows, setNbRows] = useState(Math.max(min, iterations));
+
+	useEffect(() => {
+		const initialResponses = Object.entries(valueMap)
+			.filter(([, v]) => v.length < nbRows)
+			.map(([k, v]) => {
+				return {
+					name: k,
+					value: resizeArrayVariable(v, nbRows, null),
+				};
+			});
+		if (initialResponses.length > 0) handleChanges(initialResponses);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [nbRows]);
 
 	const addRow = useCallback(() => {
 		if (nbRows < max) {

--- a/src/components/RosterForLoop/RosterForLoop.tsx
+++ b/src/components/RosterForLoop/RosterForLoop.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useCallback, useEffect, useState } from 'react';
+import { Fragment } from 'react';
 import type { LunaticComponentProps } from '../type';
 import { Table, Tbody, Td, Tr, TableHeader } from '../shared/Table';
 import { times } from '../../utils/array';
@@ -9,10 +9,7 @@ import {
 	getComponentErrors,
 } from '../shared/ComponentErrors/ComponentErrors';
 import { CustomLoop } from '../Loop/Loop';
-import { resizeArrayVariable } from '../../use-lunatic/reducer/commons';
-
-const DEFAULT_MIN_ROWS = 1;
-const DEFAULT_MAX_ROWS = 12;
+import { useLoopUtils } from '../Loop/utils';
 
 /**
  * Loop displayed as a table
@@ -20,67 +17,18 @@ const DEFAULT_MAX_ROWS = 12;
 export const RosterForLoop = (
 	props: LunaticComponentProps<'RosterForLoop'>
 ) => {
+	const { min, max, nbRows, addRow, removeRow } = useLoopUtils(props);
 	const {
-		value: valueMap,
-		lines,
 		errors,
-		handleChanges,
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		declarations,
 		header,
-		iterations,
 		id,
 		getComponents,
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		label,
 		...otherProps // These props will be passed down to the child components
 	} = props;
-	const min = lines?.min ?? DEFAULT_MIN_ROWS;
-	const max = lines?.max ?? DEFAULT_MAX_ROWS;
-	const [nbRows, setNbRows] = useState(Math.max(min, iterations));
-
-	useEffect(() => {
-		const initialResponses = Object.entries(valueMap)
-			.filter(([, v]) => v.length < nbRows)
-			.map(([k, v]) => {
-				return {
-					name: k,
-					value: resizeArrayVariable(v, nbRows, null),
-				};
-			});
-		if (initialResponses.length > 0) handleChanges(initialResponses);
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [nbRows]);
-
-	const addRow = useCallback(() => {
-		if (nbRows < max) {
-			const newNbRows = nbRows + 1;
-			setNbRows(newNbRows);
-			const newResponses = Object.entries(valueMap).map(([k, v]) => {
-				return {
-					name: k,
-					value: [...v, null],
-				};
-			});
-			handleChanges(newResponses);
-		}
-	}, [max, nbRows, valueMap, handleChanges]);
-
-	const removeRow = useCallback(() => {
-		if (nbRows <= min) {
-			return;
-		}
-		const newNbRows = nbRows - 1;
-		setNbRows(newNbRows);
-		// Downsize all variables by 1
-		const newResponses = Object.entries(valueMap).map(([k, v]) => {
-			return {
-				name: k,
-				value: v?.filter((_, i) => i < newNbRows),
-			};
-		});
-		handleChanges(newResponses);
-	}, [nbRows, min, valueMap, handleChanges]);
 
 	if (nbRows === 0) {
 		return null;

--- a/src/stories/loop/source-paginated.json
+++ b/src/stories/loop/source-paginated.json
@@ -93,7 +93,7 @@
 			"variableType": "COLLECTED",
 			"name": "PRENOM",
 			"values": {
-				"COLLECTED": ["John", "Jane"]
+				"COLLECTED": []
 			}
 		},
 		{

--- a/src/use-lunatic/props/propIterations.ts
+++ b/src/use-lunatic/props/propIterations.ts
@@ -32,20 +32,35 @@ export function getIterationsProp(
 
 	// Iterations expression is not present on the component definition
 	// infer it from the value of child components
-	return (definition.components as LunaticComponentDefinition[]).reduce(
-		(acc, component) => {
-			if (!hasResponse(component)) {
-				return acc;
-			}
-			const value = state.variables.get(
-				component.response.name,
-				isNumber(state.pager.iteration) ? [state.pager.iteration] : undefined
-			);
-			if (Array.isArray(value) && value.length > acc) {
-				return value.length;
-			}
+
+	return getFlatComponentsInLoop(definition).reduce((acc, component) => {
+		if (!hasResponse(component)) {
 			return acc;
-		},
-		0
-	);
+		}
+		const value = state.variables.get(
+			component.response.name,
+			isNumber(state.pager.iteration) ? [state.pager.iteration] : undefined
+		);
+		if (Array.isArray(value) && value.length > acc) {
+			return value.length;
+		}
+		return acc;
+	}, 0);
+}
+
+function getFlatComponentsInLoop(
+	definition: LunaticComponentDefinition
+): LunaticComponentDefinition[] {
+	if (
+		definition.componentType !== 'RosterForLoop' &&
+		definition.componentType !== 'Loop'
+	) {
+		return [definition];
+	}
+
+	return definition.components.reduce((acc, component) => {
+		if (component.componentType === 'Question')
+			return [...acc, ...component.components];
+		return [...acc, component];
+	}, [] as LunaticComponentDefinition[]);
 }


### PR DESCRIPTION
## To Improve

Fix initial value for loop/roster for loop where min is defined (and min != max): see [fix: initial value in loop/roster (kind of resizing but not exactly)](https://github.com/InseeFr/Lunatic/pull/1266/commits/2b14025e91e3e81f8703631f2c7b596a7f12a3f1)

I'm not okay by the fact that it's the UI that trigger a kind of resizing logic in case where values of loop/roster have not the right length.