### PR TITLE
feat: make mandatory suggester accessible

### DIFF
--- a/src/components/Dropdown/__snapshots__/Dropdown.spec.tsx.snap
+++ b/src/components/Dropdown/__snapshots__/Dropdown.spec.tsx.snap
@@ -15,7 +15,6 @@ exports[`Dropdown > renders without crashing 1`] = `
       >
         <div
           aria-autocomplete="list"
-          aria-controls="todo"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-labelledby="label-dropdown"
@@ -51,7 +50,6 @@ exports[`Dropdown > should handle readOnly 1`] = `
       >
         <div
           aria-autocomplete="list"
-          aria-controls="todo"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-labelledby="label-dropdown"

--- a/src/components/Suggester/CustomSuggester.spec.tsx
+++ b/src/components/Suggester/CustomSuggester.spec.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { CustomSuggester } from './CustomSuggester';
+
+const baseProps = {
+	id: 'suggester-1',
+	state: 'success' as const,
+	value: [] as [],
+	options: [],
+	search: '',
+	onSelect: vi.fn(),
+	onBlur: vi.fn(),
+	onFocus: vi.fn(),
+	onSearch: vi.fn(),
+	onClear: vi.fn(),
+	optionRenderer: vi.fn(),
+	labelRenderer: vi.fn(),
+};
+
+describe('CustomSuggester', () => {
+	it('should handle required', () => {
+		const { container } = render(<CustomSuggester {...baseProps} required />);
+
+		// expand combobox for having the input
+		const content = container.querySelector('.lunatic-combo-box-content');
+		fireEvent.click(content!);
+
+		const input = container.querySelector('input[type="text"]');
+		expect(input).toHaveAttribute('required');
+		expect(input).toHaveAttribute('aria-required', 'true');
+	});
+});

--- a/src/components/Suggester/CustomSuggester.tsx
+++ b/src/components/Suggester/CustomSuggester.tsx
@@ -35,6 +35,7 @@ type Props = {
 	onClear: () => void;
 	search: string;
 	state: 'loading' | 'error' | 'success';
+	required?: boolean;
 };
 
 export const CustomSuggester = slottableComponent<Props>(
@@ -61,6 +62,7 @@ export const CustomSuggester = slottableComponent<Props>(
 		onClear,
 		state,
 		onFocus,
+		required,
 	}) => {
 		const handleSelect = (id: string | null) => {
 			if (id === null) {
@@ -94,6 +96,7 @@ export const CustomSuggester = slottableComponent<Props>(
 				declarations={declarations}
 				description={description}
 				errors={errors}
+				required={required}
 			/>
 		);
 	}

--- a/src/components/Suggester/Suggester.tsx
+++ b/src/components/Suggester/Suggester.tsx
@@ -35,6 +35,7 @@ export function WrappedSuggester({
 	iteration,
 	arbitrary,
 	arbitraryValue,
+	required,
 }: LunaticComponentProps<'Suggester'>) {
 	const { store, storeState, setStoreState, getLabelById } = useStore({
 		storeName,
@@ -182,6 +183,7 @@ export function WrappedSuggester({
 			onClear={handleClear}
 			disabled={disabled}
 			readOnly={readOnly}
+			required={required}
 			value={selectedOptions}
 			label={label}
 			onBlur={onBlur}

--- a/src/components/shared/Combobox/Combobox.tsx
+++ b/src/components/shared/Combobox/Combobox.tsx
@@ -68,6 +68,7 @@ function LunaticComboBox({
 	onBlur,
 	onFocus,
 	isLoading,
+	required,
 }: Props) {
 	const [expanded, setExpanded] = useState(false);
 	const [focused, setFocused] = useState(false);
@@ -180,6 +181,7 @@ function LunaticComboBox({
 					onChange={handleChange}
 					classNamePrefix={classNamePrefix}
 					invalid={!!errors}
+					required={required}
 				/>
 				<ComboboxPanel
 					isLoading={isLoading}

--- a/src/components/shared/Combobox/ComboboxType.ts
+++ b/src/components/shared/Combobox/ComboboxType.ts
@@ -32,6 +32,7 @@ export type ComboboxSelectionProps = {
 	options: Array<ComboboxOptionType>;
 	search?: string;
 	disabled?: boolean;
+	required?: boolean;
 };
 
 export type ComboboxPanelProps = {

--- a/src/components/shared/Combobox/Selection/ComboboxInput.tsx
+++ b/src/components/shared/Combobox/Selection/ComboboxInput.tsx
@@ -15,6 +15,7 @@ export type InputProps = {
 	focused?: boolean;
 	invalid?: boolean;
 	readOnly?: boolean;
+	required?: boolean;
 } & HTMLAttributes<HTMLInputElement>;
 
 function LunaticComboboxInput({
@@ -27,6 +28,7 @@ function LunaticComboboxInput({
 	focused,
 	className,
 	invalid,
+	required,
 }: InputProps) {
 	const inputEl = useRef<HTMLInputElement>(null);
 
@@ -52,6 +54,8 @@ function LunaticComboboxInput({
 			onChange={onChange}
 			value={value}
 			aria-invalid={invalid}
+			aria-required={required}
+			required={required}
 			title="combo-box"
 			autoComplete="off"
 			autoCapitalize="off"

--- a/src/components/shared/Combobox/Selection/ComboboxSelection.tsx
+++ b/src/components/shared/Combobox/Selection/ComboboxSelection.tsx
@@ -24,6 +24,7 @@ export function ComboboxSelection({
 	id,
 	classNamePrefix,
 	invalid,
+	required,
 }: ComboboxSelectionProps) {
 	const showLabel = !editable || !expanded;
 	const selectedOption =
@@ -70,6 +71,7 @@ export function ComboboxSelection({
 					readOnly={readOnly}
 					focused={focused}
 					labelledBy={labelId}
+					required={required}
 				/>
 			)}
 		</div>

--- a/src/components/shared/Combobox/Selection/ComboboxSelection.tsx
+++ b/src/components/shared/Combobox/Selection/ComboboxSelection.tsx
@@ -28,7 +28,7 @@ export function ComboboxSelection({
 }: ComboboxSelectionProps) {
 	const showLabel = !editable || !expanded;
 	const selectedOption =
-		selectedIndex !== undefined ? options[selectedIndex] : undefined;
+		selectedIndex === undefined ? undefined : options[selectedIndex];
 	const LabelSelectionComponent = labelRenderer ?? ComboboxLabelSelection;
 
 	return (
@@ -42,7 +42,6 @@ export function ComboboxSelection({
 				}
 			)}
 			role="combobox"
-			aria-controls={'todo'}
 			aria-haspopup="listbox"
 			aria-expanded={expanded}
 			aria-autocomplete="list"

--- a/src/components/shared/Combobox/Selection/__snapshots__/ComboboxSelection.spec.tsx.snap
+++ b/src/components/shared/Combobox/Selection/__snapshots__/ComboboxSelection.spec.tsx.snap
@@ -3,7 +3,6 @@
 exports[`Selection component > should render correctly when it is disabled 1`] = `
 <div
   aria-autocomplete="list"
-  aria-controls="todo"
   aria-haspopup="listbox"
   class="lunatic-combo-box-selection disabled"
   role="combobox"
@@ -23,7 +22,6 @@ exports[`Selection component > should render correctly when it is disabled 1`] =
 exports[`Selection component > should render correctly when it is editable 1`] = `
 <div
   aria-autocomplete="list"
-  aria-controls="todo"
   aria-haspopup="listbox"
   class="lunatic-combo-box-selection"
   role="combobox"
@@ -41,7 +39,6 @@ exports[`Selection component > should render correctly when it is editable 1`] =
 exports[`Selection component > should render correctly when it is expanded 1`] = `
 <div
   aria-autocomplete="list"
-  aria-controls="todo"
   aria-expanded="true"
   aria-haspopup="listbox"
   class="lunatic-combo-box-selection"
@@ -60,7 +57,6 @@ exports[`Selection component > should render correctly when it is expanded 1`] =
 exports[`Selection component > should render correctly with default props 1`] = `
 <div
   aria-autocomplete="list"
-  aria-controls="todo"
   aria-haspopup="listbox"
   class="lunatic-combo-box-selection"
   role="combobox"


### PR DESCRIPTION
Handle correctly `isMandatory` for suggester : make it accessible, adding `required` & `aria-required` in its input