### PR TITLE
fix: use synonyms for sorting in suggester

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Suggester synonyms now sort correctly the results.
+
 ## [3.12.1](https://github.com/InseeFr/Lunatic/releases/tag/3.12.1) - 2026-02-23
 
 ### Fixed

--- a/src/utils/search/SearchMiniSearch.spec.ts
+++ b/src/utils/search/SearchMiniSearch.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
 import { SearchMinisearch } from './SearchMinisearch';
+import { applyMelauto } from './melauto';
 
 vi.mock('minisearch', () => {
 	return {
@@ -24,7 +25,13 @@ describe('SearchMinisearch', () => {
 	beforeAll(() => {
 		searchInstance = new SearchMinisearch({
 			name: 'test-suggester',
-			fields: [{ name: 'id' }, { name: 'label' }],
+			fields: [
+				{ name: 'id' },
+				{
+					name: 'label',
+					synonyms: { accueil: ['ACCEUIL', 'ACUEIL'] },
+				},
+			],
 			queryParser: {
 				type: 'tokenized',
 				params: { language: 'English', pattern: '\\w+', min: 1 },
@@ -54,5 +61,18 @@ describe('SearchMinisearch', () => {
 		await searchInstance.index(mockData);
 
 		expect(searchInstance.db?.addAll).not.toHaveBeenCalled();
+	});
+
+	it('should expand query synonyms before melauto sorting', async () => {
+		await searchInstance.index(mockData);
+		(searchInstance.db?.search as any).mockReturnValue(mockData);
+		vi.mocked(applyMelauto).mockReturnValue(mockData as any);
+
+		await searchInstance.search('agent acceuil');
+
+		expect(applyMelauto).toHaveBeenCalledWith(
+			'agent acceuil accueil',
+			mockData
+		);
 	});
 });

--- a/src/utils/search/SearchMinisearch.ts
+++ b/src/utils/search/SearchMinisearch.ts
@@ -6,6 +6,39 @@ import type {
 import { applyMelauto } from './melauto';
 import MiniSearch from 'minisearch';
 import { tokenizer } from './tokenizer';
+import { normalizeStr } from './utils';
+
+function getMelautoQuery(query: string, info: SearchInfo) {
+	const tokens = tokenizer(info)(query);
+
+	// existing query tokens (already tokenized/normalized by tokenizer).
+	const expandedTokens = new Set(tokens);
+
+	// add synonyms to keep melauto ranking.
+	for (const field of info.fields) {
+		if (!field.synonyms) {
+			continue;
+		}
+		for (const source in field.synonyms) {
+			const normalizedSource = normalizeStr(source);
+			const normalizedSynonyms = field.synonyms[source].map((synonym) =>
+				normalizeStr(synonym)
+			);
+
+			// source -> synonyms
+			if (expandedTokens.has(normalizedSource)) {
+				normalizedSynonyms.forEach((synonym) => expandedTokens.add(synonym));
+			}
+
+			// synonym -> source
+			if (normalizedSynonyms.some((synonym) => expandedTokens.has(synonym))) {
+				expandedTokens.add(normalizedSource);
+			}
+		}
+	}
+
+	return Array.from(expandedTokens).join(' ');
+}
 
 export class SearchMinisearch<T extends IndexEntry>
 	implements SearchInterface<T>
@@ -45,7 +78,7 @@ export class SearchMinisearch<T extends IndexEntry>
 		}) as any as T[];
 
 		// Apply melauto to classify results
-		data = applyMelauto(q, data);
+		data = applyMelauto(getMelautoQuery(q, this.info), data);
 
 		data = data.slice(0, this.info.max);
 

--- a/src/utils/search/tokenizer.ts
+++ b/src/utils/search/tokenizer.ts
@@ -1,5 +1,6 @@
 import type { SearchInfo } from './SearchInterface';
 import type { ItemOf } from '../../type.utils';
+import { normalizeStr } from './utils';
 
 /**
  * Generates a tokenize method.
@@ -74,21 +75,6 @@ export const tokenizeIndex = (
 			.match(wordRegex)
 			?.filter((w) => w.length >= minLength) ?? []
 	);
-};
-
-/**
- * Normalize a string
- * - Remove accent (é => e, à => a)
- * - remove ligatures (æ => ae, , Æ => ae, œ => oe, Œ => oe)
- * - Lowercase
- */
-const normalizeStr = (str: string) => {
-	return str
-		.toLowerCase()
-		.replaceAll('œ', 'oe')
-		.replaceAll('æ', 'ae')
-		.normalize('NFD')
-		.replace(/[\u0300-\u036f]/g, '');
 };
 
 /**

--- a/src/utils/search/utils.ts
+++ b/src/utils/search/utils.ts
@@ -1,0 +1,14 @@
+/**
+ * Normalize a string
+ * - Remove accent (é => e, à => a)
+ * - remove ligatures (æ => ae, , Æ => ae, œ => oe, Œ => oe)
+ * - Lowercase
+ */
+export const normalizeStr = (str: string) => {
+	return str
+		.toLowerCase()
+		.replaceAll('œ', 'oe')
+		.replaceAll('æ', 'ae')
+		.normalize('NFD')
+		.replace(/[\u0300-\u036f]/g, '');
+};


### PR DESCRIPTION
In a suggester query, synonyms were not used for sorting results