### PR TITLE
fix: unmount same components between successive pages

### DIFF
--- a/src/components/Datepicker/Datepicker.tsx
+++ b/src/components/Datepicker/Datepicker.tsx
@@ -16,9 +16,14 @@ export function Datepicker({
 	errors,
 	...props
 }: LunaticComponentProps<'Datepicker'>) {
+	const { id, iteration } = props;
+	// We can have the same id (same variable) for different iterations in successive pages, we need to have unique key for remount correctly
+	const datepickerFieldsKey = `${id}-${iteration}`;
+
 	return (
 		<CustomDatepicker
 			{...props}
+			key={datepickerFieldsKey}
 			dateFormat={dateFormat ?? 'YYYY-MM-DD'}
 			onChange={(value) => handleChanges([{ name: response.name, value }])}
 			errors={getComponentErrors(errors, props.id)}
@@ -37,12 +42,9 @@ type CustomProps = Omit<
 export const CustomDatepicker = slottableComponent<CustomProps>(
 	'Datepicker',
 	(props) => {
-		const { id, label, errors, description, declarations, iteration } = props;
+		const { id, label, errors, description, declarations } = props;
 
 		const labelId = `lunatic-datepicker-${id}`;
-
-		// We can have the same id (same variable) for different iterations in successive pages, we need to have unique key for remount correctly
-		const datepickerFieldsKey = `${id}-${iteration}`;
 
 		return (
 			<div className="lunatic-input">
@@ -54,7 +56,7 @@ export const CustomDatepicker = slottableComponent<CustomProps>(
 					declarations={declarations}
 					id={id}
 				/>
-				<CustomDatepickerFields {...props} key={datepickerFieldsKey} />
+				<CustomDatepickerFields {...props} />
 				<ComponentErrors errors={errors} />
 			</div>
 		);

--- a/src/components/Datepicker/Datepicker.tsx
+++ b/src/components/Datepicker/Datepicker.tsx
@@ -37,9 +37,12 @@ type CustomProps = Omit<
 export const CustomDatepicker = slottableComponent<CustomProps>(
 	'Datepicker',
 	(props) => {
-		const { id, label, errors, description, declarations } = props;
+		const { id, label, errors, description, declarations, iteration } = props;
 
 		const labelId = `lunatic-datepicker-${id}`;
+
+		// We can have the same id (same variable) for different iterations in successive pages, we need to have unique key for remount correctly
+		const datepickerFieldsKey = `${id}-${iteration}`;
 
 		return (
 			<div className="lunatic-input">
@@ -51,7 +54,7 @@ export const CustomDatepicker = slottableComponent<CustomProps>(
 					declarations={declarations}
 					id={id}
 				/>
-				<CustomDatepickerFields {...props} />
+				<CustomDatepickerFields {...props} key={datepickerFieldsKey} />
 				<ComponentErrors errors={errors} />
 			</div>
 		);

--- a/src/components/Duration/Duration.tsx
+++ b/src/components/Duration/Duration.tsx
@@ -20,11 +20,16 @@ export function Duration({
 	errors,
 	...props
 }: LunaticComponentProps<'Duration'>) {
+	const { id, iteration } = props;
+	// We can have the same id (same variable) for different iterations in successive pages, we need to have unique key for remount correctly
+	const durationKey = `${id}-${iteration}`;
+
 	return (
 		<CustomDuration
 			{...props}
+			key={durationKey}
 			onChange={(value) => handleChanges([{ name: response.name, value }])}
-			errors={getComponentErrors(errors, props.id)}
+			errors={getComponentErrors(errors, id)}
 		/>
 	);
 }

--- a/src/components/Suggester/Suggester.tsx
+++ b/src/components/Suggester/Suggester.tsx
@@ -6,7 +6,16 @@ import { OTHER_VALUE, useSuggestions } from './useSuggestions';
 import D from '../../i18n';
 import type { SuggesterOptionType } from './SuggesterType';
 
-export function Suggester({
+export function Suggester(props: LunaticComponentProps<'Suggester'>) {
+	const { id, iteration } = props;
+
+	// We can have the same id (same variable) for different iterations in successive pages, we need to have unique key for remount correctly
+	const suggesterKey = `${id}-${iteration}`;
+
+	return <WrappedSuggester {...props} key={suggesterKey} />;
+}
+
+export function WrappedSuggester({
 	storeName,
 	id,
 	className,


### PR DESCRIPTION
fixed components :
- suggester
- datepicker
- duration

Currently for those components, if on successive pages we have the same components for the same variable (which can happen espacially when having 1 iteration per page since we ask the same questions) , it did still display the value of the previous page (even if there is actually no saved data).

It was happening because we displayed the same component with same props (the displayed value is directly handled by a useEffect that does not refresh).

I prefered to keep components unchanged, but to add keys using id and iteration to ensure unicity between each component