### PR TITLE
fix: block self cleaning

### DIFF
--- a/src/use-lunatic/commons/variables/behaviours/cleaning-behaviour.ts
+++ b/src/use-lunatic/commons/variables/behaviours/cleaning-behaviour.ts
@@ -55,6 +55,8 @@ export function cleaningBehaviour(
 
 		for (const variableName in cleaningInfo) {
 			try {
+				// Skip if variable to be cleaned (variableName) is the variable causing the change (case in questionnaire (fix later in generation))
+				if (variableName === e.detail.name) continue;
 				// Skip if variable is already in a cleaned state
 				if (isAlreadyCleaned(store, variableName)) continue;
 

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
@@ -610,6 +610,27 @@ describe('lunatic-variables-store', () => {
 				[null, null, null],
 			]);
 		});
+		it('should handle not clean itself', () => {
+			variables.set('PRENOM', ['Renoir', 'Alicia', 'Verso']);
+			cleaningBehaviour(
+				variables,
+				{
+					PRENOM: {
+						PRENOM: [
+							{
+								expression: 'PRENOM <> "Renoir"',
+								shapeFrom: 'PRENOM',
+								isAggregatorUsed: false,
+							},
+						],
+					},
+				},
+				{ PRENOM: [null] }
+			);
+
+			variables.set('PRENOM', 'Maëlle', { iteration: [1] });
+			expect(variables.get('PRENOM')).toEqual(['Renoir', 'Maëlle', 'Verso']);
+		});
 	});
 
 	describe('missing', () => {


### PR DESCRIPTION
## Correction 

Dans le `cleaning` du modèle de questionnaire Lunatic, il y a actuellement (par erreur):
- Si la variable "PRENOM" change, alors la variable PRENOM peut-être "vidée" (`cleaned`)

Le fix ici, permet d'empêcher de clean tout de même la variable, permettant de corriger des questionnaires actuellement en production sans regénérer le modèle corrigé (par Eno: https://github.com/InseeFr/Eno/pull/1354)