### PR TITLE
fix: skip roundabout loop if only one disabled iteration

### DIFF
--- a/e2e/roundabout.spec.ts
+++ b/e2e/roundabout.spec.ts
@@ -58,7 +58,7 @@ test.describe('Roundabout', () => {
 	test(`navigation jump roundabout when only one iteration`, async ({
 		page,
 	}) => {
-		await goToStory(page, 'components-roundabout--default');
+		await goToStory(page, 'components-roundabout--one-iteration');
 		await page.getByLabel(/Combien/gi).fill('1');
 		await gotoNextPage(page, 2);
 		// Roundabout is skipped here
@@ -70,6 +70,20 @@ test.describe('Roundabout', () => {
 		await gotoNextPage(page);
 		await expectPageToHaveText(page, 'Merci');
 		await expectCollectedData(page, 'SEXE', ['1']);
+	});
+
+	test(`navigation jump roundabout and its loop when only one disabled iteration`, async ({
+		page,
+	}) => {
+		await goToStory(page, 'components-roundabout--one-iteration');
+		await page.getByLabel(/Combien/gi).fill('1');
+		await gotoNextPage(page);
+		// fill the iteration name and age
+		await page.getByLabel('Prénom').fill('Fanny');
+		await page.getByLabel(/^Age$/).fill('15');
+		await gotoNextPage(page);
+		// The only iteration is disabled (condition Age < 18), Roundabout and loop are skipped
+		await expectPageToHaveText(page, 'Merci');
 	});
 
 	test.describe('progression', () => {

--- a/src/stories/roundabout/roundabout.stories.tsx
+++ b/src/stories/roundabout/roundabout.stories.tsx
@@ -32,7 +32,7 @@ export const OneIteration: Story = {
 		data: dataFromObject({
 			NB_HAB: 1,
 			PRENOMS: ['Fanny'],
-			AGE: [15],
+			AGE: [20],
 		}),
 	},
 };

--- a/src/use-lunatic/reducer/commons/auto-explore-loop.ts
+++ b/src/use-lunatic/reducer/commons/auto-explore-loop.ts
@@ -52,6 +52,7 @@ export function autoExploreLoop(
 		const nbIterations = state.executeExpression<number>(page.iterations);
 		if (nbIterations === 1) {
 			const roundaboutComponent = page.components[0];
+			let isFirstIterationDisabled = false;
 			// check if the roundabout has a condition for disabling iterations
 			if (roundaboutComponent.item.disabled) {
 				const firstIterationPager = {
@@ -60,21 +61,13 @@ export function autoExploreLoop(
 				};
 
 				// check if the first iteration should be disabled
-				const isFirstIterationDisabled = state.executeExpression(
+				isFirstIterationDisabled = state.executeExpression(
 					{ value: roundaboutComponent.item.disabled?.value, type: 'VTL' },
 					firstIterationPager
 				);
-
-				if (isFirstIterationDisabled) {
-					// we skip the iteration, loop is empty
-					goInsideSubpage(page.subPages, 0);
-				} else {
-					// go the first iteration
-					goInsideSubpage(page.subPages, 1);
-				}
-			} else {
-				goInsideSubpage(page.subPages, 1);
 			}
+			// if the only iteration is disabled, we skip it, loop is empty. Else go to first iteration
+			goInsideSubpage(page.subPages, isFirstIterationDisabled ? 0 : 1);
 		}
 	}
 

--- a/src/use-lunatic/reducer/commons/auto-explore-loop.ts
+++ b/src/use-lunatic/reducer/commons/auto-explore-loop.ts
@@ -51,7 +51,30 @@ export function autoExploreLoop(
 	) {
 		const nbIterations = state.executeExpression<number>(page.iterations);
 		if (nbIterations === 1) {
-			goInsideSubpage(page.subPages, 1);
+			const roundaboutComponent = page.components[0];
+			// check if the roundabout has a condition for disabling iterations
+			if (roundaboutComponent.item.disabled) {
+				const firstIterationPager = {
+					...state.pager,
+					iteration: 0,
+				};
+
+				// check if the first iteration should be disabled
+				const isFirstIterationDisabled = state.executeExpression(
+					{ value: roundaboutComponent.item.disabled?.value, type: 'VTL' },
+					firstIterationPager
+				);
+
+				if (isFirstIterationDisabled) {
+					// we skip the iteration, loop is empty
+					goInsideSubpage(page.subPages, 0);
+				} else {
+					// go the first iteration
+					goInsideSubpage(page.subPages, 1);
+				}
+			} else {
+				goInsideSubpage(page.subPages, 1);
+			}
 		}
 	}
 


### PR DESCRIPTION
Currently, when there is only one iteration in a roundabout, we skip the "main roundabout page" for directly going to the iteration loop content. But when this iteration should be disabled (roundabout disable condition), we still go to its loop.
-> now we fully skip the loop 