### PR TITLE
fix: resize optionResponses variables when removing roster/loop row

### DIFF
--- a/src/use-lunatic/props/propValue.spec.ts
+++ b/src/use-lunatic/props/propValue.spec.ts
@@ -116,7 +116,7 @@ describe('fillComponentValue', () => {
 		});
 	});
 
-	describe('RosterForLoop', () => {
+	describe('RosterForLoop with suggester having optionResponses', () => {
 		const rosterForLoopComponent = {
 			id: 'loop-prenom',
 			componentType: 'RosterForLoop',
@@ -150,12 +150,28 @@ describe('fillComponentValue', () => {
 						name: 'PRENOM',
 					},
 				},
+				{
+					id: 'commune',
+					response: {
+						name: 'COMMUNE',
+					},
+					storeName: 'nomenclature-commune',
+					componentType: 'Suggester',
+					optionResponses: [
+						{
+							name: 'LABEL_COMMUNE',
+							attribute: 'label_attribute',
+						},
+					],
+				},
 			],
 		} as any as LunaticComponentDefinition<'RosterForLoop'>;
 
 		it('should correctly extract values from nested responses as arrays', () => {
 			const values = {
 				PRENOM: ['Alice', 'Bob', 'Charlie'],
+				COMMUNE: ['59000', '25000', '54000'],
+				LABEL_COMMUNE: ['Lille', 'Besançon', 'Nancy'],
 			};
 
 			expectFilledComponent(rosterForLoopComponent, values).toEqual(values);
@@ -164,6 +180,8 @@ describe('fillComponentValue', () => {
 		it('should return null for missing responses', () => {
 			expectFilledComponent(rosterForLoopComponent).toEqual({
 				PRENOM: null,
+				COMMUNE: null,
+				LABEL_COMMUNE: null,
 			});
 		});
 	});

--- a/src/use-lunatic/props/propValue.ts
+++ b/src/use-lunatic/props/propValue.ts
@@ -46,13 +46,33 @@ function getChildResponseValues(
 ): Record<string, unknown> {
 	return Object.fromEntries(
 		components.flatMap((c) => {
-			if ('response' in c) {
-				return [[c.response.name, variables.get(c.response.name)]];
+			const entries: [string, unknown][] = [];
+
+			// Handle main response
+			if ('response' in c && c.response?.name) {
+				entries.push([c.response.name, variables.get(c.response.name)]);
 			}
-			if ('components' in c) {
-				return Object.entries(getChildResponseValues(c.components, variables));
+
+			// Handle optionResponses safely
+			if (c.componentType === 'Suggester' && c.optionResponses) {
+				for (const optionResponse of c.optionResponses) {
+					if (optionResponse?.name) {
+						entries.push([
+							optionResponse.name,
+							variables.get(optionResponse.name),
+						]);
+					}
+				}
 			}
-			return [];
+
+			// Handle nested components
+			if ('components' in c && Array.isArray(c.components)) {
+				entries.push(
+					...Object.entries(getChildResponseValues(c.components, variables))
+				);
+			}
+
+			return entries;
 		})
 	);
 }


### PR DESCRIPTION
In a Loop or RosterForLoop, if we have a suggester with optionResponses, the variables associated to each optionResponse are not resized/cleaned when removing a row. So they keep their dimension and values that don't match anymore with the suggester values.

Due to the fact that adding/removing a row directly updates the loop/roster variables values (see https://github.com/InseeFr/Lunatic/blob/3.0/src/components/Loop/utils.ts), but optionResponses variables were forgotten when filling loop/roster variables