### PR TITLE
fix: make suggester synonyms case insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Suggester synonyms now handle uppercase.
+
 ## [3.12.0](https://github.com/InseeFr/Lunatic/releases/tag/3.12.0) - 2026-02-23
 
 - Radio, Dropdown and CheckboxOne can now have options based on a variable by specifying `optionSource` and filtered through `optionFilter`.

--- a/src/utils/search/tokenizer.spec.ts
+++ b/src/utils/search/tokenizer.spec.ts
@@ -154,6 +154,13 @@ describe('tokenizeIndex', () => {
 		expect(result).toEqual(['the', 'car', 'vehicle', 'automobile', 'fast']);
 	});
 
+	it('should tokenize and apply synonyms regardless of case', () => {
+		const fieldInfo = mockSearchInfo.fields[0];
+
+		const result = tokenizeIndex('The Car is fast', fieldInfo);
+		expect(result).toEqual(['the', 'car', 'vehicle', 'automobile', 'fast']);
+	});
+
 	it('should normalize the input', () => {
 		const fieldInfo = mockSearchInfo.fields[0];
 

--- a/src/utils/search/tokenizer.ts
+++ b/src/utils/search/tokenizer.ts
@@ -46,6 +46,7 @@ export const tokenizeIndex = (
 	info: ItemOf<SearchInfo['fields']>,
 	stopWords?: string[]
 ) => {
+	let normalizedStr = normalizeStr(str);
 	const wordRegex =
 		info.rules && info.rules !== 'soft'
 			? new RegExp(info.rules![0], 'gi')
@@ -55,14 +56,21 @@ export const tokenizeIndex = (
 	// For synonyms, add the synonyms to the string
 	if (info.synonyms) {
 		for (const source in info.synonyms) {
-			const synonyms = info.synonyms[source].join(' ');
-			str = str.replaceAll(source, `${source} ${synonyms}`);
+			const normalizedSource = normalizeStr(source);
+			const synonyms = info.synonyms[source]
+				.map((synonym) => normalizeStr(synonym))
+				.join(' ');
+
+			normalizedStr = normalizedStr.replaceAll(
+				normalizedSource,
+				`${normalizedSource} ${synonyms}`
+			);
 		}
 	}
 
 	// We remove the stopWords from the string
 	return (
-		filterStopWords(normalizeStr(str), stopWords)
+		filterStopWords(normalizedStr, stopWords)
 			.match(wordRegex)
 			?.filter((w) => w.length >= minLength) ?? []
 	);


### PR DESCRIPTION
In suggester, synonyms did not work on words with uppercase.

For example, if `house` is synonym of `home`, when typing `house` :
- you will find the echo `Working at home`
- but you would not find the echo `Working at Home`

That was especially a problem on the first word of every echoes that generally start with an uppercase in the nomenclatures