### PR TITLE
fix: loop condition filter on first iteration

### DIFF
--- a/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
@@ -95,7 +95,7 @@ describe('lunatic-variables-store', () => {
 		variables.set('LASTNAME', 'Doe');
 		expect(variables.run('FIRSTNAME || " " || LASTNAME')).toEqual('John Doe');
 		expect(variables.run('FIRSTNAME || " " || LASTNAME')).toEqual('John Doe');
-		expect(variables.interpretCount).toBe(1); // only once computation since improvment of caching result
+		expect(variables.interpretCount).toBe(2); // only once computation since improvment of caching result
 		variables.set('FIRSTNAME', 'Jane');
 		expect(variables.run('FIRSTNAME || " " || LASTNAME')).toEqual('Jane Doe');
 	});

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.ts
@@ -385,8 +385,7 @@ class LunaticVariable {
 			iteration = undefined;
 		}
 
-		const checkCache = this.shapeFrom || iteration === undefined;
-		if (checkCache && !this.isOutdated(iteration)) {
+		if (this.shapeFrom && !this.isOutdated(iteration)) {
 			return this.getSavedValue(iteration);
 		}
 		if (isTestEnv()) {


### PR DESCRIPTION
Since 3.5.0, if a loop has a conditionFilter, and the 1st iteration is filtered, then the loop is not displayed at all (even for the iterations that should not be filtered)

revert https://github.com/InseeFr/Lunatic/commit/c9609274e94c0d31bb72fe4c12dcf5e95736a814 which was improving performance by avoiding recalculations, but causing this bug.
Then later we'll find another solution for performances