### PR TITLE
fix: handle ligatures in suggesters (œ & æ characters)

### DIFF
--- a/src/utils/search/tokenizer.spec.ts
+++ b/src/utils/search/tokenizer.spec.ts
@@ -121,6 +121,13 @@ describe('tokenizeQuery', () => {
 		expect(result).toEqual(['eleve', 'etudiant']);
 	});
 
+	it('should normalize ligatures like œ and æ', () => {
+		const queryParser = { type: 'soft' } as SearchInfo['queryParser'];
+
+		const result = tokenizeQuery('œuvre Œuvre æternam Æternam', queryParser);
+		expect(result).toEqual(['oeuvre', 'oeuvre', 'aeternam', 'aeternam']);
+	});
+
 	it('should return an empty array for unmatched patterns', () => {
 		const queryParser = {
 			type: 'tokenized',
@@ -152,6 +159,13 @@ describe('tokenizeIndex', () => {
 
 		const result = tokenizeIndex('Élève Étudiant!', fieldInfo);
 		expect(result).toEqual(['eleve', 'etudiant']);
+	});
+
+	it('should normalize ligatures like œ and æ', () => {
+		const fieldInfo = mockSearchInfo.fields[0];
+
+		const result = tokenizeIndex('œuvre Œuvre æternam Æternam', fieldInfo);
+		expect(result).toEqual(['oeuvre', 'oeuvre', 'aeternam', 'aeternam']);
 	});
 
 	it('should filter out stopWords', () => {

--- a/src/utils/search/tokenizer.ts
+++ b/src/utils/search/tokenizer.ts
@@ -76,11 +76,11 @@ export const tokenizeIndex = (
  */
 const normalizeStr = (str: string) => {
 	return str
-		.replace(/œ/gi, 'oe')
-		.replace(/æ/gi, 'ae')
+		.toLowerCase()
+		.replaceAll('œ', 'oe')
+		.replaceAll('æ', 'ae')
 		.normalize('NFD')
-		.replace(/[\u0300-\u036f]/g, '')
-		.toLowerCase();
+		.replace(/[\u0300-\u036f]/g, '');
 };
 
 /**

--- a/src/utils/search/tokenizer.ts
+++ b/src/utils/search/tokenizer.ts
@@ -70,11 +70,14 @@ export const tokenizeIndex = (
 
 /**
  * Normalize a string
- * - Remove accent (é => e, à => a
+ * - Remove accent (é => e, à => a)
+ * - remove ligatures (æ => ae, , Æ => ae, œ => oe, Œ => oe)
  * - Lowercase
  */
 const normalizeStr = (str: string) => {
 	return str
+		.replace(/œ/gi, 'oe')
+		.replace(/æ/gi, 'ae')
 		.normalize('NFD')
 		.replace(/[\u0300-\u036f]/g, '')
 		.toLowerCase();


### PR DESCRIPTION
In suggester, handle search on ligatures (œ & æ characters)

Echoes like `œuvre` could not been found by searching `œu` or `oeu`. Same for echoes like `æternam`.

Now, for echo like `œuvre`, you can correctly find it by searching `œu` or `oeu`. Same idea for the `æ` and `ae`

Nb : concerning the minimum of characters before triggering search, `œ` and `æ` are considered as 2 characters (= `oe` or `ae`)