### PR TITLE
feat: enable to use MDLabel out of lunatic with custom Markdown link component

### DIFF
--- a/src/components/shared/MDLabel/MDLabel.tsx
+++ b/src/components/shared/MDLabel/MDLabel.tsx
@@ -4,14 +4,22 @@ import { MarkdownLink } from './MarkdownLink';
 import remarkBreaks from 'remark-breaks';
 import emoji from 'remark-emoji';
 
-type Props = { expression: string };
+type Props = {
+	expression: string;
+	MarkdownLinkOverride?: typeof MarkdownLink;
+};
 
-export function MDLabel({ expression }: Props) {
+export function MDLabel({ expression, MarkdownLinkOverride }: Props) {
 	const hasParagraphs = /\n\n/.test(expression);
 	const components = {
 		p: hasParagraphs ? 'p' : Fragment,
 		br: 'br',
-		a: MarkdownA,
+		a: (props: MarkdownAProps) => (
+			<MarkdownA
+				{...props}
+				MarkdownLinkComponent={MarkdownLinkOverride ?? MarkdownLink}
+			/>
+		),
 	} as Partial<Components>;
 	return (
 		<Markdown
@@ -22,15 +30,27 @@ export function MDLabel({ expression }: Props) {
 		</Markdown>
 	);
 }
+
+type MarkdownAProps = PropsWithChildren<{
+	title?: string;
+	href: string;
+	MarkdownLinkComponent: typeof MarkdownLink;
+}>;
+
 const MarkdownA = ({
 	title,
 	href,
 	children,
-}: PropsWithChildren<{ title?: string; href: string }>) => {
+	MarkdownLinkComponent,
+}: PropsWithChildren<{
+	title?: string;
+	href: string;
+	MarkdownLinkComponent: typeof MarkdownLink;
+}>) => {
 	const tooltip = title ? <MDLabel expression={title} /> : null;
 	return (
-		<MarkdownLink href={href} tooltip={tooltip}>
+		<MarkdownLinkComponent href={href} tooltip={tooltip}>
 			{children}
-		</MarkdownLink>
+		</MarkdownLinkComponent>
 	);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ export { Button } from './components/shared/Button/Button';
 export { LunaticComponents } from './components/LunaticComponents';
 export { useLunatic } from './use-lunatic/use-lunatic';
 
+export { MDLabel } from './components/shared/MDLabel/MDLabel';
+
 export type {
 	LunaticComponentDefinition,
 	LunaticControl,


### PR DESCRIPTION
For an application using Lunatic, we extract labels of lunatic components, then use them out of lunatic context.
But when there is a markdown link we want to keep the tooltip transformation done in Lunatic (for having a coherent display in the application).

So we need to :
- export MDLabel function
- enable to use a custom MarkdownLink component, since outside of lunatic context it would not use slot component of the application