### PR TITLE
feat: expose roundabout loop variables

### DIFF
--- a/lunatic-schema.json
+++ b/lunatic-schema.json
@@ -625,6 +625,12 @@
 					"type": "string",
 					"const": "Roundabout"
 				},
+				"loopDependencies": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
 				"iterations": {
 					"$ref": "#/$defs/VTLScalarExpression"
 				},

--- a/src/stories/roundabout/source.json
+++ b/src/stories/roundabout/source.json
@@ -67,6 +67,7 @@
 			"page": "3",
 			"conditionFilter": { "value": "true", "type": "VTL" },
 			"iterations": { "value": "NB_HAB", "type": "VTL" },
+			"loopDependencies": ["PRENOMS"],
 			"label": { "value": "\"Libellé du rondpoint\"", "type": "VTL" },
 			"description": {
 				"value": "\"Description du rond-point\"",

--- a/src/type.source.ts
+++ b/src/type.source.ts
@@ -48,6 +48,7 @@ export type ComponentSequenceDefinition = ComponentDefinitionBase & {
 };
 export type ComponentRoundaboutDefinition = ComponentDefinitionBase & {
 	componentType: 'Roundabout';
+	loopDependencies?: string[];
 	iterations: VTLScalarExpression;
 	locked: boolean;
 	progressVariable: string;

--- a/src/use-lunatic/hooks/use-loop-variables.ts
+++ b/src/use-lunatic/hooks/use-loop-variables.ts
@@ -2,11 +2,12 @@ import type { LunaticComponentDefinition, LunaticReducerState } from '../type';
 import { useMemo } from 'react';
 
 /**
- * Extract the list of variables used for the current loop.
+ * Extract the list of variables used for the current loop or roundabout.
  */
 export function useLoopVariables(
 	pager: LunaticReducerState['pager'],
-	pages: LunaticReducerState['pages']
+	pages: LunaticReducerState['pages'],
+	loopType: 'Loop' | 'Roundabout' = 'Loop'
 ): string[] {
 	const { iteration, page } = pager;
 	const inIteration = iteration !== undefined;
@@ -16,8 +17,12 @@ export function useLoopVariables(
 		}
 		// Find the loop to extract the dependencies
 		const loop = pages[page]?.components.find(
-			(c) => c.componentType === 'Loop'
-		) as LunaticComponentDefinition<'Loop'> | undefined;
+			(c) => c.componentType === loopType
+		) as
+			| LunaticComponentDefinition<'Loop'>
+			| LunaticComponentDefinition<'Roundabout'>
+			| undefined;
+
 		return loop?.loopDependencies ?? [];
-	}, [page, pages, inIteration]);
+	}, [inIteration, pages, page, loopType]);
 }

--- a/src/use-lunatic/type.ts
+++ b/src/use-lunatic/type.ts
@@ -258,6 +258,8 @@ export type LunaticState = {
 	isInLoop: boolean;
 	/** Current loop's variables. */
 	loopVariables: string[];
+	/** Current roundabout loop's variables. */
+	roundaboutLoopVariables: string[];
 	/** Whether or not we're on the survey first page. */
 	isFirstPage: boolean;
 	/** Whether or not we're on the survey last page (we reached `maxPage`). */

--- a/src/use-lunatic/use-lunatic.test.ts
+++ b/src/use-lunatic/use-lunatic.test.ts
@@ -5,6 +5,8 @@ import sourceLogement from '../stories/questionnaires/logement/source.json';
 import sourceSimpsons from '../stories/questionnaires/simpsons/source.json';
 import sourceOverview from '../stories/behaviour/overview/sourceLoop.json';
 import sourceCheckboxGroup from '../stories/checkbox/sourceGroup.json';
+import sourceRoundabout from '../stories/roundabout/source.json';
+import sourcePaginatedLoop from '../stories/loop/source-paginated.json';
 import sourceCleaningLoop from '../stories/behaviour/cleaning/source-loop.json';
 import sourceCleaningResizing from '../stories/behaviour/resizing/source-resizing-cleaning.json';
 import type { PageTag } from './type';
@@ -453,6 +455,123 @@ describe('use-lunatic()', () => {
 				result.current.handleChanges([{ name: 'NATIO1N1', value: false }]);
 			});
 			expect(result.current.hasPageResponse()).toBeFalsy();
+		});
+	});
+
+	describe('loopVariables', () => {
+		it('should return an empty list when being out of a loop', () => {
+			const data = {
+				COLLECTED: {
+					PRENOM: { COLLECTED: ['John', 'Doe', 'Marc'] },
+				},
+			};
+
+			const { result } = renderHook(() =>
+				useLunatic(sourcePaginatedLoop, data, {})
+			);
+
+			act(() => {
+				// go outside a loop
+				result.current.goToPage({ page: 3 });
+			});
+
+			expect(result.current.loopVariables).toMatchObject([]);
+		});
+
+		it('should return an empty list when being on a non paginated loop', () => {
+			const data = {
+				COLLECTED: {
+					PRENOM: { COLLECTED: ['John', 'Doe', 'Marc'] },
+				},
+			};
+
+			const { result } = renderHook(() =>
+				useLunatic(sourcePaginatedLoop, data, {})
+			);
+
+			// first page is a non paginated loop
+			expect(result.current.loopVariables).toMatchObject([]);
+		});
+
+		it('should return the loop dependency variables when being in the loop', () => {
+			const data = {
+				COLLECTED: {
+					PRENOM: { COLLECTED: ['John', 'Doe', 'Marc'] },
+				},
+			};
+
+			const { result } = renderHook(() =>
+				useLunatic(sourcePaginatedLoop, data, {})
+			);
+
+			act(() => {
+				// go inside the non paginated loop, no matter the subPage or iteration
+				result.current.goToPage({ page: 2, subPage: 0, iteration: 0 });
+			});
+
+			expect(result.current.loopVariables).toMatchObject(['PRENOM']);
+		});
+	});
+
+	describe('roundaboutLoopVariables', () => {
+		it('should return an empty list when being outside a roundabout', () => {
+			const data = {
+				COLLECTED: {
+					NBHAB: { COLLECTED: 2 },
+				},
+			};
+
+			const { result } = renderHook(() =>
+				useLunatic(sourceRoundabout, data, {})
+			);
+
+			act(() => {
+				result.current.goNextPage();
+			});
+
+			expect(result.current.roundaboutLoopVariables).toMatchObject([]);
+		});
+
+		it('should return an empty list when being on the roundabout page (not in its loop)', () => {
+			const data = {
+				COLLECTED: {
+					NBHAB: { COLLECTED: 2 },
+					PRENOMS: { COLLECTED: ['John', 'Doe', 'Marc'] },
+					AGE: { COLLECTED: [18, 18, 18] },
+				},
+			};
+
+			const { result } = renderHook(() =>
+				useLunatic(sourceRoundabout, data, {})
+			);
+
+			act(() => {
+				// go to roundabout page
+				result.current.goToPage({ page: 3 });
+			});
+
+			expect(result.current.roundaboutLoopVariables).toMatchObject([]);
+		});
+
+		it('should return the roundabout loop dependencies variables when being in the roundabout loop', () => {
+			const data = {
+				COLLECTED: {
+					NBHAB: { COLLECTED: 2 },
+					PRENOMS: { COLLECTED: ['John', 'Doe', 'Marc'] },
+					AGE: { COLLECTED: [18, 18, 18] },
+				},
+			};
+
+			const { result } = renderHook(() =>
+				useLunatic(sourceRoundabout, data, {})
+			);
+
+			act(() => {
+				// go inside roundabout loop, no matter the subPage or iteration
+				result.current.goToPage({ page: 3, subPage: 0, iteration: 0 });
+			});
+
+			expect(result.current.roundaboutLoopVariables).toMatchObject(['PRENOMS']);
 		});
 	});
 });

--- a/src/use-lunatic/use-lunatic.ts
+++ b/src/use-lunatic/use-lunatic.ts
@@ -231,6 +231,11 @@ export function useLunatic(
 		isInLoop: state.isInLoop,
 		overview: useOverview(state, [pageTag]),
 		loopVariables: useLoopVariables(state.pager, state.pages),
+		roundaboutLoopVariables: useLoopVariables(
+			state.pager,
+			state.pages,
+			'Roundabout'
+		),
 		// Methods
 		getComponents,
 		goPreviousPage,

--- a/website/docs/hook/return.mdx
+++ b/website/docs/hook/return.mdx
@@ -15,6 +15,7 @@ Cet objet contient des paramètres, méthodes et composants
   - isInLoop : boolean
   - overview  cf [section vue d'ensemble](./parameters#vue-densemble)
   - loopVariables : liste des variables de la boucle courrante
+  - roundaboutLoopVariables: liste des variables de la boucle du rond-point courrant
 ### Les méthodes
   - getComponents permet de récupérer les composants à afficher (cf [section affichage](../components/lunatic-components))
   -	goPreviousPage, permet de naviguer à la page précédente (cf [section navigation](./navigation))


### PR DESCRIPTION
Currently we expose loopVariables which is the loopDependencies only for 'Loop' component.

We now need to do the same for when we are in a Roundabout loop, but consumer needs to differenciate if we are in Loop or Roundabout case.

So we keep loopVariables untouched for Loop case, and we expose roundaboutLoopVariables for Roundabout case.

⚠️ It will only work for questionnaires adding loopDependencies in Roundabout component, which did not exist in schema before (without it, the roundaboutLoopVariables will always be an empty list)