### PR TITLE
fix: cleaning when no shapeFrom is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fixing the cleaning process when no `shapeFrom` is provided and `shouldCheckAllIterations` is set to `true`
+
 ## [3.13.0](https://github.com/InseeFr/Lunatic/releases/tag/3.13.0) - 2026-03-19
 
 ### Added

--- a/src/use-lunatic/commons/variables/behaviours/cleaning-behaviour.ts
+++ b/src/use-lunatic/commons/variables/behaviours/cleaning-behaviour.ts
@@ -193,7 +193,7 @@ function shouldClean(
 	}
 
 	// If expressions have shapeFrom and we're at root level, we need to check each iteration individually
-	if (hasShapeFrom(expressions) && !iteration) {
+	if (expressionsHaveShapeFrom(expressions) && !iteration) {
 		const shapeFrom = findFirstExpressionWithShapeFrom(expressions)?.shapeFrom;
 		const shapeFromVariable = store.get(shapeFrom as string) as Array<unknown>;
 
@@ -258,6 +258,10 @@ function getValueAtIteration(value: unknown, iteration?: number[]) {
 	return getValueAtIteration(value[iteration[0]], iteration.slice(1));
 }
 
+function hasShapeFrom(expression: CleaningExpression) {
+	return expression.shapeFrom !== null && expression.shapeFrom !== undefined;
+}
+
 /**
  * Checks if all expressions in the array have a shapeFrom property
  *
@@ -266,18 +270,18 @@ function getValueAtIteration(value: unknown, iteration?: number[]) {
  *
  * @returns true if all expressions have a non-null shapeFrom property
  */
-function hasShapeFrom(
+function expressionsHaveShapeFrom(
 	expressions: {
 		expression: string;
 		shapeFrom?: string;
 		isAggregatorUsed: boolean;
 	}[]
 ) {
-	return expressions.every((expression) => expression.shapeFrom !== null);
+	return expressions.every((expression) => hasShapeFrom(expression));
 }
 
 function findFirstExpressionWithShapeFrom(expressions: CleaningExpression[]) {
-	return expressions.find(({ shapeFrom }) => shapeFrom !== undefined);
+	return expressions.find((expression) => hasShapeFrom(expression));
 }
 
 /**

--- a/src/use-lunatic/commons/variables/behaviours/cleaning-behaviour.ts
+++ b/src/use-lunatic/commons/variables/behaviours/cleaning-behaviour.ts
@@ -159,13 +159,6 @@ function shouldClean(
 
 	// At least one expression requires to compute on each iteration
 	if (shouldCheckAtAllIterations(expressions)) {
-		const shapeFrom = findFirstExpressionWithShapeFrom(expressions)?.shapeFrom;
-		const shapeFromVariable = store.get(shapeFrom as string) as Array<unknown>;
-
-		const shouldCleanArray = new Array(shapeFromVariable.length).fill(
-			false
-		) as Array<boolean>;
-
 		const expressionsToCheckAtAllIterations: CleaningExpression[] = [];
 		const expressionsNotToCheckAtAllIterations: CleaningExpression[] = [];
 
@@ -176,6 +169,14 @@ function shouldClean(
 				expressionsNotToCheckAtAllIterations.push(expression);
 			}
 		}
+
+		const shapeFromVariable = store.get(
+			expressionsToCheckAtAllIterations[0].shapeFrom as string
+		) as Array<unknown>;
+
+		const shouldCleanArray = new Array(shapeFromVariable.length).fill(
+			false
+		) as Array<boolean>;
 
 		for (const [iterationIndex] of shouldCleanArray.entries()) {
 			shouldCleanArray[iterationIndex] =

--- a/src/use-lunatic/commons/variables/behaviours/cleaning-behaviour.ts
+++ b/src/use-lunatic/commons/variables/behaviours/cleaning-behaviour.ts
@@ -209,9 +209,9 @@ function shouldClean(
 			});
 		}
 		return shouldCleanArray;
-	} else {
-		return shouldCleanAtIteration(store, { expressions, iteration });
 	}
+
+	return shouldCleanAtIteration(store, { expressions, iteration });
 }
 
 function shouldCheckAtAllIterations(expressions: CleaningExpression[]) {

--- a/src/use-lunatic/commons/variables/behaviours/cleaning-behaviour.ts
+++ b/src/use-lunatic/commons/variables/behaviours/cleaning-behaviour.ts
@@ -159,9 +159,8 @@ function shouldClean(
 
 	// At least one expression requires to compute on each iteration
 	if (shouldCheckAtAllIterations(expressions)) {
-		const shapeFromVariable = store.get(
-			expressions[0].shapeFrom as string
-		) as Array<unknown>;
+		const shapeFrom = findFirstExpressionWithShapeFrom(expressions)?.shapeFrom;
+		const shapeFromVariable = store.get(shapeFrom as string) as Array<unknown>;
 
 		const shouldCleanArray = new Array(shapeFromVariable.length).fill(
 			false
@@ -195,9 +194,8 @@ function shouldClean(
 
 	// If expressions have shapeFrom and we're at root level, we need to check each iteration individually
 	if (hasShapeFrom(expressions) && !iteration) {
-		const shapeFromVariable = store.get(
-			expressions[0].shapeFrom as string
-		) as Array<unknown>;
+		const shapeFrom = findFirstExpressionWithShapeFrom(expressions)?.shapeFrom;
+		const shapeFromVariable = store.get(shapeFrom as string) as Array<unknown>;
 
 		const shouldCleanArray = new Array(shapeFromVariable.length).fill(
 			false
@@ -216,7 +214,9 @@ function shouldClean(
 }
 
 function shouldCheckAtAllIterations(expressions: CleaningExpression[]) {
-	return expressions.some((expression) => expression.shouldCheckAllIterations);
+	return expressions.some(
+		(expression) => expression.shouldCheckAllIterations && expression.shapeFrom
+	);
 }
 
 function shouldCleanAtIteration(
@@ -273,10 +273,11 @@ function hasShapeFrom(
 		isAggregatorUsed: boolean;
 	}[]
 ) {
-	return expressions.every(
-		(expression) =>
-			expression.shapeFrom !== null && expression.shapeFrom !== undefined
-	);
+	return expressions.every((expression) => expression.shapeFrom !== null);
+}
+
+function findFirstExpressionWithShapeFrom(expressions: CleaningExpression[]) {
+	return expressions.find(({ shapeFrom }) => shapeFrom !== undefined);
 }
 
 /**

--- a/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
+++ b/src/use-lunatic/commons/variables/lunatic-variables-store.spec.ts
@@ -572,6 +572,32 @@ describe('lunatic-variables-store', () => {
 			variables.set('PRENOM', ['John', 'Jane']);
 			expect(variables.get('AGE')).toEqual([null, null]);
 		});
+		it('should clean but not at every iteration when configured from an iterated source change if there is no shapeFrom provided', () => {
+			// Given
+			variables.set('PRENOM', ['Marc', 'Marc', 'Marc']);
+			variables.set('QCU', 'A');
+			cleaningBehaviour(
+				variables,
+				{
+					PRENOM: {
+						QCU: [
+							{
+								expression: 'false',
+								isAggregatorUsed: false,
+								shouldCheckAllIterations: true,
+							},
+						],
+					},
+				},
+				{ PRENOM: [], QCU: null }
+			);
+
+			// When
+			variables.set('PRENOM', 'Patrick', { iteration: [0] });
+
+			// Then
+			expect(variables.get('QCU')).toEqual(null);
+		});
 		it('should check every iteration when configured from an iterated source change', () => {
 			// Given
 			variables.set('PRENOM', ['Marc', 'Marc', 'Marc']);


### PR DESCRIPTION
improve get shapeFrom of expressions

Generation will be fixed too (to set to `false` attribute `shouldCheckAllIterations` if no shapeFrom is provided)