### PR TITLE
fix: suggester display label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Suggester**: Fix label display issue when store is not ready. Labels are now properly refreshed when the store is successfully indexed, ensuring that selected options display their correct labels even when the store takes time to load.
+
+### Added
+
+- **Suggester**: New test case to verify that selected labels are displayed correctly with COLLECTED data.
+
 ## [3.13.1](https://github.com/InseeFr/Lunatic/releases/tag/3.13.1) - 2026-04-01
 
 ### Fixed

--- a/e2e/suggester.spec.ts
+++ b/e2e/suggester.spec.ts
@@ -41,6 +41,12 @@ test.describe('Suggester', () => {
 		await expectPageToHaveText(page, 'FRANCE');
 	});
 
+	test(`can see the selected label with COLLECTED data`, async ({ page }) => {
+		await goToStory(page, 'components-suggester--with-data');
+		await expectCollectedData(page, 'VARIABLEPA', 'FRA');
+		await expectPageToHaveText(page, 'FRANCE');
+	});
+
 	test(`can clear the last selected value`, async ({ page }) => {
 		await goToStory(page, 'components-suggester--default');
 		await expectPageToHaveText(page, 'Variable Commune');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@inseefr/lunatic",
-	"version": "3.13.1",
+	"version": "3.13.2-rc.0",
 	"description": "Library of questionnaire components",
 	"repository": {
 		"type": "git",

--- a/src/components/Suggester/Suggester.tsx
+++ b/src/components/Suggester/Suggester.tsx
@@ -159,8 +159,13 @@ export function WrappedSuggester({
 			}) as [SuggesterOptionType];
 			setSelectedOptions(selectedOptionsWithLabel);
 		}
+		// Refresh label when store is indexed, only if empty label
+		// fix issue, when computeSelectedOptions return empty label because store is not ready
+		if (storeState === 'success' && selectedOptions[0]?.label.length === 0) {
+			setSelectedOptions(computeSelectedOptions());
+		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [value]);
+	}, [value, storeState]);
 
 	return (
 		<CustomSuggester

--- a/src/stories/suggester/suggester.stories.tsx
+++ b/src/stories/suggester/suggester.stories.tsx
@@ -39,6 +39,20 @@ export const Default: OrchestratorStory = {
 	},
 };
 
+export const WithData: OrchestratorStory = {
+	args: {
+		initialPage: '2',
+		source,
+		data: {
+			COLLECTED: {
+				VARIABLEPA: {
+					COLLECTED: 'FRA',
+				},
+			},
+		},
+	},
+};
+
 export const OptionResponses: OrchestratorStory = {
 	args: {
 		source: sourceOptionResponses,


### PR DESCRIPTION
### Fixed

- **Suggester**: Fix label display issue when store is not ready. Labels are now properly refreshed when the store is successfully indexed, ensuring that selected options display their correct labels even when the store takes time to load.

### Added

- **Suggester**: New test case to verify that selected labels are displayed correctly with COLLECTED data.