### PR TITLE
fix: do not trigger disabled iterations controls on roundabout

### DIFF
--- a/e2e/roundabout.spec.ts
+++ b/e2e/roundabout.spec.ts
@@ -97,6 +97,8 @@ test.describe('Roundabout', () => {
 		await gotoNextPage(page, 3);
 		// go next for triggering controls
 		await gotoNextPage(page);
+		// close control modal added by lunatic orchestrator
+		await page.getByRole('button', { name: 'Correct' }).click();
 
 		// simple control (specified on the roundabout scope)
 		await expectPageToHaveText(
@@ -106,5 +108,14 @@ test.describe('Roundabout', () => {
 
 		// row control (specified on iteration scope)
 		await expectPageToHaveText(page, "L'individu Pierre a plus de 35 ans.");
+		await expectPageToHaveText(
+			page,
+			"Vous n'avez pas renseigné l'âge de Patrick."
+		);
+
+		// check that row control are not triggered for disabled iterations
+		await expect(
+			page.getByText("Vous n'avez pas renseigné l'âge de Paul.")
+		).toHaveCount(0);
 	});
 });

--- a/src/stories/roundabout/sourceWithControl.json
+++ b/src/stories/roundabout/sourceWithControl.json
@@ -348,6 +348,20 @@
 			"locked": false,
 			"controls": [
 				{
+					"id": "lypxwut2-CI-3",
+					"type": "ROW",
+					"control": {
+						"type": "VTL",
+						"value": "not(AGE = \"null\")"
+					},
+					"criticality": "WARN",
+					"errorMessage": {
+						"type": "VTL|MD",
+						"value": "\"Vous n'avez pas renseigné l'âge de \" || PRENOM || \".\" "
+					},
+					"typeOfControl": "CONSISTENCY"
+				},
+				{
 					"id": "lypxwut2-CI-1",
 					"type": "SIMPLE",
 					"control": {

--- a/src/use-lunatic/commons/compile-controls.ts
+++ b/src/use-lunatic/commons/compile-controls.ts
@@ -217,6 +217,19 @@ function checkComponentInLoop(
 		if (!('controls' in component) || !component.controls) {
 			continue;
 		}
+
+		// For Roundabout, we don't check controls for iterations that are disabled
+		if (component.componentType === 'Roundabout' && component.item.disabled) {
+			const isIterationDisabled = state.executeExpression(
+				{ value: component.item.disabled?.value, type: 'VTL' },
+				iterationPager
+			);
+
+			if (isIterationDisabled) {
+				continue;
+			}
+		}
+
 		// The component is filtered on this iteration, skip it
 		if (
 			// conditionFilter can be the interpreted expression, or the object representing the expression


### PR DESCRIPTION
On roundabout page, we display row controls (controls that are done on iterations scope).
Since we can have disabled iterations (acting like a filter), we don't want to trigger row controls for those disabled iterations.

In fact, since all the data on those iterations should be null, it would be enough to use a nvl() in the control formula to avoid to trigger it, but we prefer to avoid one case like this to happen

----

Also improve roundabout tests on controls, since previously it did not clearly checked that the controls were displayed on the page, out of the modal added by lunatic orchestrator