### PR TITLE
fix: disable checkbox/radio option shortcut when editing field

### DIFF
--- a/e2e/checkbox.spec.ts
+++ b/e2e/checkbox.spec.ts
@@ -21,6 +21,41 @@ test.describe('Checkboxes', () => {
 			await expectCollectedData(page, 'MOIS3', null);
 		});
 
+		test(`Keyboard shortcut should be disabled when editing a field (focus on input/textarea)`, async ({
+			page,
+		}) => {
+			await goToStory(page, 'components-checkbox--checkbox-group-with-detail');
+			await expect(page.getByText('Autre préciser')).toBeVisible();
+
+			// no focus on a field, shorcut is enabled
+			await page.keyboard.type('5');
+			await expect(
+				page.getByRole('checkbox', { name: 'Autre préciser' })
+			).toHaveAttribute('aria-checked', 'true');
+
+			// detail field is autofocus, shortcut is disabled for every checkbox
+			await page.keyboard.type('345');
+			// modality 3
+			await expect(
+				page.getByRole('checkbox', {
+					name: 'Française de naissance ou par réintégration',
+				})
+			).not.toHaveAttribute('aria-checked', 'true');
+			// modality 4
+			await expect(
+				page.getByRole('checkbox', { name: 'Étrangère' })
+			).not.toHaveAttribute('aria-checked', 'true');
+			// modality 5
+			await expect(
+				page.getByRole('checkbox', { name: 'Autre préciser' })
+			).toHaveAttribute('aria-checked', 'true');
+
+			await expectCollectedData(page, 'NATIO1N3', null);
+			await expectCollectedData(page, 'NATIO1N4', null);
+			await expectCollectedData(page, 'NATIO1N_OTHER', true);
+			await expectCollectedData(page, 'NATIO1N_DETAIL', '345');
+		});
+
 		test(`Keyboard shortcut should be disabled in readonly`, async ({
 			page,
 		}) => {

--- a/e2e/missing.spec.ts
+++ b/e2e/missing.spec.ts
@@ -5,11 +5,27 @@ test.describe('Missing behaviour', () => {
 	test(`Missing keyboard shortcut are supported`, async ({ page }) => {
 		await goToStory(page, 'behaviour-missing--default');
 		await expect(page.getByLabel('NB')).toBeVisible();
+
+		// NB input should be autofocus
+		const activeTag = await page.evaluate(
+			() => document.activeElement?.tagName
+		);
+		expect(activeTag).toBe('INPUT');
+
+		// check missing keyboard works even when typing (focus on input)
 		await page.keyboard.press('F2');
 		await expect(
 			page.getByRole('button', { name: "Don't know" })
 		).toHaveAttribute('aria-pressed', 'true');
 		await expectLunaticData(page, 'COLLECTED.NB_MISSING.COLLECTED', 'DK');
+
+		// check missing keyboard works when not typing : here focus on "don't know" button
+		await page.keyboard.press('F4');
+		await expect(page.getByRole('button', { name: 'Refused' })).toHaveAttribute(
+			'aria-pressed',
+			'true'
+		);
+		await expectLunaticData(page, 'COLLECTED.NB_MISSING.COLLECTED', 'RF');
 	});
 
 	test(`Missing works in loop`, async ({ page }) => {

--- a/e2e/radio.spec.ts
+++ b/e2e/radio.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test';
+import { expectCollectedData, goToStory } from './utils';
+
+test.describe('RadioGroup', () => {
+	test(`Keyboard shortcut should select radio option`, async ({ page }) => {
+		await goToStory(page, 'components-radio--default');
+		await expect(page.getByText('oui')).toBeVisible();
+
+		// select modality 1
+		await page.keyboard.type('1');
+		await expect(page.getByRole('radio', { name: 'oui' })).toHaveAttribute(
+			'aria-checked',
+			'true'
+		);
+		await expectCollectedData(page, 'Q2', '1');
+
+		// select modality 2
+		await page.keyboard.type('2');
+		await expect(page.getByRole('radio', { name: 'non' })).toHaveAttribute(
+			'aria-checked',
+			'true'
+		);
+		await expectCollectedData(page, 'Q2', '2');
+	});
+
+	test(`Keyboard shortcut should be disabled when editing a field (focus on input/textarea)`, async ({
+		page,
+	}) => {
+		await goToStory(page, 'components-radio--with-detail');
+		await expect(page.getByText('oui')).toBeVisible();
+
+		// no focus on a field, shorcut is enabled
+		await page.keyboard.type('3');
+		await expect(page.getByRole('radio', { name: 'Autre' })).toHaveAttribute(
+			'aria-checked',
+			'true'
+		);
+
+		// detail field is autofocus, shortcut is disabled for every option
+		await page.keyboard.type('2');
+		await expect(page.getByRole('radio', { name: 'non' })).not.toHaveAttribute(
+			'aria-checked',
+			'true'
+		);
+		await expect(page.getByRole('radio', { name: 'Autre' })).toHaveAttribute(
+			'aria-checked',
+			'true'
+		);
+
+		await expectCollectedData(page, 'Q2', '3');
+		await expectCollectedData(page, 'Q2_DETAIL', '2');
+	});
+});

--- a/src/components/shared/Checkbox/CheckboxOption.tsx
+++ b/src/components/shared/Checkbox/CheckboxOption.tsx
@@ -64,7 +64,8 @@ function LunaticCheckboxOption({
 			e.preventDefault();
 			onClickOption();
 		},
-		hasKeyboardShortcut
+		hasKeyboardShortcut,
+		false // disable shortcut when editing a field
 	);
 
 	return (

--- a/src/components/shared/Radio/RadioOption.tsx
+++ b/src/components/shared/Radio/RadioOption.tsx
@@ -70,7 +70,8 @@ function LunaticRadioOption({
 			e.preventDefault();
 			onClickOption();
 		},
-		hasKeyboardShortcut
+		hasKeyboardShortcut,
+		false // disable shortcut when editing a field
 	);
 
 	return (

--- a/src/hooks/useKeyboardKey.ts
+++ b/src/hooks/useKeyboardKey.ts
@@ -7,7 +7,8 @@ import { useRefSync } from './useRefSync';
 export function useKeyboardKey(
 	key: string[],
 	cb: (e: KeyboardEvent) => void,
-	enabled: boolean = true
+	enabled: boolean = true,
+	allowWhileTyping: boolean = true
 ) {
 	const cbRef = useRefSync(cb);
 	const keyRef = useRefSync(key);
@@ -16,6 +17,18 @@ export function useKeyboardKey(
 			return;
 		}
 		const listener = (e: KeyboardEvent) => {
+			const activeEl = document.activeElement;
+			const tag = activeEl?.tagName?.toLowerCase();
+
+			if (!allowWhileTyping) {
+				const isTyping =
+					tag === 'input' ||
+					tag === 'textarea' ||
+					(activeEl as HTMLElement)?.isContentEditable;
+
+				if (isTyping) return;
+			}
+
 			if (
 				keyRef.current.map((s) => s.toLowerCase()).includes(e.key.toLowerCase())
 			) {


### PR DESCRIPTION
Currently, when filling a detail on a checkbox/radio option, we could trigger the shortcut that checks/unchecks modalities.
Now we decide that when we're focusing an input/textarea, it disables those shortcuts.

⚠️ voluntarily we do not apply this to the missing buttons. Their shortcut are still always enabled